### PR TITLE
fix(AppChrome): make AppChrome always fill it's container's height

### DIFF
--- a/packages/appChrome/components/AppChrome.tsx
+++ b/packages/appChrome/components/AppChrome.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import { cx } from "emotion";
-import { appChrome } from "../style";
-import { flex, flexItem, textSize } from "../../shared/styles/styleUtils";
+import { appChrome, appWrapper } from "../style";
+import {
+  flex,
+  flexItem,
+  textSize,
+  flush
+} from "../../shared/styles/styleUtils";
 
 export interface AppChromeProps {
   sidebar: React.ReactNode;
@@ -16,9 +21,11 @@ class AppChrome extends React.PureComponent<AppChromeProps, {}> {
     return (
       <div className={cx(appChrome, textSize("default"))}>
         <div className="headerBar">{headerBar}</div>
-        <div className={flex()}>
+        <div className={cx(flex(), appWrapper)}>
           <div className={flexItem("shrink")}>{sidebar}</div>
-          <main className={flexItem("grow")}>{mainContent}</main>
+          <main className={cx(flexItem("grow"), flush("left"))}>
+            {mainContent}
+          </main>
         </div>
       </div>
     );

--- a/packages/appChrome/style.ts
+++ b/packages/appChrome/style.ts
@@ -19,6 +19,7 @@ const sidebarWidths = {
 const layoutBreakpoint = "large";
 
 export const appChrome = css`
+  height: 100%;
   overflow: hidden;
 `;
 
@@ -32,8 +33,13 @@ export const appChromeInsetContent = css`
   `)};
 `;
 
+export const appWrapper = css`
+  height: 100%;
+`;
+
 export const sidebar = css`
   background-color: ${greyDark};
+  height: 100%;
   width: ${sidebarWidths.default};
 
   ${atMediaUp[layoutBreakpoint](css`
@@ -44,6 +50,7 @@ export const sidebar = css`
 // TODO: replace animation duration/easing with design tokens
 // once design has agreed on animation
 export const sidebarAnimator = (isOpen: boolean) => css`
+  height: 100%;
   overflow: hidden;
   transition: width 150ms ease-in-out;
   width: ${isOpen ? sidebarWidths.default : 0};

--- a/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`AppChrome renders with the app chrome regions 1`] = `
 .emotion-3 {
+  height: 100%;
   overflow: hidden;
   font-size: 14px;
 }
@@ -26,6 +27,7 @@ exports[`AppChrome renders with the app chrome regions 1`] = `
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
+  height: 100%;
 }
 
 .emotion-0 {
@@ -60,6 +62,8 @@ exports[`AppChrome renders with the app chrome regions 1`] = `
   width: auto;
   box-sizing: border-box;
   padding-left: 16px;
+  padding-left: 0 !important;
+  margin-left: 0 !important;
 }
 
 .emotion-1:first-child {

--- a/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
@@ -287,6 +287,7 @@ exports[`Sidebar SidebarSubMenuItem renders 1`] = `
 exports[`Sidebar renders 1`] = `
 .emotion-0 {
   background-color: #1B2029;
+  height: 100%;
   width: 240px;
   color: #DADDE2;
   fill: #DADDE2;
@@ -299,6 +300,7 @@ exports[`Sidebar renders 1`] = `
 }
 
 .emotion-1 {
+  height: 100%;
   overflow: hidden;
   -webkit-transition: width 150ms ease-in-out;
   transition: width 150ms ease-in-out;


### PR DESCRIPTION
Before, the Sidebar height would only be the height of it's children. Now, it will always be the height of it's container.
I also removed the gutter between the Sidebar and the main content area

This was causing issues for implementing the sidebar in the Learning Platform

Before:
<img width="910" alt="screen shot 2018-11-15 at 8 03 08 pm" src="https://user-images.githubusercontent.com/2313998/48591346-8df29000-e911-11e8-8719-f633547558a5.png">

After:
<img width="910" alt="screen shot 2018-11-15 at 8 03 24 pm" src="https://user-images.githubusercontent.com/2313998/48591353-91861700-e911-11e8-8b7e-8729f3b8110f.png">
