### PR TITLE
chore(deps): update node:8.11.2-alpine docker digest to 72205c - autoclosed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.2-alpine@sha256:421ce172099baa5307b46b4bee9c3174deb162a6880e656ddef769869cbe2898
+FROM node:8.11.2-alpine@sha256:72205cb4ba4e95412e4f44731c9ee4dc7840769aecfa8992294c945b25a4c177
 
 # For deploying the gh-pages
 RUN apk update && apk upgrade && \


### PR DESCRIPTION
<p>This Pull Request updates Docker base image <code>node:8.11.2-alpine</code> to the latest digest (<code>sha256:72205cb4ba4e95412e4f44731c9ee4dc7840769aecfa8992294c945b25a4c177</code>). For details on Renovate's Docker support, please visit <a href="https://renovatebot.com/docs/docker">https://renovatebot.com/docs/docker</a></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>