### PR TITLE
DCOS-38496, DCOS-38639, DCOS-38640: Table helper functions for calculating width

### DIFF
--- a/packages/utilities/components/compose.ts
+++ b/packages/utilities/components/compose.ts
@@ -1,0 +1,43 @@
+export function compose<A, B, C>(b: (v: B) => C, a: (v: A) => B): (a: A) => C;
+export function compose<A, B, C, D>(
+  c: (v: C) => D,
+  b: (v: B) => C,
+  a: (v: A) => B
+): (a: A) => D;
+export function compose<A, B, C, D, E>(
+  d: (v: D) => E,
+  c: (v: C) => D,
+  b: (v: B) => C,
+  a: (v: A) => B
+): (a: A) => E;
+export function compose<A, B, C, D, E, F>(
+  e: (v: E) => F,
+  d: (v: D) => E,
+  c: (v: C) => D,
+  b: (v: B) => C,
+  a: (v: A) => B
+): (a: A) => F;
+export function compose<A, B, C, D, E, F, G>(
+  f: (v: F) => G,
+  e: (v: E) => F,
+  d: (v: D) => E,
+  c: (v: C) => D,
+  b: (v: B) => C,
+  a: (v: A) => B
+): (a: A) => G;
+export function compose<A, B, C, D, E, F, G, H>(
+  g: (v: G) => H,
+  f: (v: F) => G,
+  e: (v: E) => F,
+  d: (v: D) => E,
+  c: (v: C) => D,
+  b: (v: B) => C,
+  a: (v: A) => B
+): (a: A) => H;
+
+export function compose(...functions) {
+  const fn = functions.reverse();
+  return value => fn.reduce((memo, fn) => fn(memo), value);
+}
+
+export default compose;

--- a/packages/utilities/components/max.ts
+++ b/packages/utilities/components/max.ts
@@ -1,0 +1,17 @@
+function calculate(a, b) {
+  return b > a ? b : a;
+}
+
+function max(a?: number | Date | string, b?: number | Date | string) {
+  if (arguments.length === 0) {
+    return max;
+  }
+  if (arguments.length === 1) {
+    return b => {
+      return calculate(a, b);
+    };
+  }
+  return calculate(a, b);
+}
+
+export default max;

--- a/packages/utilities/components/min.ts
+++ b/packages/utilities/components/min.ts
@@ -1,0 +1,17 @@
+function calculate(a, b) {
+  return b < a ? b : a;
+}
+
+function min(a?: number | Date | string, b?: number | Date | string) {
+  if (arguments.length === 0) {
+    return min;
+  }
+  if (arguments.length === 1) {
+    return b => {
+      return calculate(a, b);
+    };
+  }
+  return calculate(a, b);
+}
+
+export default min;

--- a/packages/utilities/components/percentage.ts
+++ b/packages/utilities/components/percentage.ts
@@ -1,0 +1,17 @@
+function calculate(a, b) {
+  return (b / 100) * a;
+}
+
+function percentage(a?: number, b?: number) {
+  if (arguments.length === 0) {
+    return percentage;
+  }
+  if (arguments.length === 1) {
+    return b => {
+      return calculate(a, b);
+    };
+  }
+  return calculate(a, b);
+}
+
+export default percentage;

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -1,1 +1,2 @@
 export { default as min } from "./components/min";
+export { default as max } from "./components/max";

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -1,0 +1,1 @@
+export { default as min } from "./components/min";

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -1,2 +1,3 @@
 export { default as min } from "./components/min";
 export { default as max } from "./components/max";
+export { default as percentage } from "./components/percentage";

--- a/packages/utilities/index.ts
+++ b/packages/utilities/index.ts
@@ -1,3 +1,4 @@
 export { default as min } from "./components/min";
 export { default as max } from "./components/max";
 export { default as percentage } from "./components/percentage";
+export { default as compose } from "./components/compose";

--- a/packages/utilities/tests/compose.test.ts
+++ b/packages/utilities/tests/compose.test.ts
@@ -1,0 +1,27 @@
+import { compose, min, percentage, max } from "../index";
+describe("Compose", () => {
+  it("returns the right composed value", () => {
+    expect(
+      compose(
+        min(29),
+        percentage(25)
+      )(100)
+    ).toEqual(25);
+  });
+  it("composes from right to left", () => {
+    expect(
+      compose(
+        min(21),
+        max(23)
+      )(22)
+    ).toEqual(21);
+  });
+  it("returns the right value multiple times", () => {
+    const f = compose(
+      min(29),
+      percentage(25)
+    );
+    expect(f(100)).toEqual(25);
+    expect(f(100)).toEqual(25);
+  });
+});

--- a/packages/utilities/tests/max.test.ts
+++ b/packages/utilities/tests/max.test.ts
@@ -1,0 +1,17 @@
+import { default as max } from "../components/max";
+describe("max", () => {
+  it("returns the larger of its two arguments", () => {
+    expect(max(-7, 7)).toEqual(7);
+    expect(max(7, -7)).toEqual(7);
+  });
+
+  it("works for any orderable type", () => {
+    var d1 = new Date("2001-01-01");
+    var d2 = new Date("2002-02-02");
+
+    expect(max(d1, d2)).toEqual(d2);
+    expect(max(d2, d1)).toEqual(d2);
+    expect(max("a", "b")).toEqual("b");
+    expect(max("b", "a")).toEqual("b");
+  });
+});

--- a/packages/utilities/tests/min.test.ts
+++ b/packages/utilities/tests/min.test.ts
@@ -1,0 +1,33 @@
+import { default as min } from "../components/min";
+
+describe("min", () => {
+  it("returns the smaller of its two arguments", () => {
+    expect(min(-7, 7)).toEqual(-7);
+    expect(min(7, -7)).toEqual(-7);
+  });
+
+  it("works for any orderable type", () => {
+    var d1 = new Date("2001-01-01");
+    var d2 = new Date("2002-02-02");
+
+    expect(min(d1, d2)).toEqual(d1);
+    expect(min(d2, d1)).toEqual(d1);
+    expect(min("a", "b")).toEqual("a");
+    expect(min("b", "a")).toEqual("a");
+  });
+  it("returns is a function", () => {
+    expect(typeof min).toBe("function");
+  });
+
+  it("returns a function after adding the min value", () => {
+    expect(typeof min(1)).toBe("function");
+  });
+
+  it("is returning the min value", () => {
+    expect(min(1)(10)).toBe(1);
+  });
+
+  it("is returning the lower value value", () => {
+    expect(min(12)(10)).toBe(10);
+  });
+});

--- a/packages/utilities/tests/percentage.test.ts
+++ b/packages/utilities/tests/percentage.test.ts
@@ -1,0 +1,15 @@
+import { default as percentage } from "../components/percentage";
+
+describe("percentage", () => {
+  it("returns percentage of total", () => {
+    expect(percentage(30, 100)).toEqual(30);
+  });
+
+  it("returns function if only percentage is provided", () => {
+    expect(typeof percentage(30)).toBe("function");
+  });
+
+  it("returns calculates the percentage from curried function", () => {
+    expect(percentage(30)(100)).toEqual(30);
+  });
+});


### PR DESCRIPTION
<details><summary><strong>feat(utilities): add min helper function</strong></summary><hr/>

This will provide a curried function to calculate the min value of two parameters. This should be
replaced by ramda as soon as their types have been fixed.

Close DCOS-38496
</details>

---
Commit:
77beb493cad778db3e6df1f1a584f9069025cea2
<details><summary><strong>feat(utilities): this adds a max helper function</strong></summary><hr/>

This provides a max helper function for the users. The function is curried and should be replaced by
ramda as soon as their types are fixed.

Close DCOS-38639
</details>

---
Commit:
ae22a28a0fd218de47c3bb55c2087e428e5afcdd
<details><summary><strong>feat(utilities): add percentage helper</strong></summary><hr/>

This provides the user wiht a curried helper function. The first parameter is the percentage of 100
which we want to calculate the second is the total value so for example if we would like to calulate
30 percent of 1024 we would write `percentage(30, 1024)` or `percentage(30)(1024)`

Close DCOS-38640
</details>

---
Commit:
aae812b56abd9994444bbe3645f026c1c1c36337
<details><summary><strong>feat(utilities): add compose function</strong></summary><hr/>

This provides the user with a compose function which will pass the result from each function to the
next one the functions are executed from right to left
</details>

---
Commit:
743a90b69e489a1e8b44fad4cc69c04c90ac8f71