### PR TITLE
fix: dynamic cell widths update with content changes

### DIFF
--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -101,6 +101,11 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
     };
   }
 
+  public componentDidUpdate() {
+    this.cellMeasureCache.clearAll();
+    this.updateGridSize();
+  }
+
   public render() {
     return (
       <AutoSizer


### PR DESCRIPTION
I tested this in the Nodes table in dcos-ui, and in Storybook by creating a story with changing values

To test in dcos-ui:
1. run `npm run dist`
2. copy `dist/packages/table` to `dcos-ui/node_modules/@dcos/ui-kit/dist/packages/table`