### PR TITLE
chore(deps): update dependency jest to v23.5.0 - autoclosed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9383,12 +9383,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9403,17 +9405,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9530,7 +9535,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9542,6 +9548,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9556,6 +9563,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9563,12 +9571,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9587,6 +9597,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9667,7 +9678,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9679,6 +9691,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9800,6 +9813,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11880,13 +11894,13 @@
       "integrity": "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w=="
     },
     "jest": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-23.4.2.tgz",
-      "integrity": "sha512-w10HGpVFWT1oN8B2coxeiMEsZoggkDaw3i26xHGLU+rsR+LYkBk8qpZCgi+1cD1S6ttPjZDL8E8M99lmNhgTeA==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-23.5.0.tgz",
+      "integrity": "sha512-+X3Fk4rD8dTnHoIxHJymZthbtYllvSOnXAApQltvyLkHsv+fqyC/SZptUJDbXkFsqZJyyIXMySkdzerz3fv4oQ==",
       "dev": true,
       "requires": {
         "import-local": "^1.0.0",
-        "jest-cli": "^23.4.2"
+        "jest-cli": "^23.5.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11957,15 +11971,15 @@
           }
         },
         "expect": {
-          "version": "23.4.0",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-23.4.0.tgz",
-          "integrity": "sha1-baTsyZwUcSU+cogziYOtHrrbYMM=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-23.5.0.tgz",
+          "integrity": "sha512-aG083W63tBloy8YgafWuC44EakjYe0Q6Mg35aujBPvyNU38DvLat9BVzOihNP2NZDLaCJiFNe0vejbtO6knnlA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
-            "jest-diff": "^23.2.0",
+            "jest-diff": "^23.5.0",
             "jest-get-type": "^22.1.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
             "jest-regex-util": "^23.3.0"
           }
@@ -12001,9 +12015,9 @@
           }
         },
         "jest-cli": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.4.2.tgz",
-          "integrity": "sha512-vaDzy0wRWrgSfz4ZImCqD2gtZqCSoEWp60y3USvGDxA2b4K0rGj2voru6a5scJFjDx5GCiNWKpz2E8IdWDVjdw==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.5.0.tgz",
+          "integrity": "sha512-Kxi2QH8s6NkpPgboza/plpmQ2bjUQ+MwYv7vM5rDwJz/x+NB4YoLXFikPXLWNP0JuYpMvYwITKneFljnNKhq2Q==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^3.0.0",
@@ -12018,18 +12032,18 @@
             "istanbul-lib-instrument": "^1.10.1",
             "istanbul-lib-source-maps": "^1.2.4",
             "jest-changed-files": "^23.4.2",
-            "jest-config": "^23.4.2",
+            "jest-config": "^23.5.0",
             "jest-environment-jsdom": "^23.4.0",
             "jest-get-type": "^22.1.0",
-            "jest-haste-map": "^23.4.1",
+            "jest-haste-map": "^23.5.0",
             "jest-message-util": "^23.4.0",
             "jest-regex-util": "^23.3.0",
-            "jest-resolve-dependencies": "^23.4.2",
-            "jest-runner": "^23.4.2",
-            "jest-runtime": "^23.4.2",
-            "jest-snapshot": "^23.4.2",
+            "jest-resolve-dependencies": "^23.5.0",
+            "jest-runner": "^23.5.0",
+            "jest-runtime": "^23.5.0",
+            "jest-snapshot": "^23.5.0",
             "jest-util": "^23.4.0",
-            "jest-validate": "^23.4.0",
+            "jest-validate": "^23.5.0",
             "jest-watcher": "^23.4.0",
             "jest-worker": "^23.2.0",
             "micromatch": "^2.3.11",
@@ -12045,9 +12059,9 @@
           }
         },
         "jest-config": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.2.tgz",
-          "integrity": "sha512-CDJGO4H+7P+T6khaSHEjTxqVaIlmQMEFAyJFOVrAQeM+Xn12iZ+YY8Pluk1RDxi8Jqj9DoE09PHQzASCGePGtg==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.5.0.tgz",
+          "integrity": "sha512-JENhQpLaVwXWPLUkhPYgIfecHKsU8GR1vj79rS4n0LSRsHx/U2wItZKoKAd5vtt2J58JPxRq4XheG79jd4fI7Q==",
           "dev": true,
           "requires": {
             "babel-core": "^6.0.0",
@@ -12057,24 +12071,25 @@
             "jest-environment-jsdom": "^23.4.0",
             "jest-environment-node": "^23.4.0",
             "jest-get-type": "^22.1.0",
-            "jest-jasmine2": "^23.4.2",
+            "jest-jasmine2": "^23.5.0",
             "jest-regex-util": "^23.3.0",
-            "jest-resolve": "^23.4.1",
+            "jest-resolve": "^23.5.0",
             "jest-util": "^23.4.0",
-            "jest-validate": "^23.4.0",
-            "pretty-format": "^23.2.0"
+            "jest-validate": "^23.5.0",
+            "micromatch": "^2.3.11",
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-diff": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
-          "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.5.0.tgz",
+          "integrity": "sha512-Miz8GakJIz443HkGpVOAyHQgSYqcgs2zQmDJl4oV7DYrFotchdoQvxceF6LhfpRBV1LOUGcFk5Dd/ffSXVwMsA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "diff": "^3.2.0",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-environment-jsdom": {
@@ -12099,34 +12114,34 @@
           }
         },
         "jest-jasmine2": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz",
-          "integrity": "sha512-MUoqn41XHMQe5u8QvRTH2HahpBNzImnnjS3pV/T7LvrCM6f2zfGdi1Pm+bRbFMLJROqR8VlK8HmsenL2WjrUIQ==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz",
+          "integrity": "sha512-xMgvDUvgqKpilsGnneC9Qr+uIlROxKI3UoJcHZeUlu6AKpQyEkGh0hKbfM0NaEjX5sy7WeFQEhcp/AiWlHcc0A==",
           "dev": true,
           "requires": {
             "babel-traverse": "^6.0.0",
             "chalk": "^2.0.1",
             "co": "^4.6.0",
-            "expect": "^23.4.0",
+            "expect": "^23.5.0",
             "is-generator-fn": "^1.0.0",
-            "jest-diff": "^23.2.0",
-            "jest-each": "^23.4.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-diff": "^23.5.0",
+            "jest-each": "^23.5.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
-            "jest-snapshot": "^23.4.2",
+            "jest-snapshot": "^23.5.0",
             "jest-util": "^23.4.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-matcher-utils": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-          "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz",
+          "integrity": "sha512-hmQUKUKYOExp3T8dNYK9A9copCFYKoRLcY4WDJJ0Z2u3oF6rmAhHuZtmpHBuGpASazobBxm3TXAfAXDvz2T7+Q==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-message-util": {
@@ -12155,9 +12170,9 @@
           "dev": true
         },
         "jest-resolve": {
-          "version": "23.4.1",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
-          "integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.5.0.tgz",
+          "integrity": "sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==",
           "dev": true,
           "requires": {
             "browser-resolve": "^1.11.3",
@@ -12166,20 +12181,20 @@
           }
         },
         "jest-snapshot": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
-          "integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.5.0.tgz",
+          "integrity": "sha512-NYg8MFNVyPXmnnihiltasr4t1FJEXFbZFaw1vZCowcnezIQ9P1w+yxTwjWT564QP24Zbn5L9cjxLs8d6K+pNlw==",
           "dev": true,
           "requires": {
             "babel-types": "^6.0.0",
             "chalk": "^2.0.1",
-            "jest-diff": "^23.2.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-diff": "^23.5.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
-            "jest-resolve": "^23.4.1",
+            "jest-resolve": "^23.5.0",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^23.2.0",
+            "pretty-format": "^23.5.0",
             "semver": "^5.5.0"
           }
         },
@@ -12200,15 +12215,15 @@
           }
         },
         "jest-validate": {
-          "version": "23.4.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
-          "integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.5.0.tgz",
+          "integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "jest-get-type": "^22.1.0",
             "leven": "^2.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-worker": {
@@ -12242,9 +12257,9 @@
           }
         },
         "pretty-format": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-          "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+          "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0",
@@ -12363,13 +12378,13 @@
       }
     },
     "jest-each": {
-      "version": "23.4.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.4.0.tgz",
-      "integrity": "sha1-L6nt2J2qGk7cn/m/YGKja3E0UUM=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.5.0.tgz",
+      "integrity": "sha512-8BgebQgAJmWXpYp4Qt9l3cn1Xei0kZ7JL4cs/NXh7750ATlPGzRRYbutFVJTk5B/Lt3mjHP3G3tLQLyBOCSHGA==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.1",
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12379,9 +12394,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-          "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+          "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0",
@@ -12442,13 +12457,14 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "23.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.4.1.tgz",
-      "integrity": "sha512-PGQxOEGAfRbTyJkmZeOKkVSs+KVeWgG625p89KUuq+sIIchY5P8iPIIc+Hw2tJJPBzahU3qopw1kF/qyhDdNBw==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.5.0.tgz",
+      "integrity": "sha512-bt9Swigb6KZ6ZQq/fQDUwdUeHenVvZ6G/lKwJjwRGp+Fap8D4B3bND3FaeJg7vXVsLX8hXshRArbVxLop/5wLw==",
       "dev": true,
       "requires": {
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.1.11",
+        "invariant": "^2.2.4",
         "jest-docblock": "^23.2.0",
         "jest-serializer": "^23.0.1",
         "jest-worker": "^23.2.0",
@@ -12567,12 +12583,12 @@
       }
     },
     "jest-leak-detector": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz",
-      "integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.5.0.tgz",
+      "integrity": "sha512-40VsHQCIEslxg91Zg5NiZGtPeWSBLXiD6Ww+lhHlIF6u8uSQ+xgiD6NbWHFOYs1VBRI+V/ym7Q1aOtVg9tqMzQ==",
       "dev": true,
       "requires": {
-        "pretty-format": "^23.2.0"
+        "pretty-format": "^23.5.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12582,9 +12598,9 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-          "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+          "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0",
@@ -12722,13 +12738,13 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz",
-      "integrity": "sha512-JUrU1/1mQAf0eKwKT4+RRnaqcw0UcRzRE38vyO+YnqoXUVidf646iuaKE+NG7E6Gb0+EVPOJ6TgqkaTPdQz78A==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.5.0.tgz",
+      "integrity": "sha512-APZc/CjfzL8rH/wr+Gh7XJJygYaDjMQsWaJy4ZR1WaHWKude4WcfdU8xjqaNbx5NsVF2P2tVvsLbumlPXCdJOw==",
       "dev": true,
       "requires": {
         "jest-regex-util": "^23.3.0",
-        "jest-snapshot": "^23.4.2"
+        "jest-snapshot": "^23.5.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -12806,26 +12822,26 @@
           }
         },
         "jest-diff": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
-          "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.5.0.tgz",
+          "integrity": "sha512-Miz8GakJIz443HkGpVOAyHQgSYqcgs2zQmDJl4oV7DYrFotchdoQvxceF6LhfpRBV1LOUGcFk5Dd/ffSXVwMsA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "diff": "^3.2.0",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-matcher-utils": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-          "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz",
+          "integrity": "sha512-hmQUKUKYOExp3T8dNYK9A9copCFYKoRLcY4WDJJ0Z2u3oF6rmAhHuZtmpHBuGpASazobBxm3TXAfAXDvz2T7+Q==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-message-util": {
@@ -12848,9 +12864,9 @@
           "dev": true
         },
         "jest-resolve": {
-          "version": "23.4.1",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
-          "integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.5.0.tgz",
+          "integrity": "sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==",
           "dev": true,
           "requires": {
             "browser-resolve": "^1.11.3",
@@ -12859,20 +12875,20 @@
           }
         },
         "jest-snapshot": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
-          "integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.5.0.tgz",
+          "integrity": "sha512-NYg8MFNVyPXmnnihiltasr4t1FJEXFbZFaw1vZCowcnezIQ9P1w+yxTwjWT564QP24Zbn5L9cjxLs8d6K+pNlw==",
           "dev": true,
           "requires": {
             "babel-types": "^6.0.0",
             "chalk": "^2.0.1",
-            "jest-diff": "^23.2.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-diff": "^23.5.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
-            "jest-resolve": "^23.4.1",
+            "jest-resolve": "^23.5.0",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^23.2.0",
+            "pretty-format": "^23.5.0",
             "semver": "^5.5.0"
           }
         },
@@ -12898,9 +12914,9 @@
           }
         },
         "pretty-format": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-          "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+          "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0",
@@ -12916,20 +12932,20 @@
       }
     },
     "jest-runner": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.4.2.tgz",
-      "integrity": "sha512-o+aEdDE7/Gyp8fLYEEf5B8aOUguz76AYcAMl5pueucey2Q50O8uUIXJ7zvt8O6OEJDztR3Kb+osMoh8MVIqgTw==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.5.0.tgz",
+      "integrity": "sha512-cpBvkBTVmW1ab1thbtoh2m6VnnM0BYKhj3MEzbOTZjPfzoIjUVIxLUTDobVNOvEK7aTEb/2oiPlNoOTSNJx8mw==",
       "dev": true,
       "requires": {
         "exit": "^0.1.2",
         "graceful-fs": "^4.1.11",
-        "jest-config": "^23.4.2",
+        "jest-config": "^23.5.0",
         "jest-docblock": "^23.2.0",
-        "jest-haste-map": "^23.4.1",
-        "jest-jasmine2": "^23.4.2",
-        "jest-leak-detector": "^23.2.0",
+        "jest-haste-map": "^23.5.0",
+        "jest-jasmine2": "^23.5.0",
+        "jest-leak-detector": "^23.5.0",
         "jest-message-util": "^23.4.0",
-        "jest-runtime": "^23.4.2",
+        "jest-runtime": "^23.5.0",
         "jest-util": "^23.4.0",
         "jest-worker": "^23.2.0",
         "source-map-support": "^0.5.6",
@@ -12993,15 +13009,15 @@
           }
         },
         "expect": {
-          "version": "23.4.0",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-23.4.0.tgz",
-          "integrity": "sha1-baTsyZwUcSU+cogziYOtHrrbYMM=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-23.5.0.tgz",
+          "integrity": "sha512-aG083W63tBloy8YgafWuC44EakjYe0Q6Mg35aujBPvyNU38DvLat9BVzOihNP2NZDLaCJiFNe0vejbtO6knnlA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
-            "jest-diff": "^23.2.0",
+            "jest-diff": "^23.5.0",
             "jest-get-type": "^22.1.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
             "jest-regex-util": "^23.3.0"
           }
@@ -13031,9 +13047,9 @@
           }
         },
         "jest-config": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.2.tgz",
-          "integrity": "sha512-CDJGO4H+7P+T6khaSHEjTxqVaIlmQMEFAyJFOVrAQeM+Xn12iZ+YY8Pluk1RDxi8Jqj9DoE09PHQzASCGePGtg==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.5.0.tgz",
+          "integrity": "sha512-JENhQpLaVwXWPLUkhPYgIfecHKsU8GR1vj79rS4n0LSRsHx/U2wItZKoKAd5vtt2J58JPxRq4XheG79jd4fI7Q==",
           "dev": true,
           "requires": {
             "babel-core": "^6.0.0",
@@ -13043,24 +13059,25 @@
             "jest-environment-jsdom": "^23.4.0",
             "jest-environment-node": "^23.4.0",
             "jest-get-type": "^22.1.0",
-            "jest-jasmine2": "^23.4.2",
+            "jest-jasmine2": "^23.5.0",
             "jest-regex-util": "^23.3.0",
-            "jest-resolve": "^23.4.1",
+            "jest-resolve": "^23.5.0",
             "jest-util": "^23.4.0",
-            "jest-validate": "^23.4.0",
-            "pretty-format": "^23.2.0"
+            "jest-validate": "^23.5.0",
+            "micromatch": "^2.3.11",
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-diff": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
-          "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.5.0.tgz",
+          "integrity": "sha512-Miz8GakJIz443HkGpVOAyHQgSYqcgs2zQmDJl4oV7DYrFotchdoQvxceF6LhfpRBV1LOUGcFk5Dd/ffSXVwMsA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "diff": "^3.2.0",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-environment-jsdom": {
@@ -13085,34 +13102,34 @@
           }
         },
         "jest-jasmine2": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz",
-          "integrity": "sha512-MUoqn41XHMQe5u8QvRTH2HahpBNzImnnjS3pV/T7LvrCM6f2zfGdi1Pm+bRbFMLJROqR8VlK8HmsenL2WjrUIQ==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz",
+          "integrity": "sha512-xMgvDUvgqKpilsGnneC9Qr+uIlROxKI3UoJcHZeUlu6AKpQyEkGh0hKbfM0NaEjX5sy7WeFQEhcp/AiWlHcc0A==",
           "dev": true,
           "requires": {
             "babel-traverse": "^6.0.0",
             "chalk": "^2.0.1",
             "co": "^4.6.0",
-            "expect": "^23.4.0",
+            "expect": "^23.5.0",
             "is-generator-fn": "^1.0.0",
-            "jest-diff": "^23.2.0",
-            "jest-each": "^23.4.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-diff": "^23.5.0",
+            "jest-each": "^23.5.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
-            "jest-snapshot": "^23.4.2",
+            "jest-snapshot": "^23.5.0",
             "jest-util": "^23.4.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-matcher-utils": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-          "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz",
+          "integrity": "sha512-hmQUKUKYOExp3T8dNYK9A9copCFYKoRLcY4WDJJ0Z2u3oF6rmAhHuZtmpHBuGpASazobBxm3TXAfAXDvz2T7+Q==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-message-util": {
@@ -13141,9 +13158,9 @@
           "dev": true
         },
         "jest-resolve": {
-          "version": "23.4.1",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
-          "integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.5.0.tgz",
+          "integrity": "sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==",
           "dev": true,
           "requires": {
             "browser-resolve": "^1.11.3",
@@ -13152,20 +13169,20 @@
           }
         },
         "jest-snapshot": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
-          "integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.5.0.tgz",
+          "integrity": "sha512-NYg8MFNVyPXmnnihiltasr4t1FJEXFbZFaw1vZCowcnezIQ9P1w+yxTwjWT564QP24Zbn5L9cjxLs8d6K+pNlw==",
           "dev": true,
           "requires": {
             "babel-types": "^6.0.0",
             "chalk": "^2.0.1",
-            "jest-diff": "^23.2.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-diff": "^23.5.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
-            "jest-resolve": "^23.4.1",
+            "jest-resolve": "^23.5.0",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^23.2.0",
+            "pretty-format": "^23.5.0",
             "semver": "^5.5.0"
           }
         },
@@ -13186,15 +13203,15 @@
           }
         },
         "jest-validate": {
-          "version": "23.4.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
-          "integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.5.0.tgz",
+          "integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "jest-get-type": "^22.1.0",
             "leven": "^2.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-worker": {
@@ -13228,9 +13245,9 @@
           }
         },
         "pretty-format": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-          "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+          "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0",
@@ -13263,9 +13280,9 @@
       }
     },
     "jest-runtime": {
-      "version": "23.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.4.2.tgz",
-      "integrity": "sha512-qaUDOi7tcdDe3MH5g5ycEslTpx0voPZvzIYbKjvWxCzCL2JEemLM+7IEe0BeLi2v5wvb/uh3dkb2wQI67uPtCw==",
+      "version": "23.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.5.0.tgz",
+      "integrity": "sha512-WzzYxYtoU8S1MJns0G4E3BsuFUTFBiu1qsk3iC9OTugzNQcQKt0BoOGsT7wXCKqkw/09QdV77vvaeJXST2Efgg==",
       "dev": true,
       "requires": {
         "babel-core": "^6.0.0",
@@ -13275,14 +13292,14 @@
         "exit": "^0.1.2",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.1.11",
-        "jest-config": "^23.4.2",
-        "jest-haste-map": "^23.4.1",
+        "jest-config": "^23.5.0",
+        "jest-haste-map": "^23.5.0",
         "jest-message-util": "^23.4.0",
         "jest-regex-util": "^23.3.0",
-        "jest-resolve": "^23.4.1",
-        "jest-snapshot": "^23.4.2",
+        "jest-resolve": "^23.5.0",
+        "jest-snapshot": "^23.5.0",
         "jest-util": "^23.4.0",
-        "jest-validate": "^23.4.0",
+        "jest-validate": "^23.5.0",
         "micromatch": "^2.3.11",
         "realpath-native": "^1.0.0",
         "slash": "^1.0.0",
@@ -13359,15 +13376,15 @@
           }
         },
         "expect": {
-          "version": "23.4.0",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-23.4.0.tgz",
-          "integrity": "sha1-baTsyZwUcSU+cogziYOtHrrbYMM=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-23.5.0.tgz",
+          "integrity": "sha512-aG083W63tBloy8YgafWuC44EakjYe0Q6Mg35aujBPvyNU38DvLat9BVzOihNP2NZDLaCJiFNe0vejbtO6knnlA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
-            "jest-diff": "^23.2.0",
+            "jest-diff": "^23.5.0",
             "jest-get-type": "^22.1.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
             "jest-regex-util": "^23.3.0"
           }
@@ -13403,9 +13420,9 @@
           }
         },
         "jest-config": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.4.2.tgz",
-          "integrity": "sha512-CDJGO4H+7P+T6khaSHEjTxqVaIlmQMEFAyJFOVrAQeM+Xn12iZ+YY8Pluk1RDxi8Jqj9DoE09PHQzASCGePGtg==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.5.0.tgz",
+          "integrity": "sha512-JENhQpLaVwXWPLUkhPYgIfecHKsU8GR1vj79rS4n0LSRsHx/U2wItZKoKAd5vtt2J58JPxRq4XheG79jd4fI7Q==",
           "dev": true,
           "requires": {
             "babel-core": "^6.0.0",
@@ -13415,24 +13432,25 @@
             "jest-environment-jsdom": "^23.4.0",
             "jest-environment-node": "^23.4.0",
             "jest-get-type": "^22.1.0",
-            "jest-jasmine2": "^23.4.2",
+            "jest-jasmine2": "^23.5.0",
             "jest-regex-util": "^23.3.0",
-            "jest-resolve": "^23.4.1",
+            "jest-resolve": "^23.5.0",
             "jest-util": "^23.4.0",
-            "jest-validate": "^23.4.0",
-            "pretty-format": "^23.2.0"
+            "jest-validate": "^23.5.0",
+            "micromatch": "^2.3.11",
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-diff": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
-          "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.5.0.tgz",
+          "integrity": "sha512-Miz8GakJIz443HkGpVOAyHQgSYqcgs2zQmDJl4oV7DYrFotchdoQvxceF6LhfpRBV1LOUGcFk5Dd/ffSXVwMsA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "diff": "^3.2.0",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-environment-jsdom": {
@@ -13457,34 +13475,34 @@
           }
         },
         "jest-jasmine2": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz",
-          "integrity": "sha512-MUoqn41XHMQe5u8QvRTH2HahpBNzImnnjS3pV/T7LvrCM6f2zfGdi1Pm+bRbFMLJROqR8VlK8HmsenL2WjrUIQ==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.5.0.tgz",
+          "integrity": "sha512-xMgvDUvgqKpilsGnneC9Qr+uIlROxKI3UoJcHZeUlu6AKpQyEkGh0hKbfM0NaEjX5sy7WeFQEhcp/AiWlHcc0A==",
           "dev": true,
           "requires": {
             "babel-traverse": "^6.0.0",
             "chalk": "^2.0.1",
             "co": "^4.6.0",
-            "expect": "^23.4.0",
+            "expect": "^23.5.0",
             "is-generator-fn": "^1.0.0",
-            "jest-diff": "^23.2.0",
-            "jest-each": "^23.4.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-diff": "^23.5.0",
+            "jest-each": "^23.5.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
-            "jest-snapshot": "^23.4.2",
+            "jest-snapshot": "^23.5.0",
             "jest-util": "^23.4.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-matcher-utils": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
-          "integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.5.0.tgz",
+          "integrity": "sha512-hmQUKUKYOExp3T8dNYK9A9copCFYKoRLcY4WDJJ0Z2u3oF6rmAhHuZtmpHBuGpASazobBxm3TXAfAXDvz2T7+Q==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "jest-get-type": "^22.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "jest-message-util": {
@@ -13513,9 +13531,9 @@
           "dev": true
         },
         "jest-resolve": {
-          "version": "23.4.1",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.4.1.tgz",
-          "integrity": "sha512-VNk4YRNR5gsHhNS0Lp46/DzTT11e+ecbUC61ikE593cKbtdrhrMO+zXkOJaE8YDD5sHxH9W6OfssNn4FkZBzZQ==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.5.0.tgz",
+          "integrity": "sha512-CRPc0ebG3baNKz/QicIy5rGfzYpMNm8AjEl/tDQhehq/QC4ttyauZdvAXel3qo+4Gri9ljajnxW+hWyxZbbcnQ==",
           "dev": true,
           "requires": {
             "browser-resolve": "^1.11.3",
@@ -13524,20 +13542,20 @@
           }
         },
         "jest-snapshot": {
-          "version": "23.4.2",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",
-          "integrity": "sha512-rCBxIURDlVEW1gJgJSpo8l2F2gFwp9U7Yb3CmcABUpmQ8NASpb6LJkEvtcQifAYSi22OL44TSuanq1G6x1GJwg==",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.5.0.tgz",
+          "integrity": "sha512-NYg8MFNVyPXmnnihiltasr4t1FJEXFbZFaw1vZCowcnezIQ9P1w+yxTwjWT564QP24Zbn5L9cjxLs8d6K+pNlw==",
           "dev": true,
           "requires": {
             "babel-types": "^6.0.0",
             "chalk": "^2.0.1",
-            "jest-diff": "^23.2.0",
-            "jest-matcher-utils": "^23.2.0",
+            "jest-diff": "^23.5.0",
+            "jest-matcher-utils": "^23.5.0",
             "jest-message-util": "^23.4.0",
-            "jest-resolve": "^23.4.1",
+            "jest-resolve": "^23.5.0",
             "mkdirp": "^0.5.1",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^23.2.0",
+            "pretty-format": "^23.5.0",
             "semver": "^5.5.0"
           }
         },
@@ -13558,15 +13576,15 @@
           }
         },
         "jest-validate": {
-          "version": "23.4.0",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
-          "integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.5.0.tgz",
+          "integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
           "dev": true,
           "requires": {
             "chalk": "^2.0.1",
             "jest-get-type": "^22.1.0",
             "leven": "^2.1.0",
-            "pretty-format": "^23.2.0"
+            "pretty-format": "^23.5.0"
           }
         },
         "micromatch": {
@@ -13591,9 +13609,9 @@
           }
         },
         "pretty-format": {
-          "version": "23.2.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
-          "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+          "version": "23.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+          "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0",
@@ -23903,9 +23921,9 @@
       }
     },
     "prompts": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.13.tgz",
-      "integrity": "sha512-5SXno8Svo4bo+aBiY0YjlnjN/ZIwMDz60dADwAxSAonDQiq8WKpB+gnP50D9PgPYtZ1MvpS4RoVa0dX4B9lrcw==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
+      "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
       "dev": true,
       "requires": {
         "kleur": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "enzyme-to-json": "3.3.4",
     "file-loader": "1.1.11",
     "fs-extra": "6.0.1",
-    "jest": "23.4.2",
+    "jest": "23.5.0",
     "jest-emotion": "9.2.4",
     "jest-runner-prettier": "0.2.6",
     "node": "10.5.0",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/facebook/jest">jest</a> from <code>v23.4.2</code> to <code>v23.5.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v2350httpsgithubcomfacebookjestblobmasterchangelogmd82032350"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2350"><code>v23.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.4.2…v23.5.0">Compare Source</a></p>
<h5 id="features">Features</h5>
<ul>
<li><code>[jest-cli]</code> Add package name to <code>NotifyReporter</code> notification (<a href="https://renovatebot.com/gh/facebook/jest/pull/5898">#&#8203;5898</a>)</li>
<li><code>[jest-runner]</code> print stack trace when <code>process.exit</code> is called from user code (<a href="https://renovatebot.com/gh/facebook/jest/pull/6714">#&#8203;6714</a>)</li>
<li><code>[jest-each]</code> introduces <code>%#</code> option to add index of the test to its title (<a href="https://renovatebot.com/gh/facebook/jest/pull/6414">#&#8203;6414</a>)</li>
<li><code>[pretty-format]</code> Support serializing <code>DocumentFragment</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6705">#&#8203;6705</a>)</li>
<li><code>[jest-validate]</code> Add <code>recursive</code> and <code>recursiveBlacklist</code> options for deep config checks (<a href="https://renovatebot.com/gh/facebook/jest/pull/6802">#&#8203;6802</a>)</li>
<li><code>[jest-cli]</code> Check watch plugins for key conflicts (<a href="https://renovatebot.com/gh/facebook/jest/pull/6697">#&#8203;6697</a>)</li>
</ul>
<h5 id="fixes">Fixes</h5>
<ul>
<li><code>[jest-snapshot</code> Mark snapshots as obsolete when moved to an inline snapshot (<a href="https://renovatebot.com/gh/facebook/jest/pull/6773">#&#8203;6773</a>)</li>
<li><code>[jest-config]</code> Fix <code>--coverage</code> with <code>--findRelatedTests</code> overwriting <code>collectCoverageFrom</code> options (<a href="https://renovatebot.com/gh/facebook/jest/pull/6736">#&#8203;6736</a>)</li>
<li><code>[jest-config]</code> Update default config for testURL from 'about:blank' to '<a href="http://localhost">http://localhost</a>' to address latest JSDOM security warning. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6792">#&#8203;6792</a>)</li>
<li><code>[jest-cli]</code> Fix <code>testMatch</code> not working with negations (<a href="https://renovatebot.com/gh/facebook/jest/pull/6648">#&#8203;6648</a>)</li>
<li><code>[jest-cli]</code> Don't report promises as open handles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6716">#&#8203;6716</a>)</li>
<li><code>[jest-each]</code> Add timeout support to parameterised tests (<a href="https://renovatebot.com/gh/facebook/jest/pull/6660">#&#8203;6660</a>)</li>
<li><code>[jest-cli]</code> Improve the message when running coverage while there are no files matching global threshold (<a href="https://renovatebot.com/gh/facebook/jest/pull/6334">#&#8203;6334</a>)</li>
<li><code>[jest-snapshot]</code> Correctly merge property matchers with the rest of the snapshot in <code>toMatchSnapshot</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6528">#&#8203;6528</a>)</li>
<li><code>[jest-snapshot]</code> Add error messages for invalid property matchers. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6528">#&#8203;6528</a>)</li>
<li><code>[jest-cli]</code> Show open handles from inside test files as well (<a href="https://renovatebot.com/gh/facebook/jest/pull/6263">#&#8203;6263</a>)</li>
<li><code>[jest-haste-map]</code> Fix a problem where creating folders ending with <code>.js</code> could cause a crash (<a href="https://renovatebot.com/gh/facebook/jest/pull/6818">#&#8203;6818</a>)</li>
</ul>
<h5 id="chore--maintenance">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Document another option to avoid warnings with React 16 (<a href="https://renovatebot.com/gh/facebook/jest/issues/5258">#&#8203;5258</a>)</li>
<li><code>[docs]</code> Add note explaining when <code>jest.setTimeout</code> should be called (<a href="https://renovatebot.com/gh/facebook/jest/pull/6817/files">#&#8203;6817</a>)</li>
<li><code>[docs]</code> Fixed bug in example code (<a href="https://renovatebot.com/gh/facebook/jest/pull/6828">#&#8203;6828</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>