### PR TITLE
DCOS-40966: added components to handle toast notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -513,6 +513,11 @@
         }
       }
     },
+    "@popmotion/easing": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.1.tgz",
+      "integrity": "sha512-NbIEz9mZAem0F0sjg2v57LbU9Y2Xc50QEX434jYrwEQzXJuJipyUV48Qz4hjHqbB/8xiUj0JMQfRvP8K9nUbxg=="
+    },
     "@semantic-release/commit-analyzer": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.0.1.tgz",
@@ -1151,6 +1156,11 @@
         "@types/react": "16.4.13"
       }
     },
+    "@types/invariant": {
+      "version": "2.2.29",
+      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.29.tgz",
+      "integrity": "sha512-lRVw09gOvgviOfeUrKc/pmTiRZ7g7oDOU6OAutyuSHpm1/o2RaBQvRhgK8QEdu+FFuw/wnWb29A/iuxv9i8OpQ=="
+    },
     "@types/jest": {
       "version": "23.3.2",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.2.tgz",
@@ -1166,8 +1176,7 @@
     "@types/node": {
       "version": "10.10.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.3.tgz",
-      "integrity": "sha512-dWk7F3b0m6uDLHero7tsnpAi9r2RGPQHGbb0/VCv7DPJRMFtk3RonY1/29vfJKnheRMBa7+uF+vunlg/mBGlxg==",
-      "dev": true
+      "integrity": "sha512-dWk7F3b0m6uDLHero7tsnpAi9r2RGPQHGbb0/VCv7DPJRMFtk3RonY1/29vfJKnheRMBa7+uF+vunlg/mBGlxg=="
     },
     "@types/prop-types": {
       "version": "15.5.5",
@@ -6656,6 +6665,14 @@
         "map-cache": "0.2.2"
       }
     },
+    "framesync": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.1.tgz",
+      "integrity": "sha512-7dF3SXz/xMdwSHFHgj8PV2dAUCFclXWhasAb06rFvAM2pX24m9eDs6X+ikK0kx92w/uIljUi0sBINwcbl0rT2Q==",
+      "requires": {
+        "hey-listen": "1.0.5"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -7903,6 +7920,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "hey-listen": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.5.tgz",
+      "integrity": "sha512-O2iCNxBBGb4hOxL9tUdnoPwDYmZhQ29t5xKV74BVZNdvwCDXCpVYTJ4yoaibc1V0I8Yw3K3nwmvDpoyjnCqUaw=="
     },
     "highlight.js": {
       "version": "9.12.0",
@@ -16263,6 +16285,32 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
+    "popmotion": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-8.4.1.tgz",
+      "integrity": "sha512-j25mAl6QlGN/ErGR7dBCCvxIKQ5pSxqEwieeqvacC3ZByXy98+UnOj+vaeVlZcr2Bjl5q03xHe1gKyr4ursL1A==",
+      "requires": {
+        "@popmotion/easing": "1.0.1",
+        "framesync": "4.0.1",
+        "hey-listen": "1.0.5",
+        "style-value-types": "3.0.7",
+        "stylefire": "2.1.0",
+        "tslib": "1.9.3"
+      }
+    },
+    "popmotion-pose": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/popmotion-pose/-/popmotion-pose-3.3.1.tgz",
+      "integrity": "sha512-F4ApzOsdvXT9Ch0x8rui1sQX8+oIyMDXvKRLaNfmi77NJF4mywNmAOn5A27oOFgR+gHt7Xy802WWALSMqmoi1Q==",
+      "requires": {
+        "@popmotion/easing": "1.0.1",
+        "hey-listen": "1.0.5",
+        "popmotion": "8.4.1",
+        "pose-core": "2.0.0",
+        "style-value-types": "3.0.7",
+        "tslib": "1.9.3"
+      }
+    },
     "portfinder": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
@@ -16280,6 +16328,17 @@
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
+      }
+    },
+    "pose-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pose-core/-/pose-core-2.0.0.tgz",
+      "integrity": "sha512-RJcDqYADmuXKQ+uP59oh+EIeRhsuAkKLeVrT25ak57q8TXkEKh8pjL99AHNQLktLUI97erpdNnOp+McK3d/CUQ==",
+      "requires": {
+        "@types/invariant": "2.2.29",
+        "@types/node": "10.10.3",
+        "hey-listen": "1.0.5",
+        "tslib": "1.9.3"
       }
     },
     "posix-character-classes": {
@@ -18070,8 +18129,7 @@
     "react-is": {
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
-      "dev": true
+      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -18095,6 +18153,18 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
       "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==",
       "dev": true
+    },
+    "react-pose": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/react-pose/-/react-pose-3.3.6.tgz",
+      "integrity": "sha512-guFH+Tv8fMIPk0hR4VQvZrBNM9k+73BWq+RqpNWYD8V5usL6UClKNEkXSmY5N1BUwfO6eyJaVUkodCrIhMx6UQ==",
+      "requires": {
+        "@emotion/is-prop-valid": "0.6.8",
+        "hey-listen": "1.0.5",
+        "popmotion-pose": "3.3.1",
+        "react-is": "16.5.2",
+        "tslib": "1.9.3"
+      }
     },
     "react-split-pane": {
       "version": "0.1.84",
@@ -19806,6 +19876,22 @@
         "schema-utils": "0.4.7"
       }
     },
+    "style-value-types": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.0.7.tgz",
+      "integrity": "sha512-7vzeicDiPNnJjvTYfJbQhZ7P3OCkXfvkJOJQ+ifFnXNTA/7KBxMZacHLvlRjM5/TtXbVdrZE6u+2nzSUSPrbSQ=="
+    },
+    "stylefire": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-2.1.0.tgz",
+      "integrity": "sha512-DeO5v4w4xwvSoatWkfD++tpPqoolSxZtmrL7mFwxHp70AXJuzvwDVlTkpaXwPXvfevXwiGXA224gOnIk2pLiRA==",
+      "requires": {
+        "framesync": "4.0.1",
+        "hey-listen": "1.0.5",
+        "style-value-types": "3.0.7",
+        "tslib": "1.9.3"
+      }
+    },
     "stylis": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
@@ -20403,8 +20489,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "16.5.2",
     "react-dom": "16.5.2",
     "react-emotion": "9.2.10",
+    "react-pose": "3.3.6",
     "react-virtualized": "9.20.1",
     "semantic-release": "^15.9.6"
   },

--- a/packages/infobox/components/InfoBox.tsx
+++ b/packages/infobox/components/InfoBox.tsx
@@ -36,7 +36,7 @@ const CloseIcon = () => (
   <svg width="16" height="16" viewBox="0 0 16 16">
     <path
       d="M8 9.237L4.119 13.12 2.88 11.88 6.763 8 2.88 4.119 4.12 2.88 8 6.763l3.881-3.882L13.12 4.12 9.237 8l3.882 3.881-1.238 1.238L8 9.237z"
-      fill-rule="nonzero"
+      fillRule="nonzero"
     />
   </svg>
 );

--- a/packages/infobox/style.ts
+++ b/packages/infobox/style.ts
@@ -2,7 +2,7 @@ import { css } from "emotion";
 import { atMediaUp } from "../shared/styles/breakpoints";
 
 import { coreColors } from "../shared/styles/color";
-import { spacingDefault } from "../shared/styles/spacing";
+import { spacingM } from "../shared/styles/spacing";
 const { greyDark, greyLight } = coreColors();
 
 const layoutBreakpoint = "small";
@@ -29,7 +29,7 @@ export const infoBoxActions = css`
 export const infoBox = (appearance, hasActions) =>
   css`
     ${infoBoxAppearances[appearance]};
-    grid-gap: ${spacingDefault};
+    grid-gap: ${spacingM};
     grid-template-columns: 1fr auto;
     ${hasActions &&
       atMediaUp[layoutBreakpoint](css`

--- a/packages/shared/styles/breakpoints.ts
+++ b/packages/shared/styles/breakpoints.ts
@@ -3,13 +3,6 @@
 //
 import { css } from "emotion";
 
-// interface Breakpoints {
-//   small: string;
-//   medium: string;
-//   large: string;
-//   jumbo: string;
-// }
-
 export const breakpoints = {
   small: "600px",
   medium: "900px",

--- a/packages/shared/styles/global.ts
+++ b/packages/shared/styles/global.ts
@@ -8,6 +8,21 @@ export const injectGlobalCss = () => {
       font-family: ${fontFamilySansSerif};
     }
 
+    h1, h2, h3, h4, h5, h6 {
+      font-weight: normal;
+      margin: 0;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    ul, ol {
+      list-style: none;
+      margin-left: 0;
+      padding-left: 0;
+    }
+
     .ReactVirtualized__Grid {
       outline: none;
     }

--- a/packages/shared/styles/spacing.ts
+++ b/packages/shared/styles/spacing.ts
@@ -1,3 +1,9 @@
 // TODO: this should be removed when we create a
 // proper design token distribution
-export const spacingDefault = "16px";
+export const spacingXXS = "8px";
+export const spacingXS = "8px";
+export const spacingS = "12px";
+export const spacingM = "16px";
+export const spacingL = "24px";
+export const spacingXL = "32px";
+export const spacingXXL = "48px";

--- a/packages/shared/styles/styleUtils/index.ts
+++ b/packages/shared/styles/styleUtils/index.ts
@@ -1,4 +1,7 @@
+export { flex, flexItem } from "./layout/flexbox";
 export { textTruncate } from "./typography/textTruncate";
-export { textSize } from "./typography/textSize";
+export { darkMode } from "./typography/color";
 export { display } from "./modifiers/display";
+export { margin, marginAt } from "./modifiers/margin";
 export { padding } from "./modifiers/padding";
+export { textSize } from "./typography/textSize";

--- a/packages/shared/styles/styleUtils/layout/flexbox.ts
+++ b/packages/shared/styles/styleUtils/layout/flexbox.ts
@@ -1,0 +1,53 @@
+import { css } from "react-emotion";
+import { spacingM } from "../../spacing";
+
+interface FlexboxProperties {
+  align?: "flex" | "center" | "flex-start" | "flex-end";
+  justify?: "flex" | "center" | "flex-start" | "flex-end";
+  direction?: "row" | "column" | "row-reverse" | "column-reverse";
+  wrap?: "wrap" | "nowrap";
+}
+
+const flexStrategies = {
+  grow: css`
+    flex-basis: 0;
+    flex-grow: 1;
+    min-width: 0;
+    width: auto;
+  `,
+  shrink: css`
+    flex-basis: auto;
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: initial;
+  `
+};
+
+export const flex = (
+  flexProps: FlexboxProperties = {
+    align: "flex",
+    direction: "row",
+    wrap: "nowrap",
+    justify: "flex-start"
+  }
+) => {
+  return css`
+    align-items: ${flexProps.align};
+    box-sizing: border-box;
+    display: flex;
+    justify-content: ${flexProps.justify};
+    flex-direction: ${flexProps.direction};
+    flex-wrap: ${flexProps.wrap};
+  `;
+};
+
+export const flexItem = (flexStrategy: "grow" | "shrink") =>
+  css`
+    ${flexStrategies[flexStrategy]};
+    box-sizing: border-box;
+    padding-left: ${spacingM};
+
+    &:first-child {
+      padding-left: 0;
+    }
+  `;

--- a/packages/shared/styles/styleUtils/modifiers/margin.ts
+++ b/packages/shared/styles/styleUtils/modifiers/margin.ts
@@ -1,0 +1,22 @@
+import { css } from "react-emotion";
+import { boxSpacing, BoxSides, SpaceSizes } from "./modifierUtils";
+import { atMediaUp, breakpoints } from "../../breakpoints";
+
+export const margin = (side: BoxSides, spaceSize?: SpaceSizes) => {
+  return css`
+    ${boxSpacing("margin", side, spaceSize)};
+  `;
+};
+
+// TODO: write better types
+export const marginAt = Object.keys(breakpoints).reduce(
+  (acc: any, curr: string) => {
+    acc[curr] = (side: BoxSides, spaceSize: SpaceSizes) => css`
+      ${atMediaUp[curr](css`
+        ${margin(side, spaceSize)};
+      `)};
+    `;
+    return acc;
+  },
+  {}
+);

--- a/packages/shared/styles/styleUtils/modifiers/modifierUtils.ts
+++ b/packages/shared/styles/styleUtils/modifiers/modifierUtils.ts
@@ -1,11 +1,36 @@
-import { spacingDefault } from "../../spacing";
+import {
+  spacingXXS,
+  spacingXS,
+  spacingS,
+  spacingM,
+  spacingL,
+  spacingXL,
+  spacingXXL
+} from "../../spacing";
 
 export type BoxSides = "all" | "top" | "right" | "bottom" | "left";
+export type SpaceSizes = "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl";
 
-export const boxSpacing = (property: "margin" | "padding", side: BoxSides) => {
+const spaceSizes = {
+  xxs: spacingXXS,
+  xs: spacingXS,
+  s: spacingS,
+  m: spacingM,
+  l: spacingL,
+  xl: spacingXL,
+  xxl: spacingXXL
+};
+
+export const boxSpacing = (
+  property: "margin" | "padding",
+  side: BoxSides,
+  spaceSize?: SpaceSizes
+) => {
+  const size = spaceSize || "m";
+
   if (side === "all") {
-    return `${property}: ${spacingDefault} !important;`;
+    return `${property}: ${spaceSizes[size]} !important;`;
   } else {
-    return `${property}-${side}: ${spacingDefault} !important;`;
+    return `${property}-${side}: ${spaceSizes[size]} !important;`;
   }
 };

--- a/packages/shared/styles/styleUtils/modifiers/padding.ts
+++ b/packages/shared/styles/styleUtils/modifiers/padding.ts
@@ -1,8 +1,8 @@
 import { css } from "react-emotion";
-import { boxSpacing, BoxSides } from "./modifierUtils";
+import { boxSpacing, BoxSides, SpaceSizes } from "./modifierUtils";
 
-export const padding = (side: BoxSides) => {
+export const padding = (side: BoxSides, spaceSize?: SpaceSizes) => {
   return css`
-    ${boxSpacing("padding", side)};
+    ${boxSpacing("padding", side, spaceSize)};
   `;
 };

--- a/packages/shared/styles/styleUtils/typography/color.ts
+++ b/packages/shared/styles/styleUtils/typography/color.ts
@@ -1,0 +1,22 @@
+import { css } from "emotion";
+import { coreColors } from "../../color";
+const { white } = coreColors();
+
+// TODO: when we do the design tokens lib,
+// generate a type for _only_ our colors
+// instead of just accepting any string
+export const tintText = (color: string) => css`
+  color: ${color};
+`;
+
+export const tintSVG = (color: string) => css`
+  &,
+  svg {
+    fill: ${color};
+  }
+`;
+
+export const darkMode = css`
+  ${tintText(white)};
+  ${tintSVG(white)};
+`;

--- a/packages/toaster/README.md
+++ b/packages/toaster/README.md
@@ -1,0 +1,3 @@
+# Toaster Name
+
+Toaster documentation

--- a/packages/toaster/components/Toast.tsx
+++ b/packages/toaster/components/Toast.tsx
@@ -1,0 +1,136 @@
+import * as React from "react";
+import { cx } from "emotion";
+import {
+  toast,
+  toastActions,
+  toastDesc,
+  toastTitle,
+  toastDismiss
+} from "../style";
+import {
+  darkMode,
+  display,
+  flex,
+  flexItem,
+  margin,
+  padding
+} from "../../shared/styles/styleUtils";
+import Clickable from "../../clickable/components/clickable";
+
+export type ToastId = React.ReactText | undefined;
+
+export interface ToastProps {
+  title: React.ReactElement<HTMLElement> | string;
+  description?: React.ReactElement<HTMLElement> | string;
+  id: ToastId;
+  appearance?: "default" | "success" | "warning" | "danger";
+  autodismiss?: boolean;
+  onDismiss?: (event?: React.SyntheticEvent<HTMLElement>) => void;
+  dismissToast?: (dismissedToastId: ToastId) => void;
+  primaryAction?: React.ReactElement<HTMLElement>;
+  secondaryAction?: React.ReactElement<HTMLElement>;
+}
+
+// TODO: once we have an icon library, use that instead
+const CloseIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16">
+    <path
+      d="M8 9.237L4.119 13.12 2.88 11.88 6.763 8 2.88 4.119 4.12 2.88 8 6.763l3.881-3.882L13.12 4.12 9.237 8l3.882 3.881-1.238 1.238L8 9.237z"
+      fillRule="nonzero"
+    />
+  </svg>
+);
+
+class Toast extends React.PureComponent<ToastProps, {}> {
+  public static defaultProps: Partial<ToastProps> = {
+    appearance: "default",
+    autodismiss: false
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.handleDismiss = this.handleDismiss.bind(this);
+  }
+
+  public render() {
+    const {
+      title,
+      description,
+      appearance,
+      primaryAction,
+      secondaryAction
+    } = this.props;
+    const isUrgentMessage = appearance === "danger" || appearance === "warning";
+
+    return (
+      <div
+        className={cx(
+          toast,
+          darkMode,
+          margin("bottom", "xxs"),
+          padding("top", "xs"),
+          padding("right", "xs"),
+          padding("left", "xs"),
+          display("grid")
+        )}
+        role={isUrgentMessage ? "alert" : "log"}
+        aria-relevant="all"
+        aria-atomic="true"
+      >
+        <div
+          className={cx(
+            toastTitle,
+            flex({ align: "center" }),
+            padding("bottom", "xs")
+          )}
+        >
+          {/* TODO: when we do the variants, an icon will always appear
+              based on appearance prop, and "default" isn't one of them */}
+          {appearance !== "default" && (
+            <div className={flexItem("shrink")}>
+              <span>☃</span>
+            </div>
+          )}
+          <div className={flexItem("grow")}>{title}</div>
+        </div>
+        {description && (
+          <div className={cx(toastDesc, padding("bottom", "xs"))}>
+            {description}
+          </div>
+        )}
+        {(primaryAction || secondaryAction) && (
+          <div
+            className={cx(
+              toastActions,
+              flex({ direction: "row-reverse" }),
+              padding("bottom", "xs")
+            )}
+          >
+            {primaryAction && (
+              <span className={padding("left")}>{primaryAction}</span>
+            )}
+            {secondaryAction && <span>{secondaryAction}</span>}
+          </div>
+        )}
+        <Clickable tabIndex={0} action={this.handleDismiss}>
+          <span className={toastDismiss}>
+            <CloseIcon />
+          </span>
+        </Clickable>
+      </div>
+    );
+  }
+
+  private handleDismiss(e) {
+    const { dismissToast, onDismiss, id } = this.props;
+    if (dismissToast) {
+      dismissToast(id);
+    }
+    if (onDismiss) {
+      onDismiss(e);
+    }
+  }
+}
+
+export default Toast;

--- a/packages/toaster/components/Toaster.tsx
+++ b/packages/toaster/components/Toaster.tsx
@@ -1,0 +1,149 @@
+import * as React from "react";
+import { cx } from "emotion";
+import posed, { PoseGroup } from "react-pose";
+import { ToastProps, ToastId } from "./Toast";
+import { toaster } from "../style";
+import { margin, marginAt } from "../../shared/styles/styleUtils";
+
+export interface ToasterProps {
+  children?: Array<React.ReactElement<ToastProps>>;
+}
+
+export interface ToasterState {
+  toasts?: Array<React.ReactElement<ToastProps>>;
+}
+
+export const DELAY_TIME = 3000;
+const MARGINAL_DELAY = 1000;
+
+const ToastWrapper = posed.li({
+  preEnter: {
+    y: 20
+  },
+  enter: {
+    opacity: 1,
+    y: 0,
+    transition: { easing: "easeInOut" }
+  },
+  exit: {
+    opacity: 0,
+    transition: { easing: "easeInOut" }
+  }
+});
+
+class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
+  // TODO: write better type for timeouts
+  public timeouts: any[] = [];
+
+  constructor(props) {
+    super(props);
+
+    this.cloneToast = this.cloneToast.bind(this);
+    this.dismissToast = this.dismissToast.bind(this);
+    this.clearTimeouts = this.clearTimeouts.bind(this);
+    this.restartTimeouts = this.restartTimeouts.bind(this);
+    this.setTimer = this.setTimer.bind(this);
+
+    const toastChildren =
+      this.props.children && this.props.children.map(this.cloneToast);
+
+    this.state = {
+      toasts: toastChildren
+    };
+  }
+
+  public componentWillUnmount() {
+    this.clearTimeouts();
+  }
+
+  public componentDidMount() {
+    this.restartTimeouts();
+  }
+
+  public componentWillReceiveProps(nextProps: ToasterProps) {
+    const currentToasts = this.state.toasts || [];
+    const childIds =
+      nextProps.children && nextProps.children.map(toast => toast.props.id);
+    const currentIds = currentToasts.map(toast => toast.props.id);
+
+    if (
+      (childIds && !currentIds.every(e => childIds.includes(e))) ||
+      !currentIds.length
+    ) {
+      this.setState(
+        () => ({
+          toasts:
+            currentToasts &&
+            currentToasts.concat(nextProps.children || []).map(this.cloneToast)
+        }),
+        () => {
+          if (this.state.toasts) {
+            this.state.toasts
+              .filter(t => t.props.autodismiss)
+              .map(this.setTimer);
+          }
+        }
+      );
+    }
+  }
+
+  public render() {
+    const toastsToRender = this.state.toasts || [];
+
+    return (
+      <div className={cx(toaster, margin("all"), marginAt.medium("all", "l"))}>
+        <ol
+          onMouseEnter={this.clearTimeouts}
+          onMouseLeave={this.restartTimeouts}
+          aria-live="assertive"
+        >
+          <PoseGroup preEnterPose="preEnter">
+            {toastsToRender.map((toast, i) => (
+              <ToastWrapper key={`toastWrapper-${i}`}>{toast}</ToastWrapper>
+            ))}
+          </PoseGroup>
+        </ol>
+      </div>
+    );
+  }
+
+  public dismissToast(dismissedToastId: ToastId = "") {
+    const currentToasts = this.state.toasts || [];
+    this.setState({
+      toasts: currentToasts.filter(toast => dismissedToastId !== toast.props.id)
+    });
+  }
+
+  public cloneToast(toast: React.ReactElement<ToastProps>, i: number) {
+    const toastProps = {
+      key: i,
+      id: toast.props.id,
+      dismissToast: this.dismissToast,
+      autodismiss: toast.props.autodismiss || false
+    };
+    return React.cloneElement(toast, toastProps);
+  }
+
+  public setTimer(toast: React.ReactElement<ToastProps>) {
+    const toastKey = toast.key as number;
+    if (toast.props.autodismiss) {
+      this.timeouts.push(
+        setTimeout(() => {
+          this.dismissToast(toast.props.id);
+        }, DELAY_TIME + MARGINAL_DELAY * toastKey)
+      );
+    }
+  }
+
+  public restartTimeouts() {
+    if (this.state.toasts) {
+      this.state.toasts.map(this.setTimer);
+    }
+  }
+
+  public clearTimeouts() {
+    this.timeouts.forEach(clearTimeout);
+  }
+}
+
+export default Toaster;

--- a/packages/toaster/index.ts
+++ b/packages/toaster/index.ts
@@ -1,0 +1,2 @@
+export { default as Toaster } from "./components/Toaster";
+export { default as Toast } from "./components/Toast";

--- a/packages/toaster/stories/Toaster.stories.tsx
+++ b/packages/toaster/stories/Toaster.stories.tsx
@@ -1,0 +1,165 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { action } from "@storybook/addon-actions";
+import { Toaster, Toast } from "..";
+import { ToastProps } from "../components/Toast";
+import { typeSizes } from "../../shared/styles/typography";
+import { coreColors } from "../../shared/styles/color";
+const { purple } = coreColors();
+
+const readme = require("../README.md");
+
+let addedToastId = 0;
+const toastTitle = "I have a message for you";
+const fakeButtonStyles = {
+  ["-webkit-appearance"]: "none",
+  ["-moz-appearance"]: "none",
+  background: "transparent",
+  border: "none",
+  color: purple,
+  cursor: "pointer",
+  fontSize: typeSizes.small,
+  padding: 0
+};
+
+export interface ToastContainerProps {
+  children: Array<React.ReactElement<ToastProps>>;
+}
+
+export interface ToastContainerState {
+  toasts: Array<React.ReactElement<ToastProps>>;
+}
+
+class ToasterContainer extends React.PureComponent<
+  ToastContainerProps,
+  ToastContainerState
+> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      toasts: this.props.children
+    };
+
+    this.addToast = this.addToast.bind(this);
+  }
+
+  addToast(toast: Array<React.ReactElement<ToastProps>>) {
+    this.setState({
+      toasts: toast
+    });
+  }
+
+  render() {
+    const handleToastAdd = () => {
+      const newToastId = addedToastId++;
+      const newToast = [
+        // tslint:disable:jsx-wrap-multiline
+        <Toast
+          autodismiss={true}
+          id={`toast-${newToastId + 1}`}
+          key={newToastId + 1}
+          title={`New message ${newToastId + 1}`}
+        />
+        // tslint:enable
+      ];
+      this.addToast(newToast);
+    };
+
+    return (
+      <div>
+        <Toaster>{this.state.toasts}</Toaster>
+        <button onClick={handleToastAdd}>Make me toast</button>
+      </div>
+    );
+  }
+}
+
+storiesOf("Toaster", module)
+  .addDecorator(withReadme([readme]))
+  .addWithInfo("default", () => (
+    <Toaster>{[<Toast title={toastTitle} key={0} id="default" />]}</Toaster>
+  ))
+  .addWithInfo("description", () => (
+    <Toaster>
+      {[
+        <Toast
+          title={toastTitle}
+          description="And this is a short description to provide more info about the message"
+          key={0}
+          id="description"
+        />
+      ]}
+    </Toaster>
+  ))
+  .addWithInfo("autodismiss", () => (
+    <ToasterContainer>
+      {[
+        <Toast
+          title="Hover me or I'll disappear"
+          autodismiss={true}
+          key={0}
+          id="autodismiss"
+        />
+      ]}
+    </ToasterContainer>
+  ))
+  .addWithInfo("with dismiss callback", () => (
+    <Toaster>
+      {[
+        <Toast
+          title={toastTitle}
+          key={0}
+          onDismiss={action("The toast has been dismissed")}
+          id="dismissCallback"
+        />
+      ]}
+    </Toaster>
+  ))
+  .addWithInfo("with 1 action", () => (
+    <Toaster>
+      {[
+        <Toast
+          title={toastTitle}
+          key={0}
+          primaryAction={
+            <button
+              onClick={action("primary action clicked")}
+              style={fakeButtonStyles}
+            >
+              primaryAction
+            </button>
+          }
+          id="oneAction"
+        />
+      ]}
+    </Toaster>
+  ))
+  .addWithInfo("with 2 actions", () => (
+    <Toaster>
+      {[
+        <Toast
+          title={toastTitle}
+          key={0}
+          primaryAction={
+            <button
+              onClick={action("primaryAction triggered")}
+              style={fakeButtonStyles}
+            >
+              primaryAction
+            </button>
+          }
+          secondaryAction={
+            <button
+              onClick={action("secondaryAction triggered")}
+              style={fakeButtonStyles}
+            >
+              secondaryAction
+            </button>
+          }
+          id="twoActions"
+        />
+      ]}
+    </Toaster>
+  ));

--- a/packages/toaster/style.ts
+++ b/packages/toaster/style.ts
@@ -1,0 +1,41 @@
+import { css } from "emotion";
+import { atMediaUp } from "../shared/styles/breakpoints";
+import { coreColors } from "../shared/styles/color";
+const { greyDark } = coreColors();
+
+export const toaster = css`
+  max-width: 100%;
+  ${atMediaUp.medium(css`
+    max-width: 20em;
+  `)};
+`;
+
+// TODO: use a design token for border-radius when it exists
+export const toast = css`
+  background-color: ${greyDark};
+  box-sizing: border-box;
+  border-radius: 6px;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    "title dismiss"
+    "desc  desc"
+    "btn   btn";
+  width: 100%;
+`;
+
+export const toastTitle = css`
+  grid-area: title;
+  text-transform: capitalize;
+`;
+
+export const toastDesc = css`
+  grid-area: desc;
+`;
+
+export const toastActions = css`
+  grid-area: btn;
+`;
+
+export const toastDismiss = css`
+  grid-area: dismiss;
+`;

--- a/packages/toaster/tests/Toast.test.tsx
+++ b/packages/toaster/tests/Toast.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import { Toaster, Toast } from "../";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import toJson from "enzyme-to-json";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+describe("Toast", () => {
+  it("renders default", () => {
+    const component = shallow(
+      <Toaster children={[<Toast title="I Am Toast" key={0} id={0} />]} />
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders with description", () => {
+    const component = shallow(
+      <Toaster
+        children={[
+          <Toast title="I Am Toast" description="Description" key={0} id={0} />
+        ]}
+      />
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders with actions", () => {
+    const component = shallow(
+      <Toaster
+        children={[
+          <Toast
+            primaryAction={<button>primaryAction</button>}
+            secondaryAction={<button>secondaryAction</button>}
+            title="I Am Toast"
+            key={0}
+            id={0}
+          />
+        ]}
+      />
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("should call the function in the action when clicked", () => {
+    const action = jest.fn();
+    const component = mount(
+      <Toaster
+        children={[
+          <Toast
+            primaryAction={<button onClick={action}>primaryAction</button>}
+            title="I Am Toast"
+            key={0}
+            id={0}
+          />
+        ]}
+      />
+    );
+    const primaryActionBtn = component.find(`button`);
+
+    expect(action).not.toHaveBeenCalled();
+    primaryActionBtn.simulate("click");
+    expect(action).toHaveBeenCalled();
+  });
+
+  it("calls dismissToast and the onDismiss callback when the dismiss button is clicked", () => {
+    const dismissToastSpy = spyOn(Toaster.prototype, "dismissToast");
+    const onDismiss = jest.fn();
+    const component = mount(
+      <Toaster
+        children={[
+          <Toast onDismiss={onDismiss} title="I Am Toast" key={0} id={0} />
+        ]}
+      />
+    );
+    const dismissBtn = component.find('span[role="button"]');
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(dismissToastSpy).not.toHaveBeenCalled();
+    dismissBtn.simulate("click");
+    expect(onDismiss).toHaveBeenCalled();
+    expect(dismissToastSpy).toHaveBeenCalled();
+  });
+
+  it("should remove the Toast from the Toaster `toasts` state when the dismiss button is clicked", () => {
+    const component = mount(
+      <Toaster children={[<Toast title="I Am Toast" key={0} id={0} />]} />
+    );
+    const instance = component.find(Toaster).instance() as Toaster;
+    const dismissBtn = component.find('span[role="button"]');
+    let toastsState = instance.state.toasts || [];
+
+    expect(toastsState.length).toBe(1);
+
+    dismissBtn.simulate("click");
+    toastsState = instance.state.toasts || [];
+
+    expect(toastsState.length).toBe(0);
+  });
+});

--- a/packages/toaster/tests/Toaster.test.tsx
+++ b/packages/toaster/tests/Toaster.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import { Toaster, Toast } from "../";
+import { DELAY_TIME } from "../components/Toaster";
+
+describe("Toaster", () => {
+  it("stores toasts in state", () => {
+    const component = shallow(
+      <Toaster children={[<Toast id={0} title="I Am Toast" key={0} />]} />
+    );
+    expect(Object.keys(component.state("toasts")).length).toBe(1);
+  });
+
+  it("clears timers on mouseEnter and sets timers on mouseLeave", () => {
+    const clearTimeoutsSpy = spyOn(Toaster.prototype, "clearTimeouts");
+    const setTimerSpy = spyOn(Toaster.prototype, "setTimer");
+    const component = shallow(
+      <Toaster children={[<Toast id={0} title="I Am Toast" key={0} />]} />
+    );
+
+    component.find("ol").simulate("mouseEnter");
+    expect(clearTimeoutsSpy).toHaveBeenCalled();
+    component.find("ol").simulate("mouseLeave");
+    expect(setTimerSpy).toHaveBeenCalled();
+  });
+
+  it("dismisses toasts", () => {
+    const testToast = [<Toast id={0} title="I Am Toast" key={0} />];
+    const component = shallow(<Toaster children={testToast} />);
+    const instance = component.instance() as Toaster;
+    instance.dismissToast(testToast[0].props.id);
+
+    expect(component.state("toasts")).not.toContain(testToast[0].props.id);
+  });
+
+  it("dismisses toasts after specified time", () => {
+    const testToast = [<Toast id={0} title="I Am Toast" key={0} />];
+    const component = shallow(<Toaster children={testToast} />);
+
+    expect(Object.keys(component.state("toasts")).length).toBe(1);
+    setTimeout(() => {
+      expect(Object.keys(component.state("toasts")).length).toBe(0);
+    }, DELAY_TIME + 1);
+  });
+
+  it("dismisses autodismiss toasts after specified time", () => {
+    const testToast = [
+      <Toast id={0} autodismiss={true} title="I Am Toast" key={0} />
+    ];
+    const component = shallow(<Toaster children={testToast} />);
+
+    expect(Object.keys(component.state("toasts")).length).toBe(1);
+    setTimeout(() => {
+      expect(Object.keys(component.state("toasts")).length).toBe(0);
+    }, DELAY_TIME + 1);
+  });
+
+  it("adds new `toast` with new toast received via props", () => {
+    const testToastId = "testToastId";
+    const ToastWithProps = passedProps => (
+      <Toaster
+        children={[
+          <Toast {...passedProps} title="I Am Toast" key={1} id={testToastId} />
+        ]}
+      />
+    );
+    const newProps = {
+      children: [<Toast id={0} key={0} title="I Am Toast" />]
+    };
+    const component = mount(<ToastWithProps />);
+    const instance = component.find(Toaster).instance() as Toaster;
+
+    expect(instance.state.toasts && instance.state.toasts.length).toEqual(1);
+    instance.componentWillReceiveProps(newProps);
+    expect(instance.state.toasts && instance.state.toasts.length).toEqual(2);
+  });
+});

--- a/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
+++ b/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
@@ -1,0 +1,153 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Toast renders default 1`] = `
+.emotion-0 {
+  max-width: 100%;
+  margin: 16px !important;
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    max-width: 20em;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    margin: 24px !important;
+  }
+}
+
+<div
+  className="emotion-0"
+>
+  <ol
+    aria-live="assertive"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <PoseGroup
+      flipMove={true}
+      preEnterPose="preEnter"
+    >
+      <Component
+        key="toastWrapper-0"
+      >
+        <Toast
+          appearance="default"
+          autodismiss={false}
+          dismissToast={[Function]}
+          id={0}
+          key="0"
+          title="I Am Toast"
+        />
+      </Component>
+    </PoseGroup>
+  </ol>
+</div>
+`;
+
+exports[`Toast renders with actions 1`] = `
+.emotion-0 {
+  max-width: 100%;
+  margin: 16px !important;
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    max-width: 20em;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    margin: 24px !important;
+  }
+}
+
+<div
+  className="emotion-0"
+>
+  <ol
+    aria-live="assertive"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <PoseGroup
+      flipMove={true}
+      preEnterPose="preEnter"
+    >
+      <Component
+        key="toastWrapper-0"
+      >
+        <Toast
+          appearance="default"
+          autodismiss={false}
+          dismissToast={[Function]}
+          id={0}
+          key="0"
+          primaryAction={
+            <button>
+              primaryAction
+            </button>
+          }
+          secondaryAction={
+            <button>
+              secondaryAction
+            </button>
+          }
+          title="I Am Toast"
+        />
+      </Component>
+    </PoseGroup>
+  </ol>
+</div>
+`;
+
+exports[`Toast renders with description 1`] = `
+.emotion-0 {
+  max-width: 100%;
+  margin: 16px !important;
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    max-width: 20em;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    margin: 24px !important;
+  }
+}
+
+<div
+  className="emotion-0"
+>
+  <ol
+    aria-live="assertive"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <PoseGroup
+      flipMove={true}
+      preEnterPose="preEnter"
+    >
+      <Component
+        key="toastWrapper-0"
+      >
+        <Toast
+          appearance="default"
+          autodismiss={false}
+          description="Description"
+          dismissToast={[Function]}
+          id={0}
+          key="0"
+          title="I Am Toast"
+        />
+      </Component>
+    </PoseGroup>
+  </ol>
+</div>
+`;


### PR DESCRIPTION
This should work as-is, but we can probably follow-up to make `Toaster` stateless by storing `toasts` data in the datalayer and adding GraphQL mutations for adding and removing toasts

## Screenshots:
![toastdismissorder](https://user-images.githubusercontent.com/2313998/46832380-de575a80-cd73-11e8-9eb4-f0472bdc2ede.gif)