### PR TITLE
A different export location for JS design tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp/
 .env
 coverage
 storybook-static/
+packages/design-tokens/index.js

--- a/packages/design-tokens/config.dev.json
+++ b/packages/design-tokens/config.dev.json
@@ -25,6 +25,20 @@
         }
       ]
     },
+    "jsIndex": {
+      "transforms": [
+        "attribute/cti",
+        "name/cti/jsConstant",
+        "value/fontNameJS"
+      ],
+      "buildPath": "packages/design-tokens/",
+      "files": [
+        {
+          "format": "javascript/commonJS",
+          "destination": "index.js"
+        }
+      ]
+    },
     "colorsForStyleguide": {
       "transforms": ["attribute/cti", "name/cti/jsConstant"],
       "buildPath": "packages/design-tokens/build/js/",

--- a/packages/design-tokens/config.release.json
+++ b/packages/design-tokens/config.release.json
@@ -25,6 +25,20 @@
         }
       ]
     },
+    "jsIndex": {
+      "transforms": [
+        "attribute/cti",
+        "name/cti/jsConstant",
+        "value/fontNameJS"
+      ],
+      "buildPath": "dist/packages/design-tokens/",
+      "files": [
+        {
+          "format": "javascript/commonJS",
+          "destination": "index.js"
+        }
+      ]
+    },
     "colorsForStyleguide": {
       "transforms": ["attribute/cti", "name/cti/jsConstant"],
       "buildPath": "dist/packages/design-tokens/build/js/",


### PR DESCRIPTION
Currently, the import path for design tokens is really long.
e.g.: `import { blue } from "@dcos/ui-kit/dist/packages/design-tokens/build/js/designTokens";`

If we change where we export the JavaScript tokens to `packages/design-tokens/`, we can make it a little shorter.
e.g.: `import { blue } from "@dcos/ui-kit/dist/packages/design-tokens/";`

---

It's only slightly shorter, and I'd love to figure out a way to get it to something like `import { blue } from "@dcos/ui-kit/design-tokens/";`.

Anybody have any ideas?

I noticed this while reviewing https://github.com/mesosphere/protoss/pull/57