### PR TITLE
DCOS-46403: allow table row heights other than default

### DIFF
--- a/packages/shared/styles/styleUtils/index.ts
+++ b/packages/shared/styles/styleUtils/index.ts
@@ -17,6 +17,7 @@ export { inputReset } from "./resets/inputReset";
 export { liReset } from "./resets/liReset";
 export { margin, marginAt } from "./modifiers/margin";
 export { padding } from "./modifiers/padding";
+export { vAlignChildren } from "./modifiers/vAlignChildren";
 export { visuallyHidden } from "./modifiers/visuallyHidden";
 export { textSize } from "./typography/textSize";
 export { textWeight } from "./typography/weight";

--- a/packages/shared/styles/styleUtils/modifiers/vAlignChildren.ts
+++ b/packages/shared/styles/styleUtils/modifiers/vAlignChildren.ts
@@ -1,0 +1,7 @@
+import { css } from "emotion";
+
+export const vAlignChildren = css`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -31,6 +31,8 @@ Organize columns and rows based on the needs of the users. For collection tables
 
 5. Row hover state: On mouse over of a row on the table, the row should be highlighted to help the user focus in on the row details and match data they are seeing within that row.
 
+6. We have a default row height that can be changed to accomodate for taller content, but this should only be used a last resort. Before making a row taller than the default height, try adjusting your design to fit on one line/fit within the default height.
+
 ## Column Alignment
 
 For Collection tables, content should be left aligned except when using a different alignment helps with comprehension. For example,numeric data is easier to read when it’s right aligned. Column headers should match the content alignment.

--- a/packages/table/components/CheckboxTable.tsx
+++ b/packages/table/components/CheckboxTable.tsx
@@ -24,6 +24,7 @@ class CheckboxTable extends React.PureComponent<CheckboxTableProps> {
       <Table
         data={this.props.data}
         selectedRows={this.props.selectedRows}
+        rowHeight={this.props.rowHeight}
         fixedColumnCount={2}
       >
         <Column

--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -19,6 +19,7 @@ import {
 
 import { ColumnProps, Column } from "./Column";
 import memoizeOne from "memoize-one";
+import { vAlignChildren } from "../../shared/styles/styleUtils";
 
 export interface TableProps {
   /**
@@ -39,6 +40,10 @@ export interface TableProps {
    * Selected row data
    */
   selectedRows?: object[];
+  /**
+   * Set the row height
+   */
+  rowHeight?: number;
 }
 
 export interface TableState {
@@ -155,7 +160,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
   );
 
   private cellMeasureCache = new CellMeasurerCache({
-    defaultHeight: ROW_HEIGHT,
+    defaultHeight: this.props.rowHeight || ROW_HEIGHT,
     defaultWidth: 150,
     fixedHeight: true
   });
@@ -240,7 +245,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
         enableFixedColumnScroll={true}
         enableFixedRowScroll={true}
         height={height}
-        rowHeight={ROW_HEIGHT}
+        rowHeight={this.props.rowHeight || ROW_HEIGHT}
         rowCount={this.props.data.length + 1}
         width={width}
         hideTopRightGridScrollbar={true}
@@ -259,7 +264,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
   ) {
     const { key, style, column } = args;
     return (
-      <div className={headerCss} style={style} key={key}>
+      <div className={cx(headerCss, vAlignChildren)} style={style} key={key}>
         {column.props.header}
       </div>
     );
@@ -313,7 +318,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
     return (
       /* tslint:disable:react-a11y-event-has-role */
       <div
-        className={cx(cellCss, {
+        className={cx(cellCss, vAlignChildren, {
           [rowHoverCss]:
             rowIndex === this.state.hoveredRowIndex ||
             selectedRows.includes(data[rowIndex])

--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -309,4 +309,43 @@ storiesOf("Table", module)
         />
       </Table>
     </div>
+  ))
+  .addWithInfo("with custom row height", () => (
+    <div
+      style={{
+        height: "300px",
+        width: "100%",
+        fontSize: "14px"
+      }}
+    >
+      <Table data={items} rowHeight={60}>
+        <Column
+          header={<HeaderCell>name</HeaderCell>}
+          cellRenderer={nameCellRenderer}
+        />
+        <Column
+          header={<HeaderCell>role</HeaderCell>}
+          cellRenderer={roleCellRenderer}
+          growToFill={true}
+        />
+        <Column
+          header={<HeaderCell>state</HeaderCell>}
+          cellRenderer={stateCellRenderer}
+        />
+        <Column
+          header={<HeaderCell>Very Long</HeaderCell>}
+          cellRenderer={veryLongRenderer}
+          maxWidth={300}
+        />
+        <Column
+          header={<HeaderCell textAlign="right">zip code</HeaderCell>}
+          cellRenderer={zipcodeCellRenderer}
+        />
+        <Column
+          header={<HeaderCell>city</HeaderCell>}
+          cellRenderer={cityCellRenderer}
+          growToFill={true}
+        />
+      </Table>
+    </div>
   ));

--- a/packages/table/style.ts
+++ b/packages/table/style.ts
@@ -29,7 +29,8 @@ export const cellCss = css`
 `;
 
 export const innerCellCss = css`
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: ${cellPadding}px;
 `;

--- a/packages/table/tests/__snapshots__/Cell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Cell.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`Cell renders correctly 1`] = `
 .emotion-0 {
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: 7px;
   text-align: left;
@@ -17,7 +18,8 @@ exports[`Cell renders correctly 1`] = `
 
 exports[`HeaderCell renders correctly 1`] = `
 .emotion-0 {
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: 7px;
   text-align: left;
@@ -34,7 +36,8 @@ exports[`HeaderCell renders correctly 1`] = `
 
 exports[`TextCell renders correctly 1`] = `
 .emotion-0 {
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: 7px;
   text-align: left;

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CheckboxTable renders default 1`] = `
-.emotion-6 {
-  box-sizing: border-box;
-  border-top: 1px solid #000;
-  border-bottom: 1px solid #000;
-}
-
-.emotion-19 {
-  box-sizing: border-box;
-  border-bottom: 1px solid #DADDE2;
-  white-space: nowrap;
-}
-
 .emotion-38 {
   font-weight: normal;
 }
@@ -47,8 +35,26 @@ exports[`CheckboxTable renders default 1`] = `
   height: 1px;
 }
 
+.emotion-6 {
+  box-sizing: border-box;
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 .emotion-5 {
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: 7px;
   text-align: left;
@@ -122,8 +128,26 @@ exports[`CheckboxTable renders default 1`] = `
   height: 1px;
 }
 
+.emotion-19 {
+  box-sizing: border-box;
+  border-bottom: 1px solid #DADDE2;
+  white-space: nowrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 .emotion-18 {
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: 7px;
   text-align: left;
@@ -431,18 +455,6 @@ exports[`CheckboxTable renders default 1`] = `
 `;
 
 exports[`CheckboxTable renders with checked row 1`] = `
-.emotion-8 {
-  box-sizing: border-box;
-  border-top: 1px solid #000;
-  border-bottom: 1px solid #000;
-}
-
-.emotion-31 {
-  box-sizing: border-box;
-  border-bottom: 1px solid #DADDE2;
-  white-space: nowrap;
-}
-
 .emotion-42 {
   font-weight: normal;
 }
@@ -477,8 +489,26 @@ exports[`CheckboxTable renders with checked row 1`] = `
   height: 1px;
 }
 
+.emotion-8 {
+  box-sizing: border-box;
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 .emotion-7 {
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: 7px;
   text-align: left;
@@ -552,8 +582,26 @@ exports[`CheckboxTable renders with checked row 1`] = `
   height: 1px;
 }
 
+.emotion-31 {
+  box-sizing: border-box;
+  border-bottom: 1px solid #DADDE2;
+  white-space: nowrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 .emotion-22 {
-  height: 100%;
+  display: inline-block;
+  height: auto;
   box-sizing: border-box;
   padding: 7px;
   text-align: left;
@@ -601,6 +649,17 @@ exports[`CheckboxTable renders with checked row 1`] = `
   box-sizing: border-box;
   border-bottom: 1px solid #DADDE2;
   white-space: nowrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #F7F8F9;
   mix-blend-mode: multiply;
   will-change: left;

--- a/packages/table/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Table.test.tsx.snap
@@ -165,18 +165,6 @@ exports[`Table renders again with new data 2`] = `
 `;
 
 exports[`Table renders default 1`] = `
-.emotion-0 {
-  box-sizing: border-box;
-  border-top: 1px solid #000;
-  border-bottom: 1px solid #000;
-}
-
-.emotion-5 {
-  box-sizing: border-box;
-  border-bottom: 1px solid #DADDE2;
-  white-space: nowrap;
-}
-
 .emotion-14 {
   font-weight: normal;
 }
@@ -197,6 +185,40 @@ exports[`Table renders default 1`] = `
 
 .emotion-4::-webkit-scrollbar {
   display: none;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-5 {
+  box-sizing: border-box;
+  border-bottom: 1px solid #DADDE2;
+  white-space: nowrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 <div
@@ -374,18 +396,6 @@ exports[`Table renders default 1`] = `
 `;
 
 exports[`Table renders with growToFill cols 1`] = `
-.emotion-0 {
-  box-sizing: border-box;
-  border-top: 1px solid #000;
-  border-bottom: 1px solid #000;
-}
-
-.emotion-6 {
-  box-sizing: border-box;
-  border-bottom: 1px solid #DADDE2;
-  white-space: nowrap;
-}
-
 .emotion-17 {
   font-weight: normal;
 }
@@ -406,6 +416,40 @@ exports[`Table renders with growToFill cols 1`] = `
 
 .emotion-5::-webkit-scrollbar {
   display: none;
+}
+
+.emotion-0 {
+  box-sizing: border-box;
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  border-bottom: 1px solid #DADDE2;
+  white-space: nowrap;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
 }
 
 <div


### PR DESCRIPTION
Before this, table rows could only be the default height, 35px

Table rows that are 60px high:
![screen shot 2019-02-07 at 3 22 08 pm](https://user-images.githubusercontent.com/2313998/52440986-7defe400-2aed-11e9-9c6e-11976195fe37.png)
