### PR TITLE
DCOS-37578: Add Cell component helpers

### DIFF
--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,3 +1,3 @@
 export { Badge } from "./badge";
 export { BadgeButton } from "./badge";
-export { Column, Table } from "./table";
+export { Column, Table, Cell } from "./table";

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,3 +1,3 @@
 export { Badge } from "./badge";
 export { BadgeButton } from "./badge";
-export { Column, Table, Cell, HeaderCell } from "./table";
+export { Column, Table, Cell, TextCell, HeaderCell } from "./table";

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,3 +1,3 @@
 export { Badge } from "./badge";
 export { BadgeButton } from "./badge";
-export { Column, Table, Cell } from "./table";
+export { Column, Table, Cell, HeaderCell } from "./table";

--- a/packages/table/components/Cell.tsx
+++ b/packages/table/components/Cell.tsx
@@ -1,0 +1,7 @@
+import styled from "react-emotion";
+
+export default styled("div")`
+  height: 100%;
+  box-sizing: border-box;
+  padding: 7px;
+`;

--- a/packages/table/components/HeaderCell.tsx
+++ b/packages/table/components/HeaderCell.tsx
@@ -1,0 +1,7 @@
+import { default as Cell } from "./Cell";
+import styled from "react-emotion";
+
+export default styled(Cell)`
+  text-transform: uppercase;
+  font-weight: bold;
+`;

--- a/packages/table/components/TextCell.tsx
+++ b/packages/table/components/TextCell.tsx
@@ -1,0 +1,7 @@
+import { default as Cell } from "./Cell";
+import styled from "react-emotion";
+
+export default styled(Cell)`
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/packages/table/index.ts
+++ b/packages/table/index.ts
@@ -1,2 +1,3 @@
 export { default as Table } from "./components/Table";
 export { default as Column } from "./components/Column";
+export { default as Cell } from "./components/Cell";

--- a/packages/table/index.ts
+++ b/packages/table/index.ts
@@ -2,3 +2,4 @@ export { default as Table } from "./components/Table";
 export { default as Column } from "./components/Column";
 export { default as Cell } from "./components/Cell";
 export { default as HeaderCell } from "./components/HeaderCell";
+export { default as TextCell } from "./components/TextCell";

--- a/packages/table/index.ts
+++ b/packages/table/index.ts
@@ -1,3 +1,4 @@
 export { default as Table } from "./components/Table";
 export { default as Column } from "./components/Column";
 export { default as Cell } from "./components/Cell";
+export { default as HeaderCell } from "./components/HeaderCell";

--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { withReadme } from "storybook-readme";
-import { Table } from "../../index";
-import { Column } from "../components/Column";
+import { Table, Column, Cell, HeaderCell, TextCell } from "../index";
 
 const readme = require("../README.md");
 
@@ -31,19 +30,40 @@ const items = [
 ];
 
 const nameCellRenderer = ({ name }: { name?: string }) => (
-  <strong>{name}</strong>
+  <Cell>
+    <strong>{name}</strong>
+  </Cell>
 );
 const cityCellRenderer = ({ city }: { city?: string }) => (
-  <strong>{city}</strong>
+  <Cell>
+    <strong>{city}</strong>
+  </Cell>
 );
-const roleCellRenderer = ({ role }: { role?: string }) => <em>{role}</em>;
+const roleCellRenderer = ({ role }: { role?: string }) => (
+  <Cell>
+    <em>{role}</em>
+  </Cell>
+);
 const stateCellRenderer = ({ state }: { state?: string }) => (
-  <span>{state}</span>
+  <Cell>
+    <span>{state}</span>
+  </Cell>
 );
 const zipcodeCellRenderer = ({ zipcode }: { zipcode?: string }) => (
-  <span>{zipcode}</span>
+  <Cell>
+    <span>{zipcode}</span>
+  </Cell>
 );
-const empty = () => "empty";
+const veryLongRenderer = () => (
+  <TextCell>
+    <span>
+      {Array(100)
+        .fill("VeryLongWord")
+        .join("")}
+    </span>
+  </TextCell>
+);
+const empty = () => <Cell>empty</Cell>;
 const width = ({ width: totalWidth }: { width?: number }) =>
   totalWidth ? totalWidth * 0.3 : 100;
 
@@ -53,20 +73,42 @@ storiesOf("Table", module)
     <div
       style={{
         height: "175px",
-        width: "100%"
+        width: "100%",
+        fontSize: "14px"
       }}
     >
       <Table data={items}>
-        <Column header="name" cellRenderer={nameCellRenderer} width={width} />
-        <Column header="role" cellRenderer={roleCellRenderer} width={width} />
-        <Column header="state" cellRenderer={stateCellRenderer} width={width} />
+        <Column
+          header={<HeaderCell>name</HeaderCell>}
+          cellRenderer={nameCellRenderer}
+          width={width}
+        />
+        <Column
+          header={<HeaderCell>role</HeaderCell>}
+          cellRenderer={roleCellRenderer}
+          width={width}
+        />
+        <Column
+          header={<HeaderCell>state</HeaderCell>}
+          cellRenderer={stateCellRenderer}
+          width={width}
+        />
         <Column header="" cellRenderer={empty} width={width} />
         <Column
-          header="zipcode"
+          header={<HeaderCell>Very Long</HeaderCell>}
+          cellRenderer={veryLongRenderer}
+          width={width}
+        />
+        <Column
+          header={<HeaderCell>zipcode</HeaderCell>}
           cellRenderer={zipcodeCellRenderer}
           width={width}
         />
-        <Column header="city" cellRenderer={cityCellRenderer} width={width} />
+        <Column
+          header={<HeaderCell>city</HeaderCell>}
+          cellRenderer={cityCellRenderer}
+          width={width}
+        />
       </Table>
     </div>
   ));

--- a/packages/table/tests/Cell.test.tsx
+++ b/packages/table/tests/Cell.test.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import Cell from "../components/Cell";
+import HeaderCell from "../components/HeaderCell";
+import TextCell from "../components/TextCell";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import { render } from "enzyme";
+import toJson from "enzyme-to-json";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+describe("Cell", () => {
+  it("renders correctly", () => {
+    expect(toJson(render(<Cell>This is content</Cell>))).toMatchSnapshot();
+  });
+});
+
+describe("HeaderCell", () => {
+  it("renders correctly", () => {
+    expect(
+      toJson(render(<HeaderCell>This is content</HeaderCell>))
+    ).toMatchSnapshot();
+  });
+});
+
+describe("TextCell", () => {
+  it("renders correctly", () => {
+    expect(
+      toJson(render(<TextCell>This is content</TextCell>))
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/table/tests/__snapshots__/Cell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Cell.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cell renders correctly 1`] = `
+.emotion-0 {
+  height: 100%;
+  box-sizing: border-box;
+  padding: 7px;
+}
+
+<div
+  class="emotion-0"
+>
+  This is content
+</div>
+`;
+
+exports[`HeaderCell renders correctly 1`] = `
+.emotion-0 {
+  height: 100%;
+  box-sizing: border-box;
+  padding: 7px;
+  text-transform: uppercase;
+  font-weight: bold;
+}
+
+<div
+  class="emotion-0"
+>
+  This is content
+</div>
+`;
+
+exports[`TextCell renders correctly 1`] = `
+.emotion-0 {
+  height: 100%;
+  box-sizing: border-box;
+  padding: 7px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+<div
+  class="emotion-0"
+>
+  This is content
+</div>
+`;


### PR DESCRIPTION
<details><summary><strong>feat(table): add cell component</strong></summary><hr/>

This adds a cell component which provides basic styling for cell content.
</details>

---
Commit:
b65ccc17854c6692e626ecbf54e1eec9a58b234e
<details><summary><strong>feat(table): add header cell component</strong></summary><hr/>

This adds a HeaderCell Component which provides basic styling for table headers.
</details>

---
Commit:
3b71b4b43a318f6aa152dd21f2f89e537cf1a9fb
<details><summary><strong>feat(table): add text cell component</strong></summary><hr/>

This adds a TextCell component which provides basic styling for text cells. Specifically
`text-transform: ellipsis;`
</details>

---
Commit:
74e3dd14acd2a07dd9f9c577c989071637b713d5
<details><summary><strong>docs(table): add cell examples</strong></summary><hr/>

This adds Cell, HeaderCell and TextCell examples.
</details>

---
Commit:
eaddacfdca7b22f4b31af2b30cd454724dd4891b