### PR TITLE
DCOS_OSS-4364: allow column width to fill available space

### DIFF
--- a/packages/table/components/Column.tsx
+++ b/packages/table/components/Column.tsx
@@ -27,6 +27,10 @@ export interface ColumnProps {
    * the maximum width a column can be
    */
   maxWidth?: number;
+  /**
+   * whether the column should grow to fill remaining space
+   */
+  growToFill?: boolean;
 }
 
 export class Column extends React.PureComponent<ColumnProps, {}> {}

--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -129,6 +129,45 @@ storiesOf("Table", module)
       </Table>
     </div>
   ))
+  .addWithInfo("column width fill remaining", () => (
+    <div
+      style={{
+        height: "175px",
+        width: "100%",
+        fontSize: "14px"
+      }}
+    >
+      <Table data={items}>
+        <Column
+          header={<HeaderCell>name</HeaderCell>}
+          cellRenderer={nameCellRenderer}
+        />
+        <Column
+          header={<HeaderCell>role</HeaderCell>}
+          cellRenderer={roleCellRenderer}
+          growToFill={true}
+        />
+        <Column
+          header={<HeaderCell>state</HeaderCell>}
+          cellRenderer={stateCellRenderer}
+        />
+        <Column
+          header={<HeaderCell>Very Long</HeaderCell>}
+          cellRenderer={veryLongRenderer}
+          maxWidth={300}
+        />
+        <Column
+          header={<HeaderCell textAlign="right">zip code</HeaderCell>}
+          cellRenderer={zipcodeCellRenderer}
+        />
+        <Column
+          header={<HeaderCell>city</HeaderCell>}
+          cellRenderer={cityCellRenderer}
+          growToFill={true}
+        />
+      </Table>
+    </div>
+  ))
   .addWithInfo("width-aware render", () => {
     const stateWidth = (args: WidthArgs): number =>
       Math.min(100, Math.max(200, args.width / args.totalColumns));

--- a/packages/table/tests/Table.test.tsx
+++ b/packages/table/tests/Table.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Table, Column } from "../";
+import { fillColumns, clampWidth } from "../components/Table";
 import * as emotion from "emotion";
 import { createSerializer } from "jest-emotion";
 import { render, shallow, mount } from "enzyme";
@@ -59,6 +60,35 @@ describe("Table", () => {
     expect(toJson(component)).toMatchSnapshot();
   });
 
+  it("renders with growToFill cols", () => {
+    const component = render(
+      <Table data={items}>
+        <Column
+          header="name"
+          cellRenderer={nameCellRenderer}
+          growToFill={true}
+        />
+        <Column
+          header="role"
+          cellRenderer={roleCellRenderer}
+          growToFill={true}
+        />
+        <Column
+          header="state"
+          cellRenderer={stateCellRenderer}
+          growToFill={true}
+        />
+        <Column
+          header="zipcode"
+          cellRenderer={zipcodeCellRenderer}
+          width={width}
+        />
+        <Column header="city" cellRenderer={cityCellRenderer} width={width} />
+      </Table>
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
   it("renders again with new data", () => {
     const itemRenderer = item => <span>{item}</span>;
     const component = mount(
@@ -85,6 +115,109 @@ describe("Table", () => {
       );
       const instance = component.instance() as Table<number>;
       expect(instance.getData([1, 2, 3])).toEqual([{}, 1, 2, 3]);
+    });
+  });
+
+  describe("clampWidth", () => {
+    it("returns the minumum width if the base is lower than minWidth", () => {
+      expect(clampWidth(100, 200, 300)).toEqual(200);
+    });
+    it("returns the maximum width if the base is higher than maxWidth", () => {
+      expect(clampWidth(400, 200, 300)).toEqual(300);
+    });
+  });
+
+  describe("fillColumns", () => {
+    it("returns resized column widths", () => {
+      const columns = [
+        // tslint:disable:jsx-wrap-multiline
+        <Column
+          header="name"
+          cellRenderer={nameCellRenderer}
+          growToFill={true}
+          key={0}
+        />,
+        <Column
+          header="role"
+          cellRenderer={roleCellRenderer}
+          growToFill={true}
+          key={1}
+        />,
+        <Column
+          header="state"
+          cellRenderer={stateCellRenderer}
+          growToFill={true}
+          key={2}
+        />,
+        <Column
+          header="zipcode"
+          cellRenderer={zipcodeCellRenderer}
+          growToFill={true}
+          key={3}
+        />,
+        <Column
+          header="city"
+          cellRenderer={cityCellRenderer}
+          growToFill={true}
+          key={4}
+        />
+        // tslint:enable:jsx-wrap-multiline
+      ];
+      const colWidths = [150, 150, 150, 150, 150];
+      const availableWidth = 1000;
+
+      expect(
+        fillColumns(columns, colWidths, availableWidth).reduce(
+          (acc, curr) => acc + curr,
+          0
+        )
+      ).toEqual(availableWidth);
+    });
+    it("distributes extra width to other columns when one has a maxWidth", () => {
+      const columns = [
+        // tslint:disable:jsx-wrap-multiline
+        <Column
+          header="name"
+          cellRenderer={nameCellRenderer}
+          growToFill={true}
+          maxWidth={100}
+          key={0}
+        />,
+        <Column
+          header="role"
+          cellRenderer={roleCellRenderer}
+          growToFill={true}
+          key={1}
+        />,
+        <Column
+          header="state"
+          cellRenderer={stateCellRenderer}
+          growToFill={true}
+          key={2}
+        />,
+        <Column
+          header="zipcode"
+          cellRenderer={zipcodeCellRenderer}
+          growToFill={true}
+          key={3}
+        />,
+        <Column
+          header="city"
+          cellRenderer={cityCellRenderer}
+          growToFill={true}
+          key={4}
+        />
+        // tslint:enable:jsx-wrap-multiline
+      ];
+      const colWidths = [100, 150, 150, 150, 150];
+      const availableWidth = 1000;
+
+      expect(
+        fillColumns(columns, colWidths, availableWidth).reduce(
+          (acc, curr) => acc + curr,
+          0
+        )
+      ).toEqual(availableWidth);
     });
   });
 });

--- a/packages/table/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Table.test.tsx.snap
@@ -372,3 +372,234 @@ exports[`Table renders default 1`] = `
   </div>
 </div>
 `;
+
+exports[`Table renders with growToFill cols 1`] = `
+.emotion-0 {
+  box-sizing: border-box;
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  border-bottom: 1px solid #DADDE2;
+  white-space: nowrap;
+}
+
+.emotion-17 {
+  font-weight: normal;
+}
+
+.emotion-17::after {
+  content: "";
+  height: 100%;
+  left: 0;
+  position: absolute;
+  pointer-events: none;
+  top: 0;
+  width: 100%;
+}
+
+.emotion-5 {
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+}
+
+.emotion-5::-webkit-scrollbar {
+  display: none;
+}
+
+<div
+  class="emotion-17"
+  style="overflow:visible;height:0;width:0"
+>
+  <div
+    style="height:768px;overflow:visible;width:1024px"
+  >
+    <div
+      style="height:35px;position:relative;width:1024px"
+    >
+      <div
+        aria-label="grid"
+        aria-readonly="true"
+        class="ReactVirtualized__Grid"
+        role="grid"
+        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:151px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
+      >
+        <div
+          class="ReactVirtualized__Grid__innerScrollContainer"
+          role="rowgroup"
+          style="width:151px;height:35px;max-width:151px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+        >
+          <div
+            class="emotion-0"
+            style="height:35px;left:0;position:absolute;top:0;width:151px"
+          >
+            name
+          </div>
+        </div>
+      </div>
+      <div
+        class="TopRightGrid_ScrollWrapper"
+        style="left:151px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:873px"
+      >
+        <div
+          aria-label="grid"
+          aria-readonly="true"
+          class="ReactVirtualized__Grid emotion-5"
+          role="grid"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:873px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+        >
+          <div
+            class="ReactVirtualized__Grid__innerScrollContainer"
+            role="rowgroup"
+            style="width:916.4000000000001px;height:35px;max-width:916.4000000000001px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+          >
+            <div
+              class="emotion-0"
+              style="height:35px;left:0;position:absolute;top:0;width:151px"
+            >
+              role
+            </div>
+            <div
+              class="emotion-0"
+              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            >
+              state
+            </div>
+            <div
+              class="emotion-0"
+              style="height:35px;left:302px;position:absolute;top:0;width:307.2px"
+            >
+              zipcode
+            </div>
+            <div
+              class="emotion-0"
+              style="height:35px;left:609.2px;position:absolute;top:0;width:307.2px"
+            >
+              city
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      style="height:733px;overflow:visible;position:relative;width:1024px"
+    >
+      <div
+        class="BottomLeftGrid_ScrollWrapper"
+        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:151px"
+      >
+        <div
+          aria-label="grid"
+          aria-readonly="true"
+          class="ReactVirtualized__Grid emotion-5"
+          role="grid"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:151px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+        >
+          <div
+            class="ReactVirtualized__Grid__innerScrollContainer"
+            role="rowgroup"
+            style="width:151px;height:70px;max-width:151px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          >
+            <div
+              class="emotion-6"
+              style="height:35px;left:0;position:absolute;top:0;width:151px"
+            >
+              <strong>
+                Brian Vaughn
+              </strong>
+            </div>
+            <div
+              class="emotion-6"
+              style="height:35px;left:0;position:absolute;top:35px;width:151px"
+            >
+              <strong>
+                Jon Doe
+              </strong>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-label="grid"
+        aria-readonly="true"
+        class="ReactVirtualized__Grid"
+        role="grid"
+        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:873px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:151px"
+        tabindex="0"
+      >
+        <div
+          class="ReactVirtualized__Grid__innerScrollContainer"
+          role="rowgroup"
+          style="width:916.4000000000001px;height:70px;max-width:916.4000000000001px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+        >
+          <div
+            class="emotion-6"
+            style="height:35px;left:0;position:absolute;top:0;width:151px"
+          >
+            <em>
+              Software Engineer
+            </em>
+          </div>
+          <div
+            class="emotion-6"
+            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+          >
+            <span>
+              CA
+            </span>
+          </div>
+          <div
+            class="emotion-6"
+            style="height:35px;left:302px;position:absolute;top:0;width:307.2px"
+          >
+            <span>
+              95125
+            </span>
+          </div>
+          <div
+            class="emotion-6"
+            style="height:35px;left:609.2px;position:absolute;top:0;width:307.2px"
+          >
+            <strong>
+              San Jose
+            </strong>
+          </div>
+          <div
+            class="emotion-6"
+            style="height:35px;left:0;position:absolute;top:35px;width:151px"
+          >
+            <em>
+              Product engineer
+            </em>
+          </div>
+          <div
+            class="emotion-6"
+            style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+          >
+            <span>
+              CA
+            </span>
+          </div>
+          <div
+            class="emotion-6"
+            style="height:35px;left:302px;position:absolute;top:35px;width:307.2px"
+          >
+            <span>
+              95125
+            </span>
+          </div>
+          <div
+            class="emotion-6"
+            style="height:35px;left:609.2px;position:absolute;top:35px;width:307.2px"
+          >
+            <strong>
+              Mountain View
+            </strong>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Adding the `growToFill` prop to a column allows that column to grow until the table fills it's parent. `maxWidth`, `minWidth`, and `width` props will still work in conjunction with this even though I can't think of a realistic use case for combining those with `growToFill` ¯\_(ツ)_/¯

In this example, the "Role" and "City" columns have `growToFill`:
![screen shot 2019-01-18 at 5 13 54 pm](https://user-images.githubusercontent.com/2313998/51415778-07427500-1b45-11e9-97f1-bd2cb84b23ce.png)
