### PR TITLE
fix: Convert React to peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18631,6 +18631,7 @@
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react/-/react-16.5.2.tgz",
       "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -18820,6 +18821,7 @@
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.5.2.tgz",
       "integrity": "sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19689,6 +19691,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/schedule/-/schedule-0.5.0.tgz",
       "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -44,15 +44,17 @@
     "emotion-theming": "9.2.9",
     "focus-trap-react": "4.0.1",
     "memoize-one": "4.0.2",
-    "react": "16.5.2",
     "react-click-outside": "3.0.1",
     "react-delegate-component": "1.0.0",
-    "react-dom": "16.5.2",
     "react-emotion": "9.2.12",
     "react-toggled": "1.2.7",
     "react-transition-group": "2.5.0",
     "react-virtualized": "9.20.1",
     "semantic-release": "15.9.6"
+  },
+  "peerDependencies": {
+    "react": ">=15.4.1 <=16.7.0 || 16.7.0-alpha.0",
+    "react-dom": ">=15.4.1 <=16.7.0 || 16.7.0-alpha.0"
   },
   "devDependencies": {
     "@commitlint/cli": "7.2.0",
@@ -92,7 +94,9 @@
     "npm": "6.4.1",
     "prettier": "1.14.3",
     "prop-types": "15.6.2",
+    "react": "16.5.2",
     "react-docgen-typescript-loader": "3.0.0",
+    "react-dom": "16.5.2",
     "react-test-renderer": "16.5.2",
     "rimraf": "2.6.2",
     "storybook-readme": "4.0.2",


### PR DESCRIPTION
It's unclear whether this will fix an underlying issue or not, but it would be good not to bundle two versions of react nonetheless.