### PR TITLE
Add npm ls to the initialization of jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,8 @@ pipeline {
       steps {
         ansiColor('xterm') {
           retry(2) {
-            sh '''npm install'''
+            // The npm ls ensures that the peer dependecies are met.
+            sh '''npm install && npm ls'''
           }
         }
       }


### PR DESCRIPTION
<details><summary><strong>ci: add check for peer dependecies</strong></summary><hr/>

`npm ls` will throw an error if any peer dependecies are unmet. This commit adds npm ls to the
initialization step of the `Jenkinsfile` so this step will fail if not all dependecies are met.
</details>

---
Commit:
2a968d2c3e65b75cf12772b93b8077e7c08ce922


**Checklist**
- [ ] Did you add a JIRA issue in a commit message or as part of the branch name?
- [ ] Did you add new unit tests?
- [ ] Did you add new integration tests?
- [ ] If this is a regression, did you write a test to catch this in the future?