### PR TITLE
chore(package): remove node modules binary directory from scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mesosphere-design-system",
+  "name": "dcos-ui-kit",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "scripts": {
     "preinstall": "./scripts/pre-install",
     "start": "NODE_ENV=development npm run storybook --root ./ ",
-    "dist": "npm run clean && NODE_ENV=production ./node_modules/.bin/webpack -p --config ./webpack.config.js",
+    "dist": "npm run clean && NODE_ENV=production webpack -p --config ./webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "commitlint": "./node_modules/.bin/commitlint -e",
+    "commitlint": "commitlint -e",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "clean": "rm -rf dist",
-    "release": "./node_modules/.bin/standard-version"
+    "release": "standard-version"
   },
   "license": "Apache-2.0",
   "main": "dist/ui-kit.js",


### PR DESCRIPTION
`npm` is adding the `node_modules/.bin/` directory to the path so there is no need to use it in the
scripts section from the `package.json`.