### PR TITLE
DCOS-39677: Capitalize only first letter in table header

### DIFF
--- a/packages/table/components/HeaderCell.tsx
+++ b/packages/table/components/HeaderCell.tsx
@@ -2,6 +2,6 @@ import { default as Cell } from "./Cell";
 import styled from "react-emotion";
 
 export default styled(Cell)`
-  text-transform: uppercase;
+  text-transform: capitalize;
   font-weight: bold;
 `;

--- a/packages/table/tests/__snapshots__/Cell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Cell.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`HeaderCell renders correctly 1`] = `
   height: 100%;
   box-sizing: border-box;
   padding: 7px;
-  text-transform: uppercase;
+  text-transform: capitalize;
   font-weight: bold;
 }
 


### PR DESCRIPTION
This `uppercase` css property is removed in order to make only first letter in headers capital.

related jira: https://jira.mesosphere.com/browse/DCOS-39677