### PR TITLE
Tooltip improvement: use mouseOver instead of mouseEnter

### DIFF
--- a/packages/tooltip/components/Tooltip.tsx
+++ b/packages/tooltip/components/Tooltip.tsx
@@ -46,10 +46,12 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
     } = this.props;
 
     return (
+      /* tslint:disable:react-a11y-event-has-role */
+      /* disabled because there is no appropriate role */
       <span
         aria-label={ariaLabel}
         aria-describedby={id}
-        onMouseEnter={this.handleOpen}
+        onMouseOver={this.handleOpen}
         onMouseLeave={this.handleClose}
         onFocus={this.handleOpen}
         onBlur={this.handleClose}
@@ -74,6 +76,7 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
           {trigger}
         </Dropdownable>
       </span>
+      /* tslint:enable:react-a11y-event-has-role */
     );
   }
 

--- a/packages/tooltip/tests/Tooltip.test.tsx
+++ b/packages/tooltip/tests/Tooltip.test.tsx
@@ -41,14 +41,14 @@ describe("Tooltip", () => {
     expect(toJson(component)).toMatchSnapshot();
   });
 
-  it("toggles state.open to true on mouseEnter", () => {
+  it("toggles state.open to true on mouseOver", () => {
     const component = mount(
       <Tooltip id="hoverOpen" trigger="trigger">
         content
       </Tooltip>
     );
     expect(component.state("open")).toBe(false);
-    component.simulate("mouseEnter");
+    component.simulate("mouseOver");
     expect(component.state("open")).toBe(true);
   });
 

--- a/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
@@ -42,8 +42,8 @@ exports[`Tooltip renders 1`] = `
     aria-describedby="renders"
     onBlur={[Function]}
     onFocus={[Function]}
-    onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    onMouseOver={[Function]}
     tabIndex={0}
   >
     <Dropdownable
@@ -230,8 +230,8 @@ exports[`Tooltip renders open tooltip 1`] = `
     aria-describedby="opened"
     onBlur={[Function]}
     onFocus={[Function]}
-    onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    onMouseOver={[Function]}
     tabIndex={0}
   >
     <Dropdownable
@@ -440,8 +440,8 @@ exports[`Tooltip renders with preferred directions 1`] = `
     aria-describedby="customDir"
     onBlur={[Function]}
     onFocus={[Function]}
-    onMouseEnter={[Function]}
     onMouseLeave={[Function]}
+    onMouseOver={[Function]}
     tabIndex={0}
   >
     <Dropdownable


### PR DESCRIPTION
I tested a Protoss PR where we were using a Tooltip inside of a table and noticed hovering the Tooltip would only work sometimes. This was likely due to the cell re-rendering when on hover to add the row hover styles.

Changing the Tooltip event handler from `onMouseEnter` to `onMouseOver` appears to fix this issue. I tested both in Storybook and in Protoss

## Screenshots

Before:
![tooltipintable-before](https://user-images.githubusercontent.com/2313998/53996110-46cd1c80-4105-11e9-98c0-7ee03c723c87.gif)

After:
![tooltipintable-after](https://user-images.githubusercontent.com/2313998/53996325-f5715d00-4105-11e9-97a1-21df6db6f138.gif)

[Protoss before](https://cl.ly/48efc03a1e6b)
[Protoss after](https://cl.ly/79a21202566c)