### PR TITLE
chore(deps): update dependency tslint-plugin-prettier to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8524,13 +8524,13 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
-      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
+      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
       },
       "dependencies": {
         "jest-docblock": {
@@ -9328,12 +9328,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -9348,17 +9350,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9475,7 +9480,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9487,6 +9493,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -9501,6 +9508,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -9508,12 +9516,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1",
             "yallist": "3.0.2"
@@ -9532,6 +9542,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9612,7 +9623,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9624,6 +9636,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -9745,6 +9758,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -23500,13 +23514,13 @@
       }
     },
     "tslint-plugin-prettier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
-      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.0.tgz",
+      "integrity": "sha512-nA8yM+1tS9dylirSajTxxFV6jCQrIMQ0Ykl//jjRgqmwwmGp3hqodG+rtr16S/OUwyQBfoFScFDK7nuHYPd4Gw==",
       "dev": true,
       "requires": {
-        "eslint-plugin-prettier": "2.6.0",
-        "tslib": "1.9.3"
+        "eslint-plugin-prettier": "^2.2.0",
+        "tslib": "^1.7.1"
       }
     },
     "tslint-react": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "tslint": "5.11.0",
     "tslint-config-prettier": "1.15.0",
     "tslint-eslint-rules": "5.4.0",
-    "tslint-plugin-prettier": "1.3.0",
+    "tslint-plugin-prettier": "2.0.0",
     "tslint-react": "3.6.0",
     "typescript": "3.0.3",
     "webpack": "3.11.0",


### PR DESCRIPTION
<p>This Pull Request updates devDependency <code>tslint-plugin-prettier</code> (<a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier">source</a>) from <code>v1.3.0</code> to <code>v2.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v200httpsgithubcomikatyangtslint-plugin-prettierblobmasterchangelogmd8203200httpsgithubcomikatyangtslint-plugin-prettiercomparev130v200-2018-09-16"><a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/blob/master/CHANGELOG.md#&#8203;200httpsgithubcomikatyangtslint-plugin-prettiercomparev130v200-2018-09-16"><code>v2.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/compare/v1.3.0…v2.0.0">Compare Source</a></p>
<h5 id="bug-fixes">Bug Fixes</h5>
<ul>
<li>specify config file correctly (<a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/commit/a46bb9f">a46bb9f</a>)</li>
</ul>
<h5 id="features">Features</h5>
<ul>
<li>support .editorconfig (<a href="https://renovatebot.com/gh/ikatyang/tslint-plugin-prettier/commit/5afdfbc">5afdfbc</a>)</li>
</ul>
<h5 id="breaking-changes">BREAKING CHANGES</h5>
<ul>
<li>require <code>prettier@^1.9.0</code></li>
<li>load <code>.editorconfig</code> by default</li>
<li>specify config file via filepath instead of directory</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>