### PR TITLE
DCOS-41268: port table docs from google docs

### DIFF
--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -1,19 +1,59 @@
-# Table
+# Tables
 
 ## Introduction
 
-The Table component gets used to render Tables with the help of a virtual list. It exposes two properties one of them is the `data` which awaits an Array.
+Use tables to display information in a way that’s easy to scan, so that user can look for patterns and insights. Users will use tables to troubleshoot, manage and monitor their systems. 
 
-The other one is `children` which has to be either an Array of Columns or one Column.
+## Types of Tables
 
-# Column
+There are two types of tables used in DC/OS today. 
 
-## Introduction
+1. Collection Tables: Collection tables are generally used when information needs to be displayed in more than two columns.
+2. Detail Tables: Detail tables generally used when information can be displayed in two columns.
 
-Column component exposes 3 Properties and does not expect to have children. The Column component ensures that the right properties are available.
+## Width
 
-`header` is providing the content for the header.
+Collection tables should span the full width of the screen. In cases where there are too few columns to span the whole screen, the table should still span the whole screen. 
 
-`cellRenderer` is expecting a function which will get called for each cell and the return value should be a React element.
+Detail tables shouldn’t span the full width of the screen.
 
-`width` expects a function. The function should return of a column width in pixels.
+## Column and Rows
+
+Organize columns and rows based on the needs of the users. For collection tables, order the columns with most important columns starting at the left. For detail tables, order the columns with the most important columns starting at the top. 
+
+1. Primary column: The primary is always the first column in the table. This column should be the identifying attribute of your data set. 
+
+2. Long text: Truncate long text to fit in the row and add an ellipses with a tooltip on hover to show the full text. 
+
+3. Table Headings: These should describe the content in the column. Try to stick to one word. Table heading should be in sentence case. 
+
+4. Empty values: Empty values should be expressed in the table as “N/A”. 
+
+5. Maximum column width: To handle columns that tend to have long text, the maximum column width allowed is 250 pixels.
+
+6. Row hover state: On mouse over of a row on the table, the row should be highlighted to help the user focus in on the row details and match data they are seeing within that row. 
+
+## Column Alignment
+
+For Collection tables, content should be left aligned except when using a different alignment helps with comprehension. For example,numeric data is easier to read when it’s right aligned. Column headers should match the content alignment. 
+
+For Detail tables, content should always be left aligned no matter if it’s numeric or string. 
+
+## Sorting
+
+By default one column is sorted in each table in ascending or descending order. It’s up to the design lead to decide which column and what order. Columns can sort both A-Z and 0-100. 
+
+* Upward chevron is for ascending the items in the column. Ascending means smallest to largest, increasing in size.
+* Downward chevron is for descending the items in the column. Descending means largest to smallest, decreasing in size.
+* Chevron should always be placed 6px to the right of the column header and centered with the column header.
+* If the user selects another column to be sorted, the new column will by default sort in ascending direction. Once the new column is selected, the user can then change the sort type to descending. 
+
+## Horizontal Scroll
+
+Horizontal scroll should only be activated when there are too many columns to fit the screen size. Keep the primary column, row actions, and column customization locked in position when horizontal scroll is activated.
+
+## Primary Column 
+
+In the collection table, the primary column is the first column (on the left) in the table. This column is the identifying attribute on the table. In most cases, the primary column has a hyperlink to drill down into more details. 
+
+In the details table, the primary column is also the first column (on the left) in the two column table. This column represents all the unique key attributes on the table. The primary column in this case is not hyperlinked. 

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -29,9 +29,7 @@ Organize columns and rows based on the needs of the users. For collection tables
 
 4. Empty values: Empty values should be expressed in the table as “N/A”. 
 
-5. Maximum column width: To handle columns that tend to have long text, the maximum column width allowed is 250 pixels.
-
-6. Row hover state: On mouse over of a row on the table, the row should be highlighted to help the user focus in on the row details and match data they are seeing within that row. 
+5. Row hover state: On mouse over of a row on the table, the row should be highlighted to help the user focus in on the row details and match data they are seeing within that row. 
 
 ## Column Alignment
 
@@ -45,7 +43,6 @@ By default one column is sorted in each table in ascending or descending order. 
 
 * Upward chevron is for ascending the items in the column. Ascending means smallest to largest, increasing in size.
 * Downward chevron is for descending the items in the column. Descending means largest to smallest, decreasing in size.
-* Chevron should always be placed 6px to the right of the column header and centered with the column header.
 * If the user selects another column to be sorted, the new column will by default sort in ascending direction. Once the new column is selected, the user can then change the sort type to descending. 
 
 ## Horizontal Scroll

--- a/packages/table/components/Column.tsx
+++ b/packages/table/components/Column.tsx
@@ -15,6 +15,9 @@ export interface ColumnProps {
    * cellRenderer is the function which is creating the cell contents for this column.
    */
   cellRenderer: (data: any, width: number) => React.ReactNode;
+  /**
+   * width should return a column width in pixels.
+   */
   width: (args: WidthArgs) => number;
 }
 

--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -19,6 +19,9 @@ export interface TableProps {
    * Contains all data represented in the table.
    */
   data: any[];
+  /**
+   * Has to be either an Array of Columns or one Column.
+   */
   children:
     | Array<React.ReactElement<ColumnProps>>
     | React.ReactElement<ColumnProps>;

--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -48,7 +48,7 @@ const empty = () => <Cell>empty</Cell>;
 
 storiesOf("Table", module)
   .addDecorator(withReadme([readme]))
-  .addWithInfo("default", () => (
+  .addWithInfo("collection table", () => (
     <div
       style={{
         height: "175px",


### PR DESCRIPTION
Only moved over things that are currently in the ui-kit. Will port over more once we have more table components built out in the ui-kit. 

[Design System Docs](https://docs.google.com/document/d/1HiT0YTZe930DdSukKapahfzMG9Dc-pEKIjFUBuVeyw0/edit#heading=h.earj3o607tlu)

Closes DCOS-41268