### PR TITLE
feat: specify badge properties

### DIFF
--- a/components/badge/badge.tsx
+++ b/components/badge/badge.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { badge } from "./style";
 
 export interface IBadgeProps {
-  appearance?: string;
+  appearance?: "default" | "success" | "primary" | "warning" | "danger" | "outline";
   children: JSX.Element | string;
 }
 


### PR DESCRIPTION
This PR improves the `badge` component to only accept specific props that way developers will be warned if some unexpected prop is passed.

**before**:
![screen shot 2018-04-09 at 3 33 39 pm](https://user-images.githubusercontent.com/549394/38526823-a2344746-3c0c-11e8-9da3-ea82b88a896d.png)

**after**:
![screen shot 2018-04-09 at 3 13 30 pm](https://user-images.githubusercontent.com/549394/38526829-ab933068-3c0c-11e8-81ec-54fd75ccdd4b.png)
