### PR TITLE
chore(renovate): bind to webpack 3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,22 @@
     {
       "packagePatterns": ["*"],
       "groupName": "all"
+    },
+    {
+      "packageNames": ["webpack"],
+      "allowedVersions": "3.11.0"
+    },
+    {
+      "packageNames": ["webpack-cli"],
+      "allowedVersions": "2.0.9"
+    },
+    {
+      "packageNames": ["webpack-dev-server"],
+      "allowedVersions": "2.11.2"
+    },
+    {
+      "packageNames": ["ts-loader"],
+      "allowedVersions": "3.5.0"
     }
   ]
 }


### PR DESCRIPTION
This ensures that webpack does not get updated to version 4 which will conflict with storybook.