### PR TITLE
CheckboxInput followup: added hint text to toggle input

### DIFF
--- a/packages/checkboxInput/components/CheckboxInput.tsx
+++ b/packages/checkboxInput/components/CheckboxInput.tsx
@@ -12,6 +12,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { iconSizeXs, white } from "../../design-tokens/build/js/designTokens";
 import { ToggleInputProps } from "../../toggleInput/components/ToggleInput";
 import { InputAppearance } from "../../shared/types/inputAppearance";
+import FormFieldWrapper from "../../shared/components/FormFieldWrapper";
 
 export interface CheckboxInputState {
   hasFocus: boolean;
@@ -58,6 +59,8 @@ class CheckboxInput extends React.PureComponent<
       vertAlign,
       disabled,
       value,
+      errors,
+      hintContent,
       ...other
     } = this.props;
     delete other.onFocus;
@@ -81,54 +84,65 @@ class CheckboxInput extends React.PureComponent<
     ].join(" ");
 
     return (
-      <ToggleInput
-        appearance={appearance}
-        disabled={disabled}
-        id={id}
-        inputLabel={inputLabel}
-        showInputLabel={showInputLabel}
-        vertAlign={vertAlign}
-        dataCy={parentDataCy}
-      >
-        <div
-          className={cx(toggleInput, checkbox, {
-            [toggleInputApperances[`${this.props.appearance}-focus`]]: this
-              .state.hasFocus,
-            [toggleInputApperances[`${this.props.appearance}-active`]]:
-              checked || isIndeterminate,
-            [toggleInputApperances["focus-active"]]:
-              checked && this.state.hasFocus,
-            [toggleInputApperances.disabled]: disabled,
-            [toggleInputApperances["disabled-active"]]: disabled && checked
-          })}
-        >
-          {/* tslint:disable react-a11y-role-has-required-aria-props */}
-          <input
-            type="checkbox"
-            id={id}
-            className={visuallyHidden}
-            checked={checked}
+      <FormFieldWrapper id={id} errors={errors} hintContent={hintContent}>
+        {({ getValidationErrors, isValid, describedByIds, getHintContent }) => (
+          <ToggleInput
+            appearance={appearance}
             disabled={disabled}
-            value={value}
-            onFocus={this.handleFocus}
-            onBlur={this.handleBlur}
-            aria-checked={isIndeterminate ? "mixed" : checked}
-            data-cy={inputDataCy}
-            {...other}
-          />
-          {/* tslint:enable */}
-
-          {(checked || isIndeterminate) && (
-            <span className={cx(checkboxIconContainer, display("inline-flex"))}>
-              <Icon
-                shape={indeterminate ? SystemIcons.Minus : SystemIcons.Check}
-                size={iconSizeXs}
-                color={white}
+            errorContent={getValidationErrors}
+            hintContent={getHintContent}
+            id={id}
+            inputLabel={inputLabel}
+            showInputLabel={showInputLabel}
+            vertAlign={vertAlign}
+            dataCy={parentDataCy}
+          >
+            <div
+              className={cx(toggleInput, checkbox, {
+                [toggleInputApperances[`${this.props.appearance}-focus`]]: this
+                  .state.hasFocus,
+                [toggleInputApperances[`${this.props.appearance}-active`]]:
+                  checked || isIndeterminate,
+                [toggleInputApperances["focus-active"]]:
+                  checked && this.state.hasFocus,
+                [toggleInputApperances.disabled]: disabled,
+                [toggleInputApperances["disabled-active"]]: disabled && checked
+              })}
+            >
+              {/* tslint:disable react-a11y-role-has-required-aria-props */}
+              <input
+                type="checkbox"
+                id={id}
+                className={visuallyHidden}
+                checked={checked}
+                disabled={disabled}
+                value={value}
+                aria-invalid={!isValid}
+                aria-describedBy={describedByIds}
+                onFocus={this.handleFocus}
+                onBlur={this.handleBlur}
+                data-cy={inputDataCy}
+                {...other}
               />
-            </span>
-          )}
-        </div>
-      </ToggleInput>
+              {/* tslint:enable */}
+
+              {(checked || isIndeterminate) && (
+                <span
+                  className={cx(checkboxIconContainer, display("inline-flex"))}
+                >
+                  <Icon
+                    shape={
+                      indeterminate ? SystemIcons.Minus : SystemIcons.Check
+                    }
+                    size={iconSizeXs}
+                    color={white}
+                  />
+                </span>
+              )}
+            </div>
+          </ToggleInput>
+        )}
+      </FormFieldWrapper>
     );
   }
 

--- a/packages/checkboxInput/stories/CheckboxInput.stories.tsx
+++ b/packages/checkboxInput/stories/CheckboxInput.stories.tsx
@@ -173,6 +173,28 @@ storiesOf("Forms/CheckboxInput", module)
     }
   )
   .add(
+    "hint text",
+    () => (
+      <CheckboxStoryHelper isChecked={true}>
+        {({ changeHandler, isChecked }) => (
+          <CheckboxInput
+            id="hiddenLabel"
+            inputLabel="You can't see me"
+            hintContent="Here's a hint"
+            value="hiddenLabelValue"
+            checked={isChecked}
+            onChange={changeHandler}
+          />
+        )}
+      </CheckboxStoryHelper>
+    ),
+    {
+      info: {
+        propTables: [CheckboxInput]
+      }
+    }
+  )
+  .add(
     "hidden label",
     () => (
       <CheckboxStoryHelper isChecked={true}>

--- a/packages/checkboxInput/tests/__snapshots__/CheckboxInput.test.tsx.snap
+++ b/packages/checkboxInput/tests/__snapshots__/CheckboxInput.test.tsx.snap
@@ -18,8 +18,8 @@ exports[`CheckboxInput renders all appearances 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -82,46 +82,54 @@ exports[`CheckboxInput renders all appearances 1`] = `
   inputLabel="Sample label"
   value="default"
 >
-  <ToggleInput
-    appearance="standard"
-    dataCy="checkboxInput"
+  <FormFieldWrapper
     id="defaultId"
-    inputLabel="Sample label"
-    showInputLabel={true}
-    vertAlign="center"
   >
-    <div
-      data-cy="checkboxInput"
+    <ToggleInput
+      appearance="standard"
+      dataCy="checkboxInput"
+      errorContent={null}
+      hintContent={null}
+      id="defaultId"
+      inputLabel="Sample label"
+      showInputLabel={true}
+      vertAlign="center"
     >
-      <label
-        className="emotion-4"
-        htmlFor="defaultId"
+      <div
+        data-cy="checkboxInput"
       >
-        <div
-          className="emotion-2"
+        <label
+          className="emotion-4"
+          htmlFor="defaultId"
         >
           <div
-            className="emotion-1"
+            className="emotion-2"
           >
-            <input
-              className="emotion-0"
-              data-cy="checkboxInput-input"
-              id="defaultId"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              type="checkbox"
-              value="default"
-            />
+            <div
+              className="emotion-1"
+            >
+              <input
+                aria-describedBy=""
+                aria-invalid={false}
+                className="emotion-0"
+                data-cy="checkboxInput-input"
+                id="defaultId"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                type="checkbox"
+                value="default"
+              />
+            </div>
           </div>
-        </div>
-        <div
-          className="emotion-3"
-        >
-          Sample label
-        </div>
-      </label>
-    </div>
-  </ToggleInput>
+          <div
+            className="emotion-3"
+          >
+            Sample label
+          </div>
+        </label>
+      </div>
+    </ToggleInput>
+  </FormFieldWrapper>
 </CheckboxInput>
 `;
 
@@ -143,8 +151,8 @@ exports[`CheckboxInput renders all appearances 2`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -209,46 +217,54 @@ exports[`CheckboxInput renders all appearances 2`] = `
   inputLabel="Sample label"
   value="default"
 >
-  <ToggleInput
-    appearance="error"
-    dataCy="checkboxInput checkboxInput.error"
+  <FormFieldWrapper
     id="defaultId"
-    inputLabel="Sample label"
-    showInputLabel={true}
-    vertAlign="center"
   >
-    <div
-      data-cy="checkboxInput checkboxInput.error"
+    <ToggleInput
+      appearance="error"
+      dataCy="checkboxInput checkboxInput.error"
+      errorContent={null}
+      hintContent={null}
+      id="defaultId"
+      inputLabel="Sample label"
+      showInputLabel={true}
+      vertAlign="center"
     >
-      <label
-        className="emotion-4"
-        htmlFor="defaultId"
+      <div
+        data-cy="checkboxInput checkboxInput.error"
       >
-        <div
-          className="emotion-2"
+        <label
+          className="emotion-4"
+          htmlFor="defaultId"
         >
           <div
-            className="emotion-1"
+            className="emotion-2"
           >
-            <input
-              className="emotion-0"
-              data-cy="checkboxInput-input checkboxInput-input.error"
-              id="defaultId"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              type="checkbox"
-              value="default"
-            />
+            <div
+              className="emotion-1"
+            >
+              <input
+                aria-describedBy=""
+                aria-invalid={false}
+                className="emotion-0"
+                data-cy="checkboxInput-input checkboxInput-input.error"
+                id="defaultId"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                type="checkbox"
+                value="default"
+              />
+            </div>
           </div>
-        </div>
-        <div
-          className="emotion-3"
-        >
-          Sample label
-        </div>
-      </label>
-    </div>
-  </ToggleInput>
+          <div
+            className="emotion-3"
+          >
+            Sample label
+          </div>
+        </label>
+      </div>
+    </ToggleInput>
+  </FormFieldWrapper>
 </CheckboxInput>
 `;
 
@@ -270,8 +286,8 @@ exports[`CheckboxInput renders all appearances 3`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -336,46 +352,54 @@ exports[`CheckboxInput renders all appearances 3`] = `
   inputLabel="Sample label"
   value="default"
 >
-  <ToggleInput
-    appearance="success"
-    dataCy="checkboxInput checkboxInput.success"
+  <FormFieldWrapper
     id="defaultId"
-    inputLabel="Sample label"
-    showInputLabel={true}
-    vertAlign="center"
   >
-    <div
-      data-cy="checkboxInput checkboxInput.success"
+    <ToggleInput
+      appearance="success"
+      dataCy="checkboxInput checkboxInput.success"
+      errorContent={null}
+      hintContent={null}
+      id="defaultId"
+      inputLabel="Sample label"
+      showInputLabel={true}
+      vertAlign="center"
     >
-      <label
-        className="emotion-4"
-        htmlFor="defaultId"
+      <div
+        data-cy="checkboxInput checkboxInput.success"
       >
-        <div
-          className="emotion-2"
+        <label
+          className="emotion-4"
+          htmlFor="defaultId"
         >
           <div
-            className="emotion-1"
+            className="emotion-2"
           >
-            <input
-              className="emotion-0"
-              data-cy="checkboxInput-input checkboxInput-input.success"
-              id="defaultId"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              type="checkbox"
-              value="default"
-            />
+            <div
+              className="emotion-1"
+            >
+              <input
+                aria-describedBy=""
+                aria-invalid={false}
+                className="emotion-0"
+                data-cy="checkboxInput-input checkboxInput-input.success"
+                id="defaultId"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                type="checkbox"
+                value="default"
+              />
+            </div>
           </div>
-        </div>
-        <div
-          className="emotion-3"
-        >
-          Sample label
-        </div>
-      </label>
-    </div>
-  </ToggleInput>
+          <div
+            className="emotion-3"
+          >
+            Sample label
+          </div>
+        </label>
+      </div>
+    </ToggleInput>
+  </FormFieldWrapper>
 </CheckboxInput>
 `;
 
@@ -449,8 +473,8 @@ exports[`CheckboxInput renders indeterminate 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
   background-color: var(--themeBrandPrimary,#7D58FF);
@@ -490,71 +514,78 @@ exports[`CheckboxInput renders indeterminate 1`] = `
   inputLabel="Sample Label"
   value="indeterminate"
 >
-  <ToggleInput
-    appearance="standard"
-    dataCy="checkboxInput checkboxInput.indeterminate"
+  <FormFieldWrapper
     id="indeterminateId"
-    inputLabel="Sample Label"
-    showInputLabel={true}
-    vertAlign="center"
   >
-    <div
-      data-cy="checkboxInput checkboxInput.indeterminate"
+    <ToggleInput
+      appearance="standard"
+      dataCy="checkboxInput checkboxInput.indeterminate"
+      errorContent={null}
+      hintContent={null}
+      id="indeterminateId"
+      inputLabel="Sample Label"
+      showInputLabel={true}
+      vertAlign="center"
     >
-      <label
-        className="emotion-6"
-        htmlFor="indeterminateId"
+      <div
+        data-cy="checkboxInput checkboxInput.indeterminate"
       >
-        <div
-          className="emotion-4"
+        <label
+          className="emotion-6"
+          htmlFor="indeterminateId"
         >
           <div
-            className="emotion-3"
+            className="emotion-4"
           >
-            <input
-              aria-checked="mixed"
-              className="emotion-0"
-              data-cy="checkboxInput-input checkboxInput-input.indeterminate"
-              id="indeterminateId"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              type="checkbox"
-              value="indeterminate"
-            />
-            <span
-              className="emotion-2"
+            <div
+              className="emotion-3"
             >
-              <Icon
-                color="#FFF"
-                shape="system-minus"
-                size="16px"
+              <input
+                aria-describedBy=""
+                aria-invalid={false}
+                className="emotion-0"
+                data-cy="checkboxInput-input checkboxInput-input.indeterminate"
+                id="indeterminateId"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                type="checkbox"
+                value="indeterminate"
+              />
+              <span
+                className="emotion-2"
               >
-                <svg
-                  aria-label="system-minus icon"
-                  className="emotion-1"
-                  data-cy="icon"
-                  height={16}
-                  preserveAspectRatio="xMinYMin meet"
-                  role="img"
-                  viewBox="0 0 16 16"
-                  width={16}
+                <Icon
+                  color="#FFF"
+                  shape="system-minus"
+                  size="16px"
                 >
-                  <use
-                    xlinkHref="#system-minus"
-                  />
-                </svg>
-              </Icon>
-            </span>
+                  <svg
+                    aria-label="system-minus icon"
+                    className="emotion-1"
+                    data-cy="icon"
+                    height={16}
+                    preserveAspectRatio="xMinYMin meet"
+                    role="img"
+                    viewBox="0 0 16 16"
+                    width={16}
+                  >
+                    <use
+                      xlinkHref="#system-minus"
+                    />
+                  </svg>
+                </Icon>
+              </span>
+            </div>
           </div>
-        </div>
-        <div
-          className="emotion-5"
-        >
-          Sample Label
-        </div>
-      </label>
-    </div>
-  </ToggleInput>
+          <div
+            className="emotion-5"
+          >
+            Sample Label
+          </div>
+        </label>
+      </div>
+    </ToggleInput>
+  </FormFieldWrapper>
 </CheckboxInput>
 `;
 
@@ -576,8 +607,8 @@ exports[`CheckboxInput renders with a hidden label 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -650,45 +681,53 @@ exports[`CheckboxInput renders with a hidden label 1`] = `
   showInputLabel={false}
   value="default"
 >
-  <ToggleInput
-    appearance="standard"
-    dataCy="checkboxInput"
+  <FormFieldWrapper
     id="hiddenLabel"
-    inputLabel="Sample Label"
-    showInputLabel={false}
-    vertAlign="center"
   >
-    <div
-      data-cy="checkboxInput"
+    <ToggleInput
+      appearance="standard"
+      dataCy="checkboxInput"
+      errorContent={null}
+      hintContent={null}
+      id="hiddenLabel"
+      inputLabel="Sample Label"
+      showInputLabel={false}
+      vertAlign="center"
     >
-      <label
-        className="emotion-4"
-        htmlFor="hiddenLabel"
+      <div
+        data-cy="checkboxInput"
       >
-        <div
-          className="emotion-2"
+        <label
+          className="emotion-4"
+          htmlFor="hiddenLabel"
         >
           <div
-            className="emotion-1"
+            className="emotion-2"
           >
-            <input
-              className="emotion-0"
-              data-cy="checkboxInput-input"
-              id="hiddenLabel"
-              onBlur={[Function]}
-              onFocus={[Function]}
-              type="checkbox"
-              value="default"
-            />
+            <div
+              className="emotion-1"
+            >
+              <input
+                aria-describedBy=""
+                aria-invalid={false}
+                className="emotion-0"
+                data-cy="checkboxInput-input"
+                id="hiddenLabel"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                type="checkbox"
+                value="default"
+              />
+            </div>
           </div>
-        </div>
-        <div
-          className="emotion-3"
-        >
-          Sample Label
-        </div>
-      </label>
-    </div>
-  </ToggleInput>
+          <div
+            className="emotion-3"
+          >
+            Sample Label
+          </div>
+        </label>
+      </div>
+    </ToggleInput>
+  </FormFieldWrapper>
 </CheckboxInput>
 `;

--- a/packages/shared/components/FormFieldWrapper.tsx
+++ b/packages/shared/components/FormFieldWrapper.tsx
@@ -13,9 +13,9 @@ import {
 import { themeError } from "../../design-tokens/build/js/designTokens";
 
 interface RenderProps {
+  describedByIds: string;
   getValidationErrors: React.ReactNode;
   getHintContent: React.ReactNode;
-  describedByIds: string;
   isValid: boolean;
 }
 

--- a/packages/shared/styles/formStyles.ts
+++ b/packages/shared/styles/formStyles.ts
@@ -9,7 +9,8 @@ import {
   themeBrandPrimary,
   themeError,
   themeBgDisabled,
-  iconSizeXs
+  iconSizeXs,
+  spaceS
 } from "../../design-tokens/build/js/designTokens";
 
 import {
@@ -27,14 +28,23 @@ const getFocusFieldBg = color => hexToRgbA(color, 0.05);
 const toggleInputHeight = 16;
 const toggleInputBorderWidth = 1;
 export const textInputHeight = 36;
+const toggleInputTextPadding = spaceS;
 
 export const toggleInput = css`
   border-color: ${themeBorder};
   background-color: ${themeBgPrimary};
   border-style: solid;
   border-width: ${toggleInputBorderWidth}px;
-  height: ${toggleInputHeight - toggleInputBorderWidth}px;
-  width: ${toggleInputHeight - toggleInputBorderWidth}px;
+  height: ${toggleInputHeight - toggleInputBorderWidth * 2}px;
+  width: ${toggleInputHeight - toggleInputBorderWidth * 2}px;
+`;
+
+export const toggleInputLabel = css`
+  padding-left: ${toggleInputTextPadding};
+`;
+
+export const toggleInputFeedbackText = css`
+  padding-left: ${toggleInputHeight + parseInt(toggleInputTextPadding, 10)}px;
 `;
 
 export const toggleInputApperances = {

--- a/packages/table/components/CheckboxTable.tsx
+++ b/packages/table/components/CheckboxTable.tsx
@@ -46,7 +46,7 @@ class CheckboxTable extends React.PureComponent<
 
     return {
       headerChecked:
-        Object.keys(selectedRows).length &&
+        Boolean(Object.keys(selectedRows).length) &&
         Object.keys(selectedRows).length ===
           data.length - Object.keys(disabledRows).length
     };

--- a/packages/table/tests/CheckboxTable.test.tsx
+++ b/packages/table/tests/CheckboxTable.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { CheckboxTable, Column } from "../";
 import * as emotion from "emotion";
 import { createSerializer } from "jest-emotion";
-import { shallow, render } from "enzyme";
+import { shallow, render, mount } from "enzyme";
 import toJson from "enzyme-to-json";
 
 expect.addSnapshotSerializer(createSerializer(emotion));
@@ -144,7 +144,7 @@ describe("CheckboxTable", () => {
       .prop("cellRenderer")(items[0], 100) as React.ReactElement<{
       children: any;
     }>;
-    const checkbox = shallow(cellRendererResult.props.children).find("input");
+    const checkbox = mount(cellRendererResult.props.children).find("input");
 
     expect(onChangeFn).not.toHaveBeenCalled();
     checkbox.simulate("change", { target: { checked: true } });

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -164,8 +164,8 @@ Array [
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -310,7 +310,8 @@ Array [
                               class="emotion-1"
                             >
                               <input
-                                aria-checked="0"
+                                aria-describedby=""
+                                aria-invalid="false"
                                 class="emotion-0"
                                 data-cy="checkboxInput-input"
                                 id="headerCheckbox"
@@ -488,7 +489,8 @@ Array [
                           class="emotion-1"
                         >
                           <input
-                            aria-checked="false"
+                            aria-describedby=""
+                            aria-invalid="false"
                             class="emotion-0"
                             data-cy="checkboxInput-input"
                             id="0"
@@ -539,7 +541,8 @@ Array [
                           class="emotion-1"
                         >
                           <input
-                            aria-checked="false"
+                            aria-describedby=""
+                            aria-invalid="false"
                             class="emotion-0"
                             data-cy="checkboxInput-input"
                             id="1"
@@ -848,8 +851,8 @@ Array [
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -945,8 +948,8 @@ Array [
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
   background-color: var(--themeBrandPrimary,#7D58FF);
@@ -1053,7 +1056,8 @@ Array [
                               class="emotion-3"
                             >
                               <input
-                                aria-checked="mixed"
+                                aria-describedby=""
+                                aria-invalid="false"
                                 class="emotion-0"
                                 data-cy="checkboxInput-input checkboxInput-input.indeterminate"
                                 id="headerCheckbox"
@@ -1249,7 +1253,8 @@ Array [
                           class="emotion-3"
                         >
                           <input
-                            aria-checked="true"
+                            aria-describedby=""
+                            aria-invalid="false"
                             checked=""
                             class="emotion-0"
                             data-cy="checkboxInput-input checkboxInput-input.checked"
@@ -1319,7 +1324,8 @@ Array [
                           class="emotion-46"
                         >
                           <input
-                            aria-checked="false"
+                            aria-describedby=""
+                            aria-invalid="false"
                             class="emotion-0"
                             data-cy="checkboxInput-input"
                             id="1"
@@ -1628,8 +1634,8 @@ Array [
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -1792,7 +1798,8 @@ Array [
                               class="emotion-1"
                             >
                               <input
-                                aria-checked="0"
+                                aria-describedby=""
+                                aria-invalid="false"
                                 class="emotion-0"
                                 data-cy="checkboxInput-input"
                                 id="headerCheckbox"
@@ -1986,7 +1993,8 @@ Array [
                           class="emotion-1"
                         >
                           <input
-                            aria-checked="false"
+                            aria-describedby=""
+                            aria-invalid="false"
                             class="emotion-0"
                             data-cy="checkboxInput-input"
                             id="1"

--- a/packages/toggleInput/components/ToggleInput.tsx
+++ b/packages/toggleInput/components/ToggleInput.tsx
@@ -4,7 +4,6 @@ import { cx } from "emotion";
 import {
   flex,
   flexItem,
-  padding,
   visuallyHidden,
   display,
   tintContent,
@@ -16,6 +15,10 @@ import {
 } from "../../design-tokens/build/js/designTokens";
 import { CheckboxInputProps } from "../../checkboxInput/components/CheckboxInput";
 import { InputAppearance } from "../../shared/types/inputAppearance";
+import {
+  toggleInputFeedbackText,
+  toggleInputLabel
+} from "../../shared/styles/formStyles";
 
 export interface ToggleInputProps extends React.HTMLProps<HTMLInputElement> {
   /**
@@ -50,10 +53,20 @@ export interface ToggleInputProps extends React.HTMLProps<HTMLInputElement> {
    * human-readable selector used for writing tests
    */
   dataCy?: string;
+  /**
+   * hintContent is text or a ReactNode that is displayed directly under the input with additional information about the expected input.
+   */
+  hintContent?: React.ReactNode;
+  /**
+   * Sets the contents for validation errors. This will be displayed below the input element. Errors are only visible when the `TextInput` appearance is also set to `TextInputAppearance.Error`.
+   */
+  errors?: React.ReactNode[];
 }
 
 interface LocalToggleInputProps extends ToggleInputProps {
   children: React.ReactElement<CheckboxInputProps>; // TODO: accept radio and toggle switch components when we have them
+  errorContent: React.ReactNode | string;
+  hintContent: React.ReactNode | string;
 }
 
 class ToggleInput extends React.PureComponent<LocalToggleInputProps, {}> {
@@ -67,6 +80,8 @@ class ToggleInput extends React.PureComponent<LocalToggleInputProps, {}> {
       appearance,
       children,
       disabled,
+      errorContent,
+      hintContent,
       id,
       inputLabel,
       showInputLabel,
@@ -89,7 +104,7 @@ class ToggleInput extends React.PureComponent<LocalToggleInputProps, {}> {
             {children}
           </div>
           <div
-            className={cx(flexItem("grow"), padding("left", "s"), {
+            className={cx(flexItem("grow"), toggleInputLabel, {
               [visuallyHidden]: !showInputLabel,
               [tintContent(themeError)]: appearance === InputAppearance.Error,
               [tintContent(themeSuccess)]:
@@ -100,6 +115,12 @@ class ToggleInput extends React.PureComponent<LocalToggleInputProps, {}> {
             {inputLabel}
           </div>
         </label>
+        {hintContent && (
+          <div className={toggleInputFeedbackText}>
+            {hintContent}
+            {appearance === InputAppearance.Error && errorContent}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/toggleInputList/components/ToggleInputList.tsx
+++ b/packages/toggleInputList/components/ToggleInputList.tsx
@@ -19,6 +19,8 @@ export interface ToggleInputProperties {
   id: string;
   value: string;
   disabled?: boolean;
+  errors?: React.ReactNode[];
+  hintContent?: React.ReactNode;
 }
 
 export interface ToggleInputListProps {
@@ -128,7 +130,15 @@ class ToggleInputList extends React.PureComponent<ToggleInputListProps, {}> {
     const { items } = this.props;
 
     return items.map(item => {
-      const { id, value, inputLabel, appearance, disabled } = item;
+      const {
+        id,
+        value,
+        inputLabel,
+        appearance,
+        disabled,
+        errors,
+        hintContent
+      } = item;
       const { vertAlign, onChange } = this.props;
       const selectedItems = this.props.selectedItems || [];
 
@@ -151,6 +161,8 @@ class ToggleInputList extends React.PureComponent<ToggleInputListProps, {}> {
             value={value}
             vertAlign={vertAlign}
             checked={selectedItems.includes(value)}
+            errors={errors}
+            hintContent={hintContent}
           />
         </li>
       );

--- a/packages/toggleInputList/tests/__snapshots__/ToggleInputList.test.tsx.snap
+++ b/packages/toggleInputList/tests/__snapshots__/ToggleInputList.test.tsx.snap
@@ -45,8 +45,8 @@ exports[`ToggleInputList renders default 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -160,49 +160,56 @@ exports[`ToggleInputList renders default 1`] = `
             value="value.1"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.1"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.1"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.1"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.1"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.1"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.1"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -218,49 +225,56 @@ exports[`ToggleInputList renders default 1`] = `
             value="value.2"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.2"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.2"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.2"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.2"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.2"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.2"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.2"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.2"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -276,49 +290,56 @@ exports[`ToggleInputList renders default 1`] = `
             value="value.3"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.3"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.3"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.3"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.3"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.3"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.3"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.3"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.3"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
       </ul>
@@ -363,8 +384,8 @@ exports[`ToggleInputList renders with error label appearance 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -515,49 +536,56 @@ exports[`ToggleInputList renders with error label appearance 1`] = `
             value="value.1"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.1"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.1"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.1"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.1"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.1"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.1"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -573,49 +601,56 @@ exports[`ToggleInputList renders with error label appearance 1`] = `
             value="value.2"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.2"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.2"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.2"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.2"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.2"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.2"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.2"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.2"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -631,49 +666,56 @@ exports[`ToggleInputList renders with error label appearance 1`] = `
             value="value.3"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.3"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.3"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.3"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.3"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.3"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.3"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.3"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.3"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
       </ul>
@@ -745,8 +787,8 @@ exports[`ToggleInputList renders with errors 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -886,49 +928,56 @@ exports[`ToggleInputList renders with errors 1`] = `
             value="value.1"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.1"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.1"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.1"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.1"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.1"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.1"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -944,49 +993,56 @@ exports[`ToggleInputList renders with errors 1`] = `
             value="value.2"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.2"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.2"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.2"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.2"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.2"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.2"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.2"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.2"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -1002,49 +1058,56 @@ exports[`ToggleInputList renders with errors 1`] = `
             value="value.3"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.3"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.3"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.3"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.3"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.3"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.3"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.3"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.3"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
       </ul>
@@ -1107,8 +1170,8 @@ exports[`ToggleInputList renders with hidden label 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -1235,49 +1298,56 @@ exports[`ToggleInputList renders with hidden label 1`] = `
             value="value.1"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.1"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.1"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.1"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.1"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.1"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.1"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -1293,49 +1363,56 @@ exports[`ToggleInputList renders with hidden label 1`] = `
             value="value.2"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.2"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.2"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.2"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.2"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.2"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.2"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.2"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.2"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -1351,49 +1428,56 @@ exports[`ToggleInputList renders with hidden label 1`] = `
             value="value.3"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.3"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.3"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-5"
-                  htmlFor="id.3"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-3"
+                  <label
+                    className="emotion-5"
+                    htmlFor="id.3"
                   >
                     <div
-                      className="emotion-2"
+                      className="emotion-3"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.3"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.3"
-                      />
+                      <div
+                        className="emotion-2"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.3"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.3"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-4"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-4"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
       </ul>
@@ -1447,8 +1531,8 @@ exports[`ToggleInputList renders with required 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -1598,49 +1682,56 @@ exports[`ToggleInputList renders with required 1`] = `
             value="value.1"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.1"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.1"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-6"
-                  htmlFor="id.1"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-4"
+                  <label
+                    className="emotion-6"
+                    htmlFor="id.1"
                   >
                     <div
-                      className="emotion-3"
+                      className="emotion-4"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-2"
-                        data-cy="checkboxInput-input"
-                        id="id.1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.1"
-                      />
+                      <div
+                        className="emotion-3"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-2"
+                          data-cy="checkboxInput-input"
+                          id="id.1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.1"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-5"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-5"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -1656,49 +1747,56 @@ exports[`ToggleInputList renders with required 1`] = `
             value="value.2"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.2"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.2"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-6"
-                  htmlFor="id.2"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-4"
+                  <label
+                    className="emotion-6"
+                    htmlFor="id.2"
                   >
                     <div
-                      className="emotion-3"
+                      className="emotion-4"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-2"
-                        data-cy="checkboxInput-input"
-                        id="id.2"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.2"
-                      />
+                      <div
+                        className="emotion-3"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-2"
+                          data-cy="checkboxInput-input"
+                          id="id.2"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.2"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-5"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-5"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -1714,49 +1812,56 @@ exports[`ToggleInputList renders with required 1`] = `
             value="value.3"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.3"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.3"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-6"
-                  htmlFor="id.3"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-4"
+                  <label
+                    className="emotion-6"
+                    htmlFor="id.3"
                   >
                     <div
-                      className="emotion-3"
+                      className="emotion-4"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-2"
-                        data-cy="checkboxInput-input"
-                        id="id.3"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.3"
-                      />
+                      <div
+                        className="emotion-3"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-2"
+                          data-cy="checkboxInput-input"
+                          id="id.3"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.3"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-5"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-5"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
       </ul>
@@ -1810,8 +1915,8 @@ exports[`ToggleInputList renders with selected items 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
 }
@@ -1873,8 +1978,8 @@ exports[`ToggleInputList renders with selected items 1`] = `
   background-color: var(--themeBgPrimary,#FFFFFF);
   border-style: solid;
   border-width: 1px;
-  height: 15px;
-  width: 15px;
+  height: 14px;
+  width: 14px;
   border-radius: 4px;
   position: relative;
   background-color: var(--themeBrandPrimary,#7D58FF);
@@ -1969,73 +2074,80 @@ exports[`ToggleInputList renders with selected items 1`] = `
             value="value.1"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput checkboxInput.checked"
+            <FormFieldWrapper
               id="id.1"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput checkboxInput.checked"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput checkboxInput.checked"
+                errorContent={null}
+                hintContent={null}
+                id="id.1"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-7"
-                  htmlFor="id.1"
+                <div
+                  data-cy="checkboxInput checkboxInput.checked"
                 >
-                  <div
-                    className="emotion-5"
+                  <label
+                    className="emotion-7"
+                    htmlFor="id.1"
                   >
                     <div
-                      className="emotion-4"
+                      className="emotion-5"
                     >
-                      <input
-                        aria-checked={true}
-                        checked={true}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input checkboxInput-input.checked"
-                        id="id.1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.1"
-                      />
-                      <span
-                        className="emotion-3"
+                      <div
+                        className="emotion-4"
                       >
-                        <Icon
-                          color="#FFF"
-                          shape="system-check"
-                          size="16px"
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={true}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input checkboxInput-input.checked"
+                          id="id.1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.1"
+                        />
+                        <span
+                          className="emotion-3"
                         >
-                          <svg
-                            aria-label="system-check icon"
-                            className="emotion-2"
-                            data-cy="icon"
-                            height={16}
-                            preserveAspectRatio="xMinYMin meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
+                          <Icon
+                            color="#FFF"
+                            shape="system-check"
+                            size="16px"
                           >
-                            <use
-                              xlinkHref="#system-check"
-                            />
-                          </svg>
-                        </Icon>
-                      </span>
+                            <svg
+                              aria-label="system-check icon"
+                              className="emotion-2"
+                              data-cy="icon"
+                              height={16}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width={16}
+                            >
+                              <use
+                                xlinkHref="#system-check"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-6"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-6"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -2051,73 +2163,80 @@ exports[`ToggleInputList renders with selected items 1`] = `
             value="value.2"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput checkboxInput.checked"
+            <FormFieldWrapper
               id="id.2"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput checkboxInput.checked"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput checkboxInput.checked"
+                errorContent={null}
+                hintContent={null}
+                id="id.2"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-7"
-                  htmlFor="id.2"
+                <div
+                  data-cy="checkboxInput checkboxInput.checked"
                 >
-                  <div
-                    className="emotion-5"
+                  <label
+                    className="emotion-7"
+                    htmlFor="id.2"
                   >
                     <div
-                      className="emotion-4"
+                      className="emotion-5"
                     >
-                      <input
-                        aria-checked={true}
-                        checked={true}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input checkboxInput-input.checked"
-                        id="id.2"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.2"
-                      />
-                      <span
-                        className="emotion-3"
+                      <div
+                        className="emotion-4"
                       >
-                        <Icon
-                          color="#FFF"
-                          shape="system-check"
-                          size="16px"
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={true}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input checkboxInput-input.checked"
+                          id="id.2"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.2"
+                        />
+                        <span
+                          className="emotion-3"
                         >
-                          <svg
-                            aria-label="system-check icon"
-                            className="emotion-2"
-                            data-cy="icon"
-                            height={16}
-                            preserveAspectRatio="xMinYMin meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width={16}
+                          <Icon
+                            color="#FFF"
+                            shape="system-check"
+                            size="16px"
                           >
-                            <use
-                              xlinkHref="#system-check"
-                            />
-                          </svg>
-                        </Icon>
-                      </span>
+                            <svg
+                              aria-label="system-check icon"
+                              className="emotion-2"
+                              data-cy="icon"
+                              height={16}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width={16}
+                            >
+                              <use
+                                xlinkHref="#system-check"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-6"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-6"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
         <li
@@ -2133,49 +2252,56 @@ exports[`ToggleInputList renders with selected items 1`] = `
             value="value.3"
             vertAlign="center"
           >
-            <ToggleInput
-              appearance="standard"
-              dataCy="checkboxInput"
+            <FormFieldWrapper
               id="id.3"
-              inputLabel="Sample label"
-              showInputLabel={true}
-              vertAlign="center"
             >
-              <div
-                data-cy="checkboxInput"
+              <ToggleInput
+                appearance="standard"
+                dataCy="checkboxInput"
+                errorContent={null}
+                hintContent={null}
+                id="id.3"
+                inputLabel="Sample label"
+                showInputLabel={true}
+                vertAlign="center"
               >
-                <label
-                  className="emotion-7"
-                  htmlFor="id.3"
+                <div
+                  data-cy="checkboxInput"
                 >
-                  <div
-                    className="emotion-5"
+                  <label
+                    className="emotion-7"
+                    htmlFor="id.3"
                   >
                     <div
-                      className="emotion-18"
+                      className="emotion-5"
                     >
-                      <input
-                        aria-checked={false}
-                        checked={false}
-                        className="emotion-1"
-                        data-cy="checkboxInput-input"
-                        id="id.3"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value="value.3"
-                      />
+                      <div
+                        className="emotion-18"
+                      >
+                        <input
+                          aria-describedBy=""
+                          aria-invalid={false}
+                          checked={false}
+                          className="emotion-1"
+                          data-cy="checkboxInput-input"
+                          id="id.3"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value="value.3"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    className="emotion-6"
-                  >
-                    Sample label
-                  </div>
-                </label>
-              </div>
-            </ToggleInput>
+                    <div
+                      className="emotion-6"
+                    >
+                      Sample label
+                    </div>
+                  </label>
+                </div>
+              </ToggleInput>
+            </FormFieldWrapper>
           </CheckboxInput>
         </li>
       </ul>


### PR DESCRIPTION
I asked the design team about this pattern:
<img width="1118" alt="screen shot 2019-01-29 at 6 43 38 pm" src="https://user-images.githubusercontent.com/2313998/51948338-1b645d00-23f6-11e9-9606-ae5dca6488a8.png">

They said clicking the hint text should not toggle the input. I made it possible to pass `hintContent` to an individual `CheckboxInput`, and automatically render the correct styling and functionality.
This might have been annoying to do manually in a consumer application, and prone to layout bugs if we changed the size of the toggle input.