### PR TITLE
Fix TextCell to not wrap

### DIFF
--- a/packages/table/components/TextCell.tsx
+++ b/packages/table/components/TextCell.tsx
@@ -4,4 +4,5 @@ import styled from "react-emotion";
 export default styled(Cell)`
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 `;

--- a/packages/table/tests/__snapshots__/Cell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Cell.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`TextCell renders correctly 1`] = `
   padding: 7px;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 <div


### PR DESCRIPTION
<details><summary><strong>fix(table): fix text cell white space wrap</strong></summary><hr/>

This fixes white space wrap to no wrap so that the text is getting correctly shortend.
</details>

---
Commit:
6583318f02ba4301ccf4c97bad380787406742a0