### PR TITLE
fix(storybook): build design tokens pre deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "commitlint": "commitlint -e",
     "create:component": "./scripts/create-component",
     "deploy:storybook": "storybook-to-ghpages",
+    "predeploy:storybook": "npm run prebuild:storybook",
     "prestart": "npm run build:design-tokens",
     "pretest": "npm run build:design-tokens",
     "predist": "npm run clean && npm run build:design-tokens",


### PR DESCRIPTION
The deploy step of master was broken because of the design tokens which were not build. The problem was that the module we are using to deploy storybook does just build storybook and not run `build:storybook`.