### PR TITLE
chore(deps): update dependency react-docgen-typescript-loader to v2.2.0 - autoclosed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9383,12 +9383,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9403,17 +9405,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9530,7 +9535,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9542,6 +9548,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9556,6 +9563,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9563,12 +9571,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -9587,6 +9597,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9667,7 +9678,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9679,6 +9691,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9800,6 +9813,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -24348,15 +24362,15 @@
       }
     },
     "react-docgen-typescript": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.6.1.tgz",
-      "integrity": "sha512-GNjoMwGfksDcPKnMMJ8LKElV/gWZ478B3cJMDNp3MnZ6Dd49jicpmlVg11/IpuycwWAfCyDiyv2VJNNJ55q5zA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-1.6.3.tgz",
+      "integrity": "sha512-7fpH8+hPlSAPfiZvbtAagfvBXnkTWQrh+gMbwPjFCqY5MARB3nmBuGnq8LirRUpQtKdc3IX5Bpb+DAj0gkzZgA==",
       "dev": true
     },
     "react-docgen-typescript-loader": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/react-docgen-typescript-loader/-/react-docgen-typescript-loader-2.1.1.tgz",
-      "integrity": "sha1-i6aNzA2RPB/oKy37ioN7AqI9904=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript-loader/-/react-docgen-typescript-loader-2.2.0.tgz",
+      "integrity": "sha512-x+utgL5fiTiliGFmLFbcd4GihmKonsCFpjo+VrZM8tbF5qKYkHRnIy35FxbWYKrOVrdK+8bUnh7ttjXLVWqIDw==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "npm": "6.1.0",
     "prettier": "1.13.5",
     "prop-types": "15.6.1",
-    "react-docgen-typescript-loader": "2.1.1",
+    "react-docgen-typescript-loader": "2.2.0",
     "react-test-renderer": "16.4.0",
     "rimraf": "2.6.2",
     "storybook-readme": "3.3.0",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/strothj/react-docgen-typescript-loader">react-docgen-typescript-loader</a> from <code>v2.1.1</code> to <code>v2.2.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v220httpsgithubcomstrothjreact-docgen-typescript-loadercompare1b7f84381ebb797f661f20f37db51a08f3f3e5c8bd696730dfc067d1e9bf238938aa3a6037000898"><a href="https://renovatebot.com/gh/strothj/react-docgen-typescript-loader/compare/1b7f84381ebb797f661f20f37db51a08f3f3e5c8…bd696730dfc067d1e9bf238938aa3a6037000898"><code>v2.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/strothj/react-docgen-typescript-loader/compare/1b7f84381ebb797f661f20f37db51a08f3f3e5c8…bd696730dfc067d1e9bf238938aa3a6037000898">Compare Source</a></p>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>