### PR TITLE
fix: React 15 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -414,11 +414,6 @@
         }
       }
     },
-    "@popmotion/easing": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.1.tgz",
-      "integrity": "sha512-NbIEz9mZAem0F0sjg2v57LbU9Y2Xc50QEX434jYrwEQzXJuJipyUV48Qz4hjHqbB/8xiUj0JMQfRvP8K9nUbxg=="
-    },
     "@semantic-release/commit-analyzer": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.1.0.tgz",
@@ -977,11 +972,6 @@
         "@types/cheerio": "0.22.9",
         "@types/react": "16.4.16"
       }
-    },
-    "@types/invariant": {
-      "version": "2.2.29",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.29.tgz",
-      "integrity": "sha512-lRVw09gOvgviOfeUrKc/pmTiRZ7g7oDOU6OAutyuSHpm1/o2RaBQvRhgK8QEdu+FFuw/wnWb29A/iuxv9i8OpQ=="
     },
     "@types/jest": {
       "version": "23.3.5",
@@ -6689,14 +6679,6 @@
         "map-cache": "0.2.2"
       }
     },
-    "framesync": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.1.tgz",
-      "integrity": "sha512-7dF3SXz/xMdwSHFHgj8PV2dAUCFclXWhasAb06rFvAM2pX24m9eDs6X+ikK0kx92w/uIljUi0sBINwcbl0rT2Q==",
-      "requires": {
-        "hey-listen": "1.0.5"
-      }
-    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -7979,11 +7961,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "hey-listen": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.5.tgz",
-      "integrity": "sha512-O2iCNxBBGb4hOxL9tUdnoPwDYmZhQ29t5xKV74BVZNdvwCDXCpVYTJ4yoaibc1V0I8Yw3K3nwmvDpoyjnCqUaw=="
     },
     "highlight.js": {
       "version": "9.13.1",
@@ -15938,32 +15915,6 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
-    "popmotion": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-8.4.1.tgz",
-      "integrity": "sha512-j25mAl6QlGN/ErGR7dBCCvxIKQ5pSxqEwieeqvacC3ZByXy98+UnOj+vaeVlZcr2Bjl5q03xHe1gKyr4ursL1A==",
-      "requires": {
-        "@popmotion/easing": "1.0.1",
-        "framesync": "4.0.1",
-        "hey-listen": "1.0.5",
-        "style-value-types": "3.0.7",
-        "stylefire": "2.1.0",
-        "tslib": "1.9.3"
-      }
-    },
-    "popmotion-pose": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/popmotion-pose/-/popmotion-pose-3.3.2.tgz",
-      "integrity": "sha512-wJs6ZMJikppmoNnAV+olyF51HuUdKMS/Ba56aE1iLs60rFcQqhJrpGTHIhGLFwTDLs1Sbkae7N4klnrPl4bTxQ==",
-      "requires": {
-        "@popmotion/easing": "1.0.1",
-        "hey-listen": "1.0.5",
-        "popmotion": "8.4.1",
-        "pose-core": "2.0.0",
-        "style-value-types": "3.0.7",
-        "tslib": "1.9.3"
-      }
-    },
     "portfinder": {
       "version": "1.0.18",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.18.tgz",
@@ -15995,24 +15946,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        }
-      }
-    },
-    "pose-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pose-core/-/pose-core-2.0.0.tgz",
-      "integrity": "sha512-RJcDqYADmuXKQ+uP59oh+EIeRhsuAkKLeVrT25ak57q8TXkEKh8pjL99AHNQLktLUI97erpdNnOp+McK3d/CUQ==",
-      "requires": {
-        "@types/invariant": "2.2.29",
-        "@types/node": "10.12.0",
-        "hey-listen": "1.0.5",
-        "tslib": "1.9.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.12.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
-          "integrity": "sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ=="
         }
       }
     },
@@ -18829,7 +18762,8 @@
     "react-is": {
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.5.2.tgz",
-      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ=="
+      "integrity": "sha512-hSl7E6l25GTjNEZATqZIuWOgSnpXb3kD0DVCujmg46K5zLxsbiKaaT6VO9slkSBDPZfYs30lwfJwbOFOnoEnKQ==",
+      "dev": true
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -18853,18 +18787,6 @@
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
       "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg==",
       "dev": true
-    },
-    "react-pose": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/react-pose/-/react-pose-3.3.6.tgz",
-      "integrity": "sha512-guFH+Tv8fMIPk0hR4VQvZrBNM9k+73BWq+RqpNWYD8V5usL6UClKNEkXSmY5N1BUwfO6eyJaVUkodCrIhMx6UQ==",
-      "requires": {
-        "@emotion/is-prop-valid": "0.6.8",
-        "hey-listen": "1.0.5",
-        "popmotion-pose": "3.3.2",
-        "react-is": "16.5.2",
-        "tslib": "1.9.3"
-      }
     },
     "react-split-pane": {
       "version": "0.1.84",
@@ -18912,7 +18834,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
       "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
-      "dev": true,
       "requires": {
         "dom-helpers": "3.3.1",
         "loose-envify": "1.4.0",
@@ -20609,22 +20530,6 @@
         "schema-utils": "0.4.7"
       }
     },
-    "style-value-types": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.0.7.tgz",
-      "integrity": "sha512-7vzeicDiPNnJjvTYfJbQhZ7P3OCkXfvkJOJQ+ifFnXNTA/7KBxMZacHLvlRjM5/TtXbVdrZE6u+2nzSUSPrbSQ=="
-    },
-    "stylefire": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-2.1.0.tgz",
-      "integrity": "sha512-DeO5v4w4xwvSoatWkfD++tpPqoolSxZtmrL7mFwxHp70AXJuzvwDVlTkpaXwPXvfevXwiGXA224gOnIk2pLiRA==",
-      "requires": {
-        "framesync": "4.0.1",
-        "hey-listen": "1.0.5",
-        "style-value-types": "3.0.7",
-        "tslib": "1.9.3"
-      }
-    },
     "stylis": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
@@ -21195,7 +21100,8 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     },
     "tslint": {
       "version": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react": "16.5.2",
     "react-dom": "16.5.2",
     "react-emotion": "9.2.12",
-    "react-pose": "3.3.6",
+    "react-transition-group": "2.5.0",
     "react-virtualized": "9.20.1",
     "semantic-release": "^15.9.6"
   },

--- a/packages/toaster/components/Toaster.tsx
+++ b/packages/toaster/components/Toaster.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { cx } from "emotion";
-import posed, { PoseGroup } from "react-pose";
+import { TransitionGroup, Transition } from "react-transition-group";
 import { ToastProps, ToastId } from "./Toast";
-import { toaster } from "../style";
+import { toaster, preTransitionStyle, transitionStyles } from "../style";
 import { margin, marginAt } from "../../shared/styles/styleUtils";
 
 export interface ToasterProps {
@@ -16,20 +16,7 @@ export interface ToasterState {
 export const DELAY_TIME = 3000;
 const MARGINAL_DELAY = 1000;
 
-const ToastWrapper = posed.li({
-  preEnter: {
-    y: 20
-  },
-  enter: {
-    opacity: 1,
-    y: 0,
-    transition: { easing: "easeInOut" }
-  },
-  exit: {
-    opacity: 0,
-    transition: { easing: "easeInOut" }
-  }
-});
+const animationDuration = 300;
 
 class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
   // TODO: write better type for timeouts
@@ -97,11 +84,27 @@ class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
           onMouseLeave={this.restartTimeouts}
           aria-live="assertive"
         >
-          <PoseGroup preEnterPose="preEnter">
+          <TransitionGroup>
             {toastsToRender.map((toast, i) => (
-              <ToastWrapper key={`toastWrapper-${i}`}>{toast}</ToastWrapper>
+              <Transition
+                key={`toastWrapper-${i}`}
+                timeout={{ enter: 0, exit: animationDuration }}
+              >
+                {state => {
+                  return (
+                    <li
+                      className={cx(
+                        preTransitionStyle(animationDuration),
+                        transitionStyles[state]
+                      )}
+                    >
+                      {toast}
+                    </li>
+                  );
+                }}
+              </Transition>
             ))}
-          </PoseGroup>
+          </TransitionGroup>
         </ol>
       </div>
     );

--- a/packages/toaster/style.ts
+++ b/packages/toaster/style.ts
@@ -10,6 +10,24 @@ export const toaster = css`
   `)};
 `;
 
+export const preTransitionStyle = duration => css`
+  transition: opacity ${duration}ms ease-in-out,
+    transform ${duration}ms ease-in-out;
+  opacity: 0;
+  transform: translateY(20px);
+`;
+
+export const transitionStyles = {
+  entered: css`
+    opacity: 1;
+    transform: translateY(0);
+  `,
+  exiting: css`
+    opacity: 0;
+    transform: translateY(0);
+  `
+};
+
 // TODO: use a design token for border-radius when it exists
 export const toast = css`
   background-color: ${greyDark};

--- a/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
+++ b/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
@@ -26,23 +26,34 @@ exports[`Toast renders default 1`] = `
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <PoseGroup
-      flipMove={true}
-      preEnterPose="preEnter"
+    <TransitionGroup
+      childFactory={[Function]}
+      component="div"
     >
-      <Component
+      <Transition
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
         key="toastWrapper-0"
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={
+          Object {
+            "enter": 0,
+            "exit": 300,
+          }
+        }
+        unmountOnExit={false}
       >
-        <Toast
-          appearance="default"
-          autodismiss={false}
-          dismissToast={[Function]}
-          id={0}
-          key="0"
-          title="I Am Toast"
-        />
-      </Component>
-    </PoseGroup>
+        <Component />
+      </Transition>
+    </TransitionGroup>
   </ol>
 </div>
 `;
@@ -73,33 +84,34 @@ exports[`Toast renders with actions 1`] = `
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <PoseGroup
-      flipMove={true}
-      preEnterPose="preEnter"
+    <TransitionGroup
+      childFactory={[Function]}
+      component="div"
     >
-      <Component
+      <Transition
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
         key="toastWrapper-0"
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={
+          Object {
+            "enter": 0,
+            "exit": 300,
+          }
+        }
+        unmountOnExit={false}
       >
-        <Toast
-          appearance="default"
-          autodismiss={false}
-          dismissToast={[Function]}
-          id={0}
-          key="0"
-          primaryAction={
-            <button>
-              primaryAction
-            </button>
-          }
-          secondaryAction={
-            <button>
-              secondaryAction
-            </button>
-          }
-          title="I Am Toast"
-        />
-      </Component>
-    </PoseGroup>
+        <Component />
+      </Transition>
+    </TransitionGroup>
   </ol>
 </div>
 `;
@@ -130,24 +142,34 @@ exports[`Toast renders with description 1`] = `
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
-    <PoseGroup
-      flipMove={true}
-      preEnterPose="preEnter"
+    <TransitionGroup
+      childFactory={[Function]}
+      component="div"
     >
-      <Component
+      <Transition
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
         key="toastWrapper-0"
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        timeout={
+          Object {
+            "enter": 0,
+            "exit": 300,
+          }
+        }
+        unmountOnExit={false}
       >
-        <Toast
-          appearance="default"
-          autodismiss={false}
-          description="Description"
-          dismissToast={[Function]}
-          id={0}
-          key="0"
-          title="I Am Toast"
-        />
-      </Component>
-    </PoseGroup>
+        <Component />
+      </Transition>
+    </TransitionGroup>
   </ol>
 </div>
 `;


### PR DESCRIPTION
I had to replace the `react-pose` dependency with `react-transition-group` because I hadn't realized `react-pose` requires React 16.

I tested this by running `npm run dist` and then manually replacing `dcos-ui/node_modules/ui-kit/dist` with `dist` directory generated in ui-kit

**This needs to merge before I can submit a PR for [DCOS-40871](https://jira.mesosphere.com/browse/DCOS-40871)**