### PR TITLE
DCOS-46141: remove padding from secondary button

### DIFF
--- a/packages/button/style.ts
+++ b/packages/button/style.ts
@@ -36,6 +36,8 @@ const filledButton = (
   return css`
     ${tintContent(contentColor)};
     background-color: ${baseColor};
+    border-radius: ${borderRadiusSmall};
+    padding: 10px 18px;
 
     &:hover {
       background-color: ${hoverColor};
@@ -94,10 +96,8 @@ export const processingTextStyle = css`
 `;
 
 export const buttonBase = css`
-  border-radius: ${borderRadiusSmall};
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
 `;
 
 export const buttonContent = css`
@@ -138,7 +138,17 @@ export const focusStyleByAppearance = (appearance, isInverse) => {
       return focusStyles(purpleDarken1);
       break;
     case "secondary":
-      return focusStyles("transparent", purpleDarken1);
+      return css`
+        ${focusStyles("transparent", purpleDarken1)};
+        &:focus {
+          &:after {
+            border-radius: 0;
+            border-left-width: 0;
+            border-right-width: 0;
+            border-top-width: 0;
+          }
+        }
+      `;
       break;
     case "standard":
       return isInverse

--- a/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
+++ b/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
@@ -13,9 +13,9 @@ exports[`ButtonBase renders all appearances with props 1`] = `
   color: #FFF;
   background-color: #7D58FF;
   border-radius: 4px;
+  padding: 10px 18px;
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
   font-weight: 500;
   display: block;
   text-align: center;
@@ -252,10 +252,8 @@ exports[`ButtonBase renders all appearances with props 2`] = `
   padding: 0;
   text-align: inherit;
   color: #7D58FF;
-  border-radius: 4px;
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
   font-weight: 500;
   display: block;
   text-align: center;
@@ -313,7 +311,7 @@ exports[`ButtonBase renders all appearances with props 2`] = `
 }
 
 <FocusStyleManager
-  focusEnabledClass="css-wynu49"
+  focusEnabledClass="css-14x8wbg"
 >
   <button
     ariaHaspopup={true}
@@ -428,9 +426,9 @@ exports[`ButtonBase renders all appearances with props 3`] = `
   color: #1B2029;
   background-color: #DADDE2;
   border-radius: 4px;
+  padding: 10px 18px;
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
   font-weight: 500;
   display: block;
   text-align: center;
@@ -600,9 +598,9 @@ exports[`ButtonBase renders all appearances with props 4`] = `
   color: #FFF;
   background-color: #EB293A;
   border-radius: 4px;
+  padding: 10px 18px;
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
   font-weight: 500;
   display: block;
   text-align: center;
@@ -772,9 +770,9 @@ exports[`ButtonBase renders all appearances with props 5`] = `
   color: #FFF;
   background-color: #14C684;
   border-radius: 4px;
+  padding: 10px 18px;
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
   font-weight: 500;
   display: block;
   text-align: center;

--- a/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
+++ b/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
@@ -28,9 +28,9 @@ exports[`Dropdownable is visible after opening 1`] = `
   color: #FFF;
   background-color: #7D58FF;
   border-radius: 4px;
+  padding: 10px 18px;
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
   font-weight: 500;
   display: block;
 }
@@ -181,9 +181,9 @@ exports[`Dropdownable is visible after opening 2`] = `
   color: #FFF;
   background-color: #7D58FF;
   border-radius: 4px;
+  padding: 10px 18px;
   cursor: pointer;
   outline: none;
-  padding: 10px 18px;
   font-weight: 500;
   display: block;
 }


### PR DESCRIPTION
Lily and I discussed potential issues with aligning the text of a secondary button with other text on the page or in a modal.

We decided to change the secondary button to have no padding and a different `:focus` style.