### PR TITLE
chore(deps): update dependency memoize-one to v4 - autoclosed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6724,12 +6724,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6744,17 +6746,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6871,7 +6876,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6883,6 +6889,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6897,6 +6904,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6904,12 +6912,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6928,6 +6938,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7008,7 +7019,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7020,6 +7032,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7141,6 +7154,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -12147,9 +12161,9 @@
       }
     },
     "memoize-one": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
-      "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.0.tgz",
+      "integrity": "sha512-wdpOJ4XBejprGn/xhd1i2XR8Dv1A25FJeIvR7syQhQlz9eXsv+06llcvcmBxlWVGv4C73QBsWA8kxvZozzNwiQ=="
     },
     "memory-fs": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "typings": "dist/components/index",
   "dependencies": {
     "emotion": "9.2.4",
-    "memoize-one": "3.1.1",
+    "memoize-one": "4.0.0",
     "react": "16.4.1",
     "react-dom": "16.4.0",
     "react-emotion": "9.2.4",


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/alexreardon/memoize-one">memoize-one</a> from <code>v3.1.1</code> to <code>v4.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="400httpsgithubcomalexreardonmemoize-onereleasesv400"><a href="https://renovatebot.com/gh/alexreardon/memoize-one/releases/v4.0.0">4.0.0</a></h3>
<p><a href="https://renovatebot.com/gh/alexreardon/memoize-one/compare/v3.1.1…v4.0.0">Compare Source</a></p>
<h4 id="changes">Changes</h4>
<h5 id="a-bundle-of-joy-🎁">A bundle of joy 🎁</h5>
<p>We are now publishing a number of bundle builds for your consumption needs!</p>
<ul>
<li><code>dist/memoize-one.cjs.js</code> CommonJS bundle</li>
<li><code>dist/memoize-one.esm.js</code> ESM bundle</li>
<li><code>dist/memoize-one.min.js</code> UMD bundle (production build)</li>
<li><code>dist/memoize-one.js</code> UMD bundle (development build)</li>
</ul>
<blockquote>
  <p>This was listed as a breaking change 💥 - even though there are no api changes. The only changes are to the names and paths of the build files.</p>
  <h5 id="bumping-flow">Bumping <code>flow</code></h5>
</blockquote>
<p>We are now on the latest version of <code>flow</code>: <code>0.75</code>.</p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>