### PR TITLE
chore(deps): update dependency react to v16.4.2 - autoclosed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3821,11 +3821,12 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.1.tgz",
-      "integrity": "sha512-uZP8Fd4f7rwHKztnOhFJYEJsKXO7opmcyKk5P9vRC8UJAx3AiWaGFiLxDqPJqzO3n3IhF/v6rdscxadarEXnag==",
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.10.tgz",
+      "integrity": "sha512-lnJeNJL5KJefTpemubc1HULbH+O1laDeUOJXlP2G12faTKmyPo3wRzbuBoKCli9mCW4hRUKM14PbadGx5rILgg==",
       "dev": true,
       "requires": {
+        "@types/prop-types": "*",
         "csstype": "^2.2.0"
       }
     },
@@ -9383,12 +9384,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9403,17 +9406,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9530,7 +9536,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9542,6 +9549,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9556,6 +9564,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9563,12 +9572,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9587,6 +9598,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9667,7 +9679,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9679,6 +9692,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9800,6 +9814,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -24199,9 +24214,9 @@
       }
     },
     "react": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.4.1.tgz",
-      "integrity": "sha512-3GEs0giKp6E0Oh/Y9ZC60CmYgUPnp7voH9fbjWsvXtYFb4EWtgQub0ADSq0sJR0BbHc4FThLLtzlcFaFXIorwg==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.4.2.tgz",
+      "integrity": "sha512-dMv7YrbxO4y2aqnvA7f/ik9ibeLSHQJTI6TrYAenPSaQ6OXfb+Oti+oJiy8WBxgRzlKatYqtCjphTgDSCEiWFg==",
       "requires": {
         "fbjs": "^0.8.16",
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "emotion": "9.2.4",
     "memoize-one": "3.1.1",
-    "react": "16.4.1",
+    "react": "16.4.2",
     "react-dom": "16.4.2",
     "react-emotion": "9.2.4",
     "react-virtualized": "9.19.1",
@@ -58,7 +58,7 @@
     "@types/jest": "23.3.1",
     "@types/memoize-one": "3.1.1",
     "@types/node": "10.3.4",
-    "@types/react": "16.4.1",
+    "@types/react": "16.4.10",
     "@types/react-dom": "16.0.7",
     "@types/react-test-renderer": "16.0.1",
     "@types/react-virtualized": "9.18.3",


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/facebook/react">react</a> from <code>v16.4.1</code> to <code>v16.4.2</code></p>
<p>This PR also includes an upgrade to the corresponding <a href="https://npmjs.com/package/@&#8203;types/react">@&#8203;types/react</a> package.</p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v1642httpsgithubcomfacebookreactblobmasterchangelogmd82031642-august-1-2018"><a href="https://renovatebot.com/gh/facebook/react/blob/master/CHANGELOG.md#&#8203;1642-August-1-2018"><code>v16.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/react/compare/v16.4.1…v16.4.2">Compare Source</a></p>
<h5 id="react-dom-server">React DOM Server</h5>
<ul>
<li><p>Fix a <a href="https://reactjs.org/blog/2018/08/01/react-v-16-4-2.html">potential XSS vulnerability when the attacker controls an attribute name</a> (<code>CVE-2018-6341</code>). This fix is available in the latest <code>react-dom@&amp;#8203;16.4.2</code>, as well as in previous affected minor versions: <code>react-dom@&amp;#8203;16.0.1</code>, <code>react-dom@&amp;#8203;16.1.2</code>, <code>react-dom@&amp;#8203;16.2.1</code>, and <code>react-dom@&amp;#8203;16.3.3</code>. (<a href="https://renovatebot.com/gh/gaearon">@&#8203;gaearon</a> in <a href="https://renovatebot.com/gh/facebook/react/pull/13302">#&#8203;13302</a>)</p></li>
<li><p>Fix a crash in the server renderer when an attribute is called <code>hasOwnProperty</code>. This fix is only available in <code>react-dom@&amp;#8203;16.4.2</code>. (<a href="https://renovatebot.com/gh/gaearon">@&#8203;gaearon</a> in <a href="https://renovatebot.com/gh/facebook/react/pull/13303">#&#8203;13303</a>)</p></li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>