### PR TITLE
fix: styled types path not found

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,12 @@
     "esModuleInterop": true,
     "strict": true,
     "moduleResolution": "node",
-    "typeRoots": ["node_modules/@types"],
+    "typeRoots": [
+      "node_modules/@types",
+      "node_modules/emotion/types",
+      "node_modules/create-emotion-styled/types",
+      "node_modules/create-emotion-styled/types/react"
+    ],
     "lib": ["es6", "dom", "es2017"]
   },
   "include": ["./packages/index.ts"],


### PR DESCRIPTION
*Solution*
Paired with @Fabs to find a fix for the dist issue.

Explicitly target emotion types to fix module import in ts, from:

```ts
declare const _default: import("../../../../../../../Users/fabs/ship/ui-kit/node_modules/create-emotion-styled/types/react").StyledOtherComponent<{}, import("../../../../../../../Users/fabs/ship/ui-kit/node_modules/create-emotion-styled/types/common").StyledOtherProps<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, any, React.Ref<any>>, any>;
```

to:

```ts
/// <reference path="../../../../node_modules/emotion/types/index.d.ts" />
/// <reference types="react" />
declare const _default: import("react").StyledOtherComponent<{}, React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, any>;
export default _default;
```

Closes DCOS-39087

*How to test*

- Checkout this code
- npm run dist
- check if your dist/ folder have any relative paths to your home