### PR TITLE
DCOS-40355: add hover style for Table rows

### DIFF
--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -7,7 +7,8 @@ import {
   cellCss,
   tableCss,
   rightGrid,
-  hideScrollbarCss
+  hideScrollbarCss,
+  rowHoverCss
 } from "../style";
 
 import { IColumnProps, Column } from "./Column";
@@ -25,6 +26,7 @@ export interface ITableProps {
 
 export interface ITableState {
   isScrolling: boolean;
+  hoveredRowIndex: number;
 }
 
 const ROW_HEIGHT = 35;
@@ -70,7 +72,8 @@ export class Table<T> extends React.PureComponent<ITableProps, ITableState> {
     this.onScroll = this.onScroll.bind(this);
 
     this.state = {
-      isScrolling: false
+      isScrolling: false,
+      hoveredRowIndex: -1
     };
   }
 
@@ -183,8 +186,18 @@ export class Table<T> extends React.PureComponent<ITableProps, ITableState> {
     const className = css(cellCss, {
       ...style
     });
+    const updateHoveredRowIndex = () => {
+      this.setState({ hoveredRowIndex: rowIndex });
+    };
+
     return (
-      <div className={className} key={key}>
+      <div
+        className={cx(className, {
+          [rowHoverCss]: rowIndex === this.state.hoveredRowIndex
+        })}
+        key={key}
+        onMouseOver={updateHoveredRowIndex}
+      >
         {column.props.cellRenderer(data[rowIndex])}
       </div>
     );

--- a/packages/table/style.ts
+++ b/packages/table/style.ts
@@ -2,7 +2,7 @@ import { css } from "emotion";
 import { coreColors, hexToRgbA } from "../shared/styles/color";
 import { coreFonts } from "../shared/styles/typography";
 
-const { black, greyLight } = coreColors();
+const { black, greyLight, greyLightLighten5 } = coreColors();
 const { fontFamilySansSerif } = coreFonts();
 
 export const headerCss = css`
@@ -39,4 +39,10 @@ export const hideScrollbarCss = css`
   ::-webkit-scrollbar {
     display: none;
   }
+`;
+
+export const rowHoverCss = css`
+  background-color: ${greyLightLighten5};
+  mix-blend-mode: multiply;
+  will-change: left;
 `;


### PR DESCRIPTION
Before:
![rowhover_before](https://user-images.githubusercontent.com/2313998/44344562-0656cb80-a45f-11e8-9021-d447f2477be2.gif)

After (the hover shadow is _very_ hard to see in after the uploaded gif has been compressed, but it's there):
![rowhover_after](https://user-images.githubusercontent.com/2313998/44344574-0bb41600-a45f-11e8-8c58-fea8f93d1cbc.gif)
