### PR TITLE
chore(deps): update dependency enzyme-adapter-react-16 to v1.2.0 - autoclosed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5685,29 +5685,60 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz",
-      "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.2.0.tgz",
+      "integrity": "sha512-UgBra+xZFVFbU5Tw7Inw0bPrNJhM2ru4vCoO7preX6sOicXuDbOH927QJx4pk6m6vatd8jnPXTF6/GCjzytJTg==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.3.0",
-        "lodash": "^4.17.4",
-        "object.assign": "^4.0.4",
+        "enzyme-adapter-utils": "^1.5.0",
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
         "object.values": "^1.0.4",
-        "prop-types": "^15.6.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.4.2",
         "react-reconciler": "^0.7.0",
         "react-test-renderer": "^16.0.0-0"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-is": {
+          "version": "16.4.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.2.tgz",
+          "integrity": "sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg==",
+          "dev": true
+        }
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
-      "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.5.0.tgz",
+      "integrity": "sha512-cLUaPYU8GEzAHi/1hiO+ylz4QiQWI8eb9SysAk8Tbul2O918dRf4cfD4s2BjijtwSvhapkOsPW9XRix1EXlJ1Q==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
-        "object.assign": "^4.0.4",
-        "prop-types": "^15.6.0"
+        "function.prototype.name": "^1.1.0",
+        "object.assign": "^4.1.0",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "enzyme-to-json": {
@@ -6709,7 +6740,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7124,7 +7156,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7180,6 +7213,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7223,12 +7257,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "commander": "2.15.1",
     "cz-conventional-changelog": "2.1.0",
     "enzyme": "3.3.0",
-    "enzyme-adapter-react-16": "1.1.1",
+    "enzyme-adapter-react-16": "1.2.0",
     "enzyme-to-json": "3.3.4",
     "file-loader": "1.1.11",
     "fs-extra": "6.0.1",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/airbnb/enzyme">enzyme-adapter-react-16</a> from <code>v1.1.1</code> to <code>v1.2.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v120httpsgithubcomairbnbenzymeblobmasterchangelogmd8203120-december-10-2015"><a href="https://renovatebot.com/gh/airbnb/enzyme/blob/master/CHANGELOG.md#&#8203;120-December-10-2015"><code>v1.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/airbnb/enzyme/compare/0a513b74a2a83118ace45554b13fcd5c25ea1c31…v1.2.0">Compare Source</a></p>
<h5 id="minor-changes">Minor Changes</h5>
<ul>
<li>Support for context (<a href="https://renovatebot.com/gh/airbnb/enzyme/pull/62">#&#8203;62</a>)</li>
</ul>
<h5 id="patches">Patches</h5>
<ul>
<li><code>nodeHasId</code> fix for some 0.14 corner cases (<a href="https://renovatebot.com/gh/airbnb/enzyme/pull/65">#&#8203;65</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>