### PR TITLE
AppChrome fix: content/sidebar height

### DIFF
--- a/packages/appChrome/components/AppChrome.tsx
+++ b/packages/appChrome/components/AppChrome.tsx
@@ -19,7 +19,9 @@ class AppChrome extends React.PureComponent<AppChromeProps, {}> {
     const { sidebar, headerBar, mainContent } = this.props;
 
     return (
-      <div className={cx(appChrome, textSize("m"))}>
+      <div
+        className={cx(appChrome, textSize("m"), flex({ direction: "column" }))}
+      >
         <div className="headerBar">{headerBar}</div>
         <div className={cx(flex(), appWrapper)}>
           <div className={flexItem("shrink")}>{sidebar}</div>

--- a/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
@@ -5,6 +5,15 @@ exports[`AppChrome renders with the app chrome regions 1`] = `
   height: 100%;
   overflow: hidden;
   font-size: 14px;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .emotion-2 {


### PR DESCRIPTION
Before, the `height: 100%` on the sidebar and the main content area was setting the elements to be the full height of their parent.

Now, they only fill the available space after accounting for headerbar height because the headerbar and the div that wraps the sidebar and main content area are in a flex container.