### PR TITLE
Remove children prop type from Sidebar

### DIFF
--- a/packages/appChrome/components/Sidebar.tsx
+++ b/packages/appChrome/components/Sidebar.tsx
@@ -8,7 +8,6 @@ import { atMediaUp } from "../../shared/styles/breakpoints";
 import { isHexDark } from "../../shared/styles/color";
 
 export interface SidebarProps {
-  children: React.ReactElement<HTMLElement> | string;
   isOpen: boolean;
   onOpen?: () => void;
   onClose?: () => void;

--- a/packages/appChrome/components/SidebarItem.tsx
+++ b/packages/appChrome/components/SidebarItem.tsx
@@ -7,7 +7,6 @@ import { tintContentPrimary } from "../../shared/styles/styleUtils";
 import { spaceSizes } from "../../../packages/shared/styles/styleUtils/modifiers/modifierUtils";
 
 export interface SidebarItemProps {
-  children?: React.ReactElement<HTMLElement> | string;
   icon?: React.ReactElement<HTMLElement> | string;
   isActive?: boolean;
   onClick: (event?: React.SyntheticEvent<HTMLElement>) => void;


### PR DESCRIPTION
It is too strict and we don't do any operations with `children` prop. We don't map it, nor filter, neither we enforce a specific type of a child.

Other alternative would be to use type from React that cover all possible types of a child.

Without this change this code https://github.com/dcos-labs/ui-shell-app/blob/19be4a16844a4dc67d1a2b30e707a373f27f7cae/src/components/AppSidebar.tsx#L20 fails with

```
[tsl] ERROR in /src/components/AppSidebar.tsx(30,11)
      TS2322: Type '{ children: Element[]; isOpen: boolean; }' is not assignable to type 'Readonly<SidebarProps>'.
  Types of property 'children' are incompatible.
    Type 'Element[]' is not assignable to type 'string | ReactElement<HTMLElement>'.
      Type 'Element[]' is not assignable to type 'ReactElement<HTMLElement>'.
        Property 'type' is missing in type 'Element[]'.
```