### PR TITLE
Table cell perf fix: only re-render classname for cells

### DIFF
--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -111,6 +111,22 @@ export const fillColumns = (
   }
 };
 
+const ContentCell = styled("div")`
+  ${props => {
+    return `${
+      props.theme.coloredRows &&
+      props.theme.coloredRows[props["data-rowindex"] - 1]
+        ? rowHoverStyles
+        : ""
+    }
+  ${
+    props.theme.mutedRows && props.theme.mutedRows[props["data-rowindex"] - 1]
+      ? `color: ${textColorSecondary};`
+      : ""
+  }`;
+  }};
+`;
+
 export class Table<T> extends React.PureComponent<TableProps, TableState> {
   public multiGridRef: { recomputeGridSize?: any } = {};
 
@@ -312,21 +328,6 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
       this.setState({ hoveredRowIndex: rowIndex });
     };
 
-    const ContentCell = styled("div")`
-      ${props => {
-        return `${
-          props.theme.coloredRows && props.theme.coloredRows[rowIndex - 1]
-            ? rowHoverStyles
-            : ""
-        }
-        ${
-          props.theme.mutedRows && props.theme.mutedRows[rowIndex - 1]
-            ? `color: ${textColorSecondary};`
-            : ""
-        }`;
-      }};
-    `;
-
     return (
       /* tslint:disable:react-a11y-event-has-role */
       <ContentCell
@@ -338,6 +339,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
         style={style}
         key={key}
         onMouseOver={updateHoveredRowIndex}
+        data-rowindex={rowIndex}
       >
         {column.props.cellRenderer(data[rowIndex], style.width as number)}
       </ContentCell>

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -283,6 +283,7 @@ exports[`CheckboxTable renders default 1`] = `
           >
             <div
               class="emotion-19"
+              data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:151px"
             >
               <div
@@ -318,6 +319,7 @@ exports[`CheckboxTable renders default 1`] = `
             </div>
             <div
               class="emotion-19"
+              data-rowindex="1"
               style="height:35px;left:151px;position:absolute;top:0;width:151px"
             >
               <strong>
@@ -326,6 +328,7 @@ exports[`CheckboxTable renders default 1`] = `
             </div>
             <div
               class="emotion-19"
+              data-rowindex="2"
               style="height:35px;left:0;position:absolute;top:35px;width:151px"
             >
               <div
@@ -361,6 +364,7 @@ exports[`CheckboxTable renders default 1`] = `
             </div>
             <div
               class="emotion-19"
+              data-rowindex="2"
               style="height:35px;left:151px;position:absolute;top:35px;width:151px"
             >
               <strong>
@@ -385,6 +389,7 @@ exports[`CheckboxTable renders default 1`] = `
         >
           <div
             class="emotion-19"
+            data-rowindex="1"
             style="height:35px;left:0;position:absolute;top:0;width:151px"
           >
             <em>
@@ -393,6 +398,7 @@ exports[`CheckboxTable renders default 1`] = `
           </div>
           <div
             class="emotion-19"
+            data-rowindex="1"
             style="height:35px;left:151px;position:absolute;top:0;width:151px"
           >
             <span>
@@ -401,6 +407,7 @@ exports[`CheckboxTable renders default 1`] = `
           </div>
           <div
             class="emotion-19"
+            data-rowindex="1"
             style="height:35px;left:302px;position:absolute;top:0;width:151px"
           >
             <span>
@@ -409,6 +416,7 @@ exports[`CheckboxTable renders default 1`] = `
           </div>
           <div
             class="emotion-19"
+            data-rowindex="1"
             style="height:35px;left:453px;position:absolute;top:0;width:151px"
           >
             <strong>
@@ -417,6 +425,7 @@ exports[`CheckboxTable renders default 1`] = `
           </div>
           <div
             class="emotion-19"
+            data-rowindex="2"
             style="height:35px;left:0;position:absolute;top:35px;width:151px"
           >
             <em>
@@ -425,6 +434,7 @@ exports[`CheckboxTable renders default 1`] = `
           </div>
           <div
             class="emotion-19"
+            data-rowindex="2"
             style="height:35px;left:151px;position:absolute;top:35px;width:151px"
           >
             <span>
@@ -433,6 +443,7 @@ exports[`CheckboxTable renders default 1`] = `
           </div>
           <div
             class="emotion-19"
+            data-rowindex="2"
             style="height:35px;left:302px;position:absolute;top:35px;width:151px"
           >
             <span>
@@ -441,6 +452,7 @@ exports[`CheckboxTable renders default 1`] = `
           </div>
           <div
             class="emotion-19"
+            data-rowindex="2"
             style="height:35px;left:453px;position:absolute;top:35px;width:151px"
           >
             <strong>
@@ -813,6 +825,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           >
             <div
               class="emotion-23"
+              data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:151px"
             >
               <div
@@ -866,6 +879,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
             </div>
             <div
               class="emotion-23"
+              data-rowindex="1"
               style="height:35px;left:151px;position:absolute;top:0;width:151px"
             >
               <strong>
@@ -874,6 +888,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
             </div>
             <div
               class="emotion-31"
+              data-rowindex="2"
               style="height:35px;left:0;position:absolute;top:35px;width:151px"
             >
               <div
@@ -909,6 +924,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
             </div>
             <div
               class="emotion-31"
+              data-rowindex="2"
               style="height:35px;left:151px;position:absolute;top:35px;width:151px"
             >
               <strong>
@@ -933,6 +949,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
         >
           <div
             class="emotion-23"
+            data-rowindex="1"
             style="height:35px;left:0;position:absolute;top:0;width:151px"
           >
             <em>
@@ -941,6 +958,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           </div>
           <div
             class="emotion-23"
+            data-rowindex="1"
             style="height:35px;left:151px;position:absolute;top:0;width:151px"
           >
             <span>
@@ -949,6 +967,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           </div>
           <div
             class="emotion-23"
+            data-rowindex="1"
             style="height:35px;left:302px;position:absolute;top:0;width:151px"
           >
             <span>
@@ -957,6 +976,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           </div>
           <div
             class="emotion-23"
+            data-rowindex="1"
             style="height:35px;left:453px;position:absolute;top:0;width:151px"
           >
             <strong>
@@ -965,6 +985,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           </div>
           <div
             class="emotion-31"
+            data-rowindex="2"
             style="height:35px;left:0;position:absolute;top:35px;width:151px"
           >
             <em>
@@ -973,6 +994,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           </div>
           <div
             class="emotion-31"
+            data-rowindex="2"
             style="height:35px;left:151px;position:absolute;top:35px;width:151px"
           >
             <span>
@@ -981,6 +1003,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           </div>
           <div
             class="emotion-31"
+            data-rowindex="2"
             style="height:35px;left:302px;position:absolute;top:35px;width:151px"
           >
             <span>
@@ -989,6 +1012,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
           </div>
           <div
             class="emotion-31"
+            data-rowindex="2"
             style="height:35px;left:453px;position:absolute;top:35px;width:151px"
           >
             <strong>
@@ -1303,10 +1327,12 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           >
             <div
               class="emotion-13"
+              data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:151px"
             />
             <div
               class="emotion-13"
+              data-rowindex="1"
               style="height:35px;left:151px;position:absolute;top:0;width:151px"
             >
               <strong>
@@ -1315,6 +1341,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
             </div>
             <div
               class="emotion-21"
+              data-rowindex="2"
               style="height:35px;left:0;position:absolute;top:35px;width:151px"
             >
               <div
@@ -1350,6 +1377,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
             </div>
             <div
               class="emotion-21"
+              data-rowindex="2"
               style="height:35px;left:151px;position:absolute;top:35px;width:151px"
             >
               <strong>
@@ -1374,6 +1402,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
         >
           <div
             class="emotion-13"
+            data-rowindex="1"
             style="height:35px;left:0;position:absolute;top:0;width:151px"
           >
             <em>
@@ -1382,6 +1411,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           </div>
           <div
             class="emotion-13"
+            data-rowindex="1"
             style="height:35px;left:151px;position:absolute;top:0;width:151px"
           >
             <span>
@@ -1390,6 +1420,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           </div>
           <div
             class="emotion-13"
+            data-rowindex="1"
             style="height:35px;left:302px;position:absolute;top:0;width:151px"
           >
             <span>
@@ -1398,6 +1429,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           </div>
           <div
             class="emotion-13"
+            data-rowindex="1"
             style="height:35px;left:453px;position:absolute;top:0;width:151px"
           >
             <strong>
@@ -1406,6 +1438,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           </div>
           <div
             class="emotion-21"
+            data-rowindex="2"
             style="height:35px;left:0;position:absolute;top:35px;width:151px"
           >
             <em>
@@ -1414,6 +1447,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           </div>
           <div
             class="emotion-21"
+            data-rowindex="2"
             style="height:35px;left:151px;position:absolute;top:35px;width:151px"
           >
             <span>
@@ -1422,6 +1456,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           </div>
           <div
             class="emotion-21"
+            data-rowindex="2"
             style="height:35px;left:302px;position:absolute;top:35px;width:151px"
           >
             <span>
@@ -1430,6 +1465,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
           </div>
           <div
             class="emotion-21"
+            data-rowindex="2"
             style="height:35px;left:453px;position:absolute;top:35px;width:151px"
           >
             <strong>

--- a/packages/table/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Table.test.tsx.snap
@@ -310,6 +310,7 @@ exports[`Table renders default 1`] = `
           >
             <div
               class="emotion-5"
+              data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:307.2px"
             >
               <strong>
@@ -318,6 +319,7 @@ exports[`Table renders default 1`] = `
             </div>
             <div
               class="emotion-5"
+              data-rowindex="2"
               style="height:35px;left:0;position:absolute;top:35px;width:307.2px"
             >
               <strong>
@@ -342,6 +344,7 @@ exports[`Table renders default 1`] = `
         >
           <div
             class="emotion-5"
+            data-rowindex="1"
             style="height:35px;left:0;position:absolute;top:0;width:307.2px"
           >
             <em>
@@ -350,6 +353,7 @@ exports[`Table renders default 1`] = `
           </div>
           <div
             class="emotion-5"
+            data-rowindex="1"
             style="height:35px;left:307.2px;position:absolute;top:0;width:307.2px"
           >
             <span>
@@ -358,6 +362,7 @@ exports[`Table renders default 1`] = `
           </div>
           <div
             class="emotion-5"
+            data-rowindex="1"
             style="height:35px;left:614.4px;position:absolute;top:0;width:307.2px"
           >
             <span>
@@ -366,6 +371,7 @@ exports[`Table renders default 1`] = `
           </div>
           <div
             class="emotion-5"
+            data-rowindex="2"
             style="height:35px;left:0;position:absolute;top:35px;width:307.2px"
           >
             <em>
@@ -374,6 +380,7 @@ exports[`Table renders default 1`] = `
           </div>
           <div
             class="emotion-5"
+            data-rowindex="2"
             style="height:35px;left:307.2px;position:absolute;top:35px;width:307.2px"
           >
             <span>
@@ -382,6 +389,7 @@ exports[`Table renders default 1`] = `
           </div>
           <div
             class="emotion-5"
+            data-rowindex="2"
             style="height:35px;left:614.4px;position:absolute;top:35px;width:307.2px"
           >
             <span>
@@ -547,6 +555,7 @@ exports[`Table renders with growToFill cols 1`] = `
           >
             <div
               class="emotion-6"
+              data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:151px"
             >
               <strong>
@@ -555,6 +564,7 @@ exports[`Table renders with growToFill cols 1`] = `
             </div>
             <div
               class="emotion-6"
+              data-rowindex="2"
               style="height:35px;left:0;position:absolute;top:35px;width:151px"
             >
               <strong>
@@ -579,6 +589,7 @@ exports[`Table renders with growToFill cols 1`] = `
         >
           <div
             class="emotion-6"
+            data-rowindex="1"
             style="height:35px;left:0;position:absolute;top:0;width:151px"
           >
             <em>
@@ -587,6 +598,7 @@ exports[`Table renders with growToFill cols 1`] = `
           </div>
           <div
             class="emotion-6"
+            data-rowindex="1"
             style="height:35px;left:151px;position:absolute;top:0;width:151px"
           >
             <span>
@@ -595,6 +607,7 @@ exports[`Table renders with growToFill cols 1`] = `
           </div>
           <div
             class="emotion-6"
+            data-rowindex="1"
             style="height:35px;left:302px;position:absolute;top:0;width:307.2px"
           >
             <span>
@@ -603,6 +616,7 @@ exports[`Table renders with growToFill cols 1`] = `
           </div>
           <div
             class="emotion-6"
+            data-rowindex="1"
             style="height:35px;left:609.2px;position:absolute;top:0;width:307.2px"
           >
             <strong>
@@ -611,6 +625,7 @@ exports[`Table renders with growToFill cols 1`] = `
           </div>
           <div
             class="emotion-6"
+            data-rowindex="2"
             style="height:35px;left:0;position:absolute;top:35px;width:151px"
           >
             <em>
@@ -619,6 +634,7 @@ exports[`Table renders with growToFill cols 1`] = `
           </div>
           <div
             class="emotion-6"
+            data-rowindex="2"
             style="height:35px;left:151px;position:absolute;top:35px;width:151px"
           >
             <span>
@@ -627,6 +643,7 @@ exports[`Table renders with growToFill cols 1`] = `
           </div>
           <div
             class="emotion-6"
+            data-rowindex="2"
             style="height:35px;left:302px;position:absolute;top:35px;width:307.2px"
           >
             <span>
@@ -635,6 +652,7 @@ exports[`Table renders with growToFill cols 1`] = `
           </div>
           <div
             class="emotion-6"
+            data-rowindex="2"
             style="height:35px;left:609.2px;position:absolute;top:35px;width:307.2px"
           >
             <strong>


### PR DESCRIPTION
We noticed in Protoss that the table cells were rewriting the DOM nodes for table cells instead of changing the attributes of the table cell nodes. This was causing images to flicker on state change and components like `Tooltip` inside the table to unnecessarily do expensive re-renders.

Before:
![TableCellReRender-before](https://user-images.githubusercontent.com/2313998/54062632-3a17f980-41d5-11e9-973e-346435cf00f1.gif)

After:
![TableCellReRender-after](https://user-images.githubusercontent.com/2313998/54062642-4ac86f80-41d5-11e9-8353-edd7ab4e2037.gif)

