### PR TITLE
Enable renovate autoMerge for dev deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "devDependencies": {
+    "automerge": true
+  },
   "packageRules": [
     {
       "packagePatterns": ["*"],


### PR DESCRIPTION
Expanding the practice of auto merging dev deps updates in `dcos-labs` repos.