### PR TITLE
chore(deps): update dependency fs-extra to v7 - autoclosed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9315,9 +9315,9 @@
       }
     },
     "fs-extra": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
+      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -9383,12 +9383,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9403,17 +9405,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9530,7 +9535,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9542,6 +9548,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9556,6 +9563,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9563,12 +9571,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9587,6 +9597,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9667,7 +9678,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9679,6 +9691,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9800,6 +9813,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "enzyme-adapter-react-16": "1.1.1",
     "enzyme-to-json": "3.3.4",
     "file-loader": "1.1.11",
-    "fs-extra": "6.0.1",
+    "fs-extra": "7.0.0",
     "jest": "23.4.2",
     "jest-emotion": "9.2.4",
     "jest-runner-prettier": "0.2.6",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/jprichardson/node-fs-extra">fs-extra</a> from <code>v6.0.1</code> to <code>v7.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v700httpsgithubcomjprichardsonnode-fs-extrablobmasterchangelogmd8203700--2018-07-16"><a href="https://renovatebot.com/gh/jprichardson/node-fs-extra/blob/master/CHANGELOG.md#&#8203;700--2018-07-16"><code>v7.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/jprichardson/node-fs-extra/compare/6.0.1…7.0.0">Compare Source</a></p>
<ul>
<li><strong>BREAKING:</strong> Refine <code>copy*()</code> handling of symlinks to properly detect symlinks that point to the same file. (<a href="https://renovatebot.com/gh/jprichardson/node-fs-extra/pull/582">#&#8203;582</a>)</li>
<li>Fix bug with copying write-protected directories (<a href="https://renovatebot.com/gh/jprichardson/node-fs-extra/pull/600">#&#8203;600</a>)</li>
<li>Universalify <code>fs.lchmod()</code> (<a href="https://renovatebot.com/gh/jprichardson/node-fs-extra/pull/596">#&#8203;596</a>)</li>
<li>Add <code>engines</code> field to <code>package.json</code> (<a href="https://renovatebot.com/gh/jprichardson/node-fs-extra/pull/580">#&#8203;580</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>