### PR TITLE
fix(ui): required prop missing from Dropdownable

### DIFF
--- a/packages/tooltip/components/Tooltip.tsx
+++ b/packages/tooltip/components/Tooltip.tsx
@@ -32,6 +32,7 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
 
     this.handleClose = this.handleClose.bind(this);
     this.handleOpen = this.handleOpen.bind(this);
+    this.handleDropdownableClose = this.handleDropdownableClose.bind(this);
   }
 
   public render() {
@@ -57,6 +58,7 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       >
         <Dropdownable
           open={this.state.open}
+          onClose={this.handleDropdownableClose}
           dropdown={
             <TooltipContent
               id={id}
@@ -75,6 +77,11 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
         </Dropdownable>
       </span>
     );
+  }
+
+  private handleDropdownableClose() {
+    // No need for inner component to close using "on click outside" since
+    // the parent is handling onMouseLeave already
   }
 
   private handleOpen() {

--- a/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`Tooltip renders 1`] = `
           content
         </TooltipContent>
       }
+      onClose={[Function]}
       open={false}
       preferredDirections={
         Array [
@@ -148,9 +149,11 @@ exports[`Tooltip renders 1`] = `
               >
                 <div>
                   <clickOutside(DropdownContents)
+                    onClose={[Function]}
                     open={false}
                   >
                     <DropdownContents
+                      onClose={[Function]}
                       open={false}
                     >
                       <TooltipContent
@@ -243,6 +246,7 @@ exports[`Tooltip renders open tooltip 1`] = `
           content
         </TooltipContent>
       }
+      onClose={[Function]}
       open={true}
       preferredDirections={
         Array [
@@ -353,9 +357,11 @@ exports[`Tooltip renders open tooltip 1`] = `
               >
                 <div>
                   <clickOutside(DropdownContents)
+                    onClose={[Function]}
                     open={true}
                   >
                     <DropdownContents
+                      onClose={[Function]}
                       open={true}
                     >
                       <TooltipContent
@@ -453,6 +459,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
           content
         </TooltipContent>
       }
+      onClose={[Function]}
       open={true}
       preferredDirections={
         Array [
@@ -583,9 +590,11 @@ exports[`Tooltip renders with preferred directions 1`] = `
               >
                 <div>
                   <clickOutside(DropdownContents)
+                    onClose={[Function]}
                     open={true}
                   >
                     <DropdownContents
+                      onClose={[Function]}
                       open={true}
                     >
                       <TooltipContent


### PR DESCRIPTION
This resolves a console error when "on click outside" triggers for tooltips. However, there is a bigger underlying problem here that I don't fully understand and is also hard to google: The props defined in each component appear to allow undefined values when they in fact not allowed. This should have been a typescript error