### PR TITLE
chore(commit-msg): fix commit msg hook

### DIFF
--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -19,7 +19,7 @@ then
     "\nUse the following command to amend changes and edit the commit message."\
     "\n\n> git commit --amend\n"
 
-  exit -1
+  exit 0
 fi
 
 info "Commit message looks good"


### PR DESCRIPTION
This fixes the issue where a commit is not created if the commit msg is not fulfilling the
convetion. Which means that the commit lint is telling you to run `git commit --amend` to change the
message which means that the changes are appended to the previous commit. Also the message entered
before is lost, which means if someone has entered a rather long commit message that work would have
been lost.