### PR TITLE
DCOS-39076: export SortableHeaderCell

### DIFF
--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,6 +1,14 @@
 import { injectGlobalCss } from "./shared/styles/global";
 export { Badge, BadgeButton } from "./badge";
-export { Column, Table, Cell, TextCell, HeaderCell, NumberCell } from "./table";
+export {
+  Column,
+  Table,
+  Cell,
+  TextCell,
+  HeaderCell,
+  SortableHeaderCell,
+  NumberCell
+} from "./table";
 export { ToggleContent } from "./toggleContent";
 
 injectGlobalCss();


### PR DESCRIPTION
In the intial PR (https://github.com/dcos-labs/ui-kit/pull/219) to resolve DCOS-39076, I forgot to export SortableHeaderCell from the packages index.

If this PR needs a separate JIRA ticket, I can close this and re-open with a new issue number