### PR TITLE
DCOS-41116: add dashed underline on ToggleContent text

### DIFF
--- a/packages/toggleContent/style.ts
+++ b/packages/toggleContent/style.ts
@@ -1,5 +1,7 @@
 import { css } from "emotion";
 
 export const style = css`
+  border-bottom: 1px dashed;
   cursor: pointer;
+  padding-bottom: 1px;
 `;

--- a/packages/toggleContent/tests/__snapshots__/toggleContent.test.tsx.snap
+++ b/packages/toggleContent/tests/__snapshots__/toggleContent.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`ToggleContent renders a div wrapping the content passed as props 1`] = `
 .emotion-0 {
+  border-bottom: 1px dashed;
   cursor: pointer;
+  padding-bottom: 1px;
 }
 
 .emotion-0:focus {


### PR DESCRIPTION
Before:
<img width="47" alt="screen shot 2018-08-29 at 3 44 31 pm" src="https://user-images.githubusercontent.com/2313998/44811452-bab0ca00-aba2-11e8-85c0-ab7fc09893c1.png">

After:
<img width="53" alt="screen shot 2018-08-29 at 3 44 11 pm" src="https://user-images.githubusercontent.com/2313998/44811462-bedce780-aba2-11e8-8158-64aa924fac20.png">