### PR TITLE
DCOS-41098: ToggleContent no toggle when text highlighted

### DIFF
--- a/packages/toggleContent/components/toggleContent.tsx
+++ b/packages/toggleContent/components/toggleContent.tsx
@@ -30,9 +30,11 @@ export class ToggleContent extends React.PureComponent<
   }
 
   public handleClick(): void {
-    this.setState({
-      isOn: !this.state.isOn
-    });
+    if (!window.getSelection().toString()) {
+      this.setState({
+        isOn: !this.state.isOn
+      });
+    }
   }
 
   public render() {
@@ -45,7 +47,7 @@ export class ToggleContent extends React.PureComponent<
 
     return (
       <Clickable tabIndex={tabIndex} action={this.handleClick}>
-        <div className={style}>{content}</div>
+        <span className={style}>{content}</span>
       </Clickable>
     );
   }

--- a/packages/toggleContent/tests/__snapshots__/toggleContent.test.tsx.snap
+++ b/packages/toggleContent/tests/__snapshots__/toggleContent.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`ToggleContent renders a div wrapping the content passed as props 1`] = 
   outline: 0;
 }
 
-<div
+<span
   class="emotion-0"
   role="button"
   tabindex="0"
 >
   Hello
-</div>
+</span>
 `;

--- a/packages/toggleContent/tests/toggleContent.test.tsx
+++ b/packages/toggleContent/tests/toggleContent.test.tsx
@@ -12,6 +12,14 @@ const primary = () => <div>primary</div>;
 const secondary = () => <div>secondary</div>;
 
 describe("ToggleContent", () => {
+  beforeEach(() => {
+    const mock = jest.fn();
+    mock.mockReturnValue({
+      toString: jest.fn()
+    });
+    window.getSelection = mock;
+  });
+
   it("renders a div wrapping the content passed as props", () => {
     expect(
       toJson(


### PR DESCRIPTION
The click event was completing when a user highlighted text and released the click

Before:
![before](https://cl.ly/e7e813eb9e46/Screen%2520Recording%25202018-08-29%2520at%252011.18%2520AM.gif)

After:
![after](https://cl.ly/9848ebeb8452/Screen%2520Recording%25202018-08-29%2520at%252011.20%2520AM.gif)