### PR TITLE
remove unreachable code

### DIFF
--- a/packages/appChrome/tests/AppChrome.test.tsx
+++ b/packages/appChrome/tests/AppChrome.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { shallow } from "enzyme";
 import * as emotion from "emotion";
 import { createSerializer } from "jest-emotion";

--- a/packages/design-tokens/scripts/transforms.js
+++ b/packages/design-tokens/scripts/transforms.js
@@ -28,22 +28,16 @@ const getPropNamePatterns = (prop, opts) => {
 const getFormattedName = (prop, namePatterns) => {
   const { category, type } = prop.attributes;
 
-  let name;
   switch (category) {
     case "color":
-      name = type !== "base" ? namePatterns.t_c_i_si : namePatterns.i_si_s;
-      break;
+      return type !== "base" ? namePatterns.t_c_i_si : namePatterns.i_si_s;
     case "layout":
-      name = namePatterns.t_i;
-      break;
+      return namePatterns.t_i;
     case "font":
-      name = namePatterns.c_t_i;
-      break;
+      return namePatterns.c_t_i;
     default:
-      name = namePatterns.c_t_i;
+      return namePatterns.c_t_i;
   }
-
-  return name;
 };
 
 const fontNameJS = {

--- a/packages/shared/styles/styleUtils/modifiers/modifierUtils.ts
+++ b/packages/shared/styles/styleUtils/modifiers/modifierUtils.ts
@@ -39,19 +39,16 @@ export const boxSpacing = (
   switch (side) {
     case "all":
       return `${property}: ${spaceSizes[size]};`;
-      break;
     case "horiz":
       return `
         ${property}-left: ${spaceSizes[size]};
         ${property}-right: ${spaceSizes[size]};
       `;
-      break;
     case "vert":
       return `
         ${property}-bottom: ${spaceSizes[size]};
         ${property}-top: ${spaceSizes[size]};
       `;
-      break;
     default:
       return `${property}-${side}: ${spaceSizes[size]};`;
   }

--- a/packages/toaster/components/Toast.tsx
+++ b/packages/toaster/components/Toast.tsx
@@ -104,13 +104,10 @@ class Toast extends React.PureComponent<ToastProps, {}> {
       switch (status) {
         case "danger":
           return <DangerIcon className={tintSVG(red)} />;
-          break;
         case "success":
           return <SuccessIcon className={tintSVG(green)} />;
-          break;
         case "warning":
           return <WarningIcon className={tintSVG(yellow)} />;
-          break;
       }
     };
 


### PR DESCRIPTION
no need to `break` after a `return`!

also fixes a type error saying that React has no default export.