### PR TITLE
fix: do not export global element reset styles

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -4,6 +4,7 @@ import { configure, setAddon, addDecorator } from "@storybook/react";
 import { withKnobs } from "@storybook/addon-knobs/react";
 import { setOptions } from "@storybook/addon-options";
 import infoAddon, { setDefaults } from "@storybook/addon-info";
+require("../packages/shared/styles/global").injectStorybookResetCss();
 
 addDecorator(withKnobs);
 setAddon(infoAddon);

--- a/packages/shared/styles/global.ts
+++ b/packages/shared/styles/global.ts
@@ -4,27 +4,16 @@ const { fontFamilySansSerif } = coreFonts();
 
 export const injectGlobalCss = () => {
   return injectGlobal`
-    body {
-      font-family: ${fontFamilySansSerif};
-    }
-
-    h1, h2, h3, h4, h5, h6 {
-      font-weight: normal;
-      margin: 0;
-    }
-
-    p {
-      margin: 0;
-    }
-
-    ul, ol {
-      list-style: none;
-      margin-left: 0;
-      padding-left: 0;
-    }
-
     .ReactVirtualized__Grid {
       outline: none;
+    }
+  `;
+};
+
+export const injectStorybookResetCss = () => {
+  return injectGlobal`
+    body {
+        font-family: ${fontFamilySansSerif};
     }
   `;
 };

--- a/packages/toaster/components/Toaster.tsx
+++ b/packages/toaster/components/Toaster.tsx
@@ -2,7 +2,12 @@ import * as React from "react";
 import { cx } from "emotion";
 import { TransitionGroup, Transition } from "react-transition-group";
 import { ToastProps, ToastId } from "./Toast";
-import { toaster, preTransitionStyle, transitionStyles } from "../style";
+import {
+  toaster,
+  toasterList,
+  preTransitionStyle,
+  transitionStyles
+} from "../style";
 import { margin, marginAt } from "../../shared/styles/styleUtils";
 
 export interface ToasterProps {
@@ -83,6 +88,7 @@ class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
           onMouseEnter={this.clearTimeouts}
           onMouseLeave={this.restartTimeouts}
           aria-live="assertive"
+          className={toasterList}
         >
           <TransitionGroup>
             {toastsToRender.map((toast, i) => (

--- a/packages/toaster/style.ts
+++ b/packages/toaster/style.ts
@@ -10,6 +10,12 @@ export const toaster = css`
   `)};
 `;
 
+export const toasterList = css`
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+`;
+
 export const preTransitionStyle = duration => css`
   transition: opacity ${duration}ms ease-in-out,
     transform ${duration}ms ease-in-out;

--- a/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
+++ b/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
@@ -2,27 +2,34 @@
 
 exports[`Toast renders default 1`] = `
 .emotion-0 {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.emotion-1 {
   max-width: 100%;
   margin: 16px !important;
 }
 
 @media (min-width:900px) {
-  .emotion-0 {
+  .emotion-1 {
     max-width: 20em;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-0 {
+  .emotion-1 {
     margin: 24px !important;
   }
 }
 
 <div
-  className="emotion-0"
+  className="emotion-1"
 >
   <ol
     aria-live="assertive"
+    className="emotion-0"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -60,27 +67,34 @@ exports[`Toast renders default 1`] = `
 
 exports[`Toast renders with actions 1`] = `
 .emotion-0 {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.emotion-1 {
   max-width: 100%;
   margin: 16px !important;
 }
 
 @media (min-width:900px) {
-  .emotion-0 {
+  .emotion-1 {
     max-width: 20em;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-0 {
+  .emotion-1 {
     margin: 24px !important;
   }
 }
 
 <div
-  className="emotion-0"
+  className="emotion-1"
 >
   <ol
     aria-live="assertive"
+    className="emotion-0"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -118,27 +132,34 @@ exports[`Toast renders with actions 1`] = `
 
 exports[`Toast renders with description 1`] = `
 .emotion-0 {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.emotion-1 {
   max-width: 100%;
   margin: 16px !important;
 }
 
 @media (min-width:900px) {
-  .emotion-0 {
+  .emotion-1 {
     max-width: 20em;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-0 {
+  .emotion-1 {
     margin: 24px !important;
   }
 }
 
 <div
-  className="emotion-0"
+  className="emotion-1"
 >
   <ol
     aria-live="assertive"
+    className="emotion-0"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >


### PR DESCRIPTION
Injecting global element styles was overriding some CNVS styles that we want in dcos-ui.