### PR TITLE
DCOS-49609 refactor(Toaster): children as source-of-truth

### DIFF
--- a/packages/toaster/components/Toast.tsx
+++ b/packages/toaster/components/Toast.tsx
@@ -178,8 +178,7 @@ class Toast extends React.PureComponent<ToastProps, {}> {
     const { dismissToast, onDismiss, id } = this.props;
     if (dismissToast) {
       dismissToast(id);
-    }
-    if (onDismiss) {
+    } else if (onDismiss) {
       onDismiss(e);
     }
   }

--- a/packages/toaster/components/Toaster.tsx
+++ b/packages/toaster/components/Toaster.tsx
@@ -50,18 +50,18 @@ class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
   public componentWillReceiveProps(nextProps: ToasterProps) {
     const currentToasts = this.state.toasts || [];
     const childIds =
-      nextProps.children && nextProps.children.map(toast => toast.props.id);
+      (nextProps.children && nextProps.children.map(toast => toast.props.id)) ||
+      [];
     const currentIds = currentToasts.map(toast => toast.props.id);
 
     if (
       (childIds && !currentIds.every(e => childIds.includes(e))) ||
-      !currentIds.length
+      !currentIds.length ||
+      childIds.length !== currentIds.length
     ) {
       this.setState(
         () => ({
-          toasts:
-            currentToasts &&
-            currentToasts.concat(nextProps.children || []).map(this.cloneToast)
+          toasts: (nextProps.children || []).map(this.cloneToast)
         }),
         () => {
           if (this.state.toasts) {
@@ -86,9 +86,9 @@ class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
           className={listReset}
         >
           <TransitionGroup>
-            {toastsToRender.map((toast, i) => (
+            {toastsToRender.map(toast => (
               <Transition
-                key={`toastWrapper-${i}`}
+                key={`toastWrapper-${toast.props.id}`}
                 timeout={{ enter: 0, exit: animationDuration }}
               >
                 {state => {
@@ -113,6 +113,12 @@ class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
 
   public dismissToast(dismissedToastId: ToastId = "") {
     const currentToasts = this.state.toasts || [];
+    const toast = currentToasts.find(
+      toast => toast.props.id === dismissedToastId
+    );
+    if (toast && toast.props.onDismiss) {
+      toast.props.onDismiss();
+    }
     this.setState({
       toasts: currentToasts.filter(toast => dismissedToastId !== toast.props.id)
     });

--- a/packages/toaster/stories/Toaster.stories.tsx
+++ b/packages/toaster/stories/Toaster.stories.tsx
@@ -42,27 +42,43 @@ class ToasterContainer extends React.PureComponent<
     };
 
     this.addToast = this.addToast.bind(this);
+    this.removeToast = this.removeToast.bind(this);
   }
 
   addToast(toast: Array<React.ReactElement<ToastProps>>) {
     this.setState({
-      toasts: toast
+      toasts: this.state.toasts.concat(toast)
+    });
+  }
+
+  removeToast(toastId: string) {
+    const newToasts = this.state.toasts.filter(
+      toast => toast.props.id !== toastId
+    );
+    this.setState({
+      toasts: newToasts
     });
   }
 
   render() {
     const handleToastAdd = () => {
       const newToastId = addedToastId++;
+      const toastId = `toast-${newToastId + 1}`;
+      const dismissToast = dismissedToastId => {
+        this.removeToast(dismissedToastId);
+      };
       const newToast = [
         // tslint:disable:jsx-wrap-multiline
         <Toast
           autodismiss={true}
-          id={`toast-${newToastId + 1}`}
+          id={toastId}
           key={newToastId + 1}
           title={`New message ${newToastId + 1}`}
+          onDismiss={dismissToast.bind(this, toastId)}
         />
         // tslint:enable
       ];
+
       this.addToast(newToast);
     };
 
@@ -107,18 +123,7 @@ storiesOf("Toaster", module)
       ]}
     </Toaster>
   ))
-  .addWithInfo("autodismiss", () => (
-    <ToasterContainer>
-      {[
-        <Toast
-          title="Hover me or I'll disappear"
-          autodismiss={true}
-          key={0}
-          id="autodismiss"
-        />
-      ]}
-    </ToasterContainer>
-  ))
+  .addWithInfo("autodismiss", () => <ToasterContainer>{[]}</ToasterContainer>)
   .addWithInfo("with dismiss callback", () => (
     <Toaster>
       {[

--- a/packages/toaster/tests/Toast.test.tsx
+++ b/packages/toaster/tests/Toast.test.tsx
@@ -64,21 +64,14 @@ describe("Toast", () => {
     expect(action).toHaveBeenCalled();
   });
 
-  it("calls dismissToast and the onDismiss callback when the dismiss button is clicked", () => {
+  it("calls dismissToast when the dismiss button is clicked", () => {
     const dismissToastSpy = spyOn(Toaster.prototype, "dismissToast");
-    const onDismiss = jest.fn();
     const component = mount(
-      <Toaster
-        children={[
-          <Toast onDismiss={onDismiss} title="I Am Toast" key={0} id={0} />
-        ]}
-      />
+      <Toaster children={[<Toast title="I Am Toast" key={0} id={0} />]} />
     );
     const dismissBtn = component.find('span[role="button"]');
-    expect(onDismiss).not.toHaveBeenCalled();
     expect(dismissToastSpy).not.toHaveBeenCalled();
     dismissBtn.simulate("click");
-    expect(onDismiss).toHaveBeenCalled();
     expect(dismissToastSpy).toHaveBeenCalled();
   });
 

--- a/packages/toaster/tests/Toaster.test.tsx
+++ b/packages/toaster/tests/Toaster.test.tsx
@@ -33,17 +33,19 @@ describe("Toaster", () => {
     expect(component.state("toasts")).not.toContain(testToast[0].props.id);
   });
 
-  it("dismisses toasts after specified time", () => {
-    const testToast = [<Toast id={0} title="I Am Toast" key={0} />];
+  it("calls onDismiss callback when toast is dismissed", () => {
+    const dismissCallback = jest.fn();
+    const testToast = [
+      <Toast id={0} title="I Am Toast" key={0} onDismiss={dismissCallback} />
+    ];
     const component = shallow(<Toaster children={testToast} />);
+    const instance = component.instance() as Toaster;
+    instance.dismissToast(testToast[0].props.id);
 
-    expect(Object.keys(component.state("toasts")).length).toBe(1);
-    setTimeout(() => {
-      expect(Object.keys(component.state("toasts")).length).toBe(0);
-    }, DELAY_TIME + 1);
+    expect(dismissCallback).toHaveBeenCalledTimes(1);
   });
 
-  it("dismisses autodismiss toasts after specified time", () => {
+  it("dismisses autodismiss toasts after specified time", done => {
     const testToast = [
       <Toast id={0} autodismiss={true} title="I Am Toast" key={0} />
     ];
@@ -52,6 +54,27 @@ describe("Toaster", () => {
     expect(Object.keys(component.state("toasts")).length).toBe(1);
     setTimeout(() => {
       expect(Object.keys(component.state("toasts")).length).toBe(0);
+      done();
+    }, DELAY_TIME + 1);
+  });
+
+  it("calls onDismiss callback for autodismissed toasts", done => {
+    const dismissCallback = jest.fn();
+    const testToast = (
+      <Toast
+        id={0}
+        autodismiss={true}
+        title="I Am Toast"
+        key={0}
+        onDismiss={dismissCallback}
+      />
+    );
+    const component = shallow(<Toaster children={[testToast]} />);
+
+    expect(Object.keys(component.state("toasts")).length).toBe(1);
+    setTimeout(() => {
+      expect(dismissCallback).toHaveBeenCalledTimes(1);
+      done();
     }, DELAY_TIME + 1);
   });
 
@@ -65,7 +88,10 @@ describe("Toaster", () => {
       />
     );
     const newProps = {
-      children: [<Toast id={0} key={0} title="I Am Toast" />]
+      children: [
+        <Toast id={testToastId} key={1} title="I Am Toast" />,
+        <Toast id={0} key={0} title="I Am Toast" />
+      ]
     };
     const component = mount(<ToastWithProps />);
     const instance = component.find(Toaster).instance() as Toaster;


### PR DESCRIPTION
Refactored Toaster to always trust it's children as the source of truth
for which toasts should be displayed. This requires the app using
toaster to keep and accurate list of toasts and handle removing toasts
from that list whenever onDismiss callback is invoked.

Updated `autodismiss` code to also ensure onDismiss callback is called.