### PR TITLE
fix: don't create styled component in render function

### DIFF
--- a/packages/dropdownable/components/Dropdownable.tsx
+++ b/packages/dropdownable/components/Dropdownable.tsx
@@ -21,6 +21,11 @@ const DEFAULT_DIRECTION_PREFERENCES = [
   Direction.TopLeft
 ];
 
+const Container = styled("div")`
+  position: relative;
+  display: inline-block;
+`;
+
 export interface DropdownableProps {
   open: boolean;
   dropdown: React.ReactElement<any>;
@@ -94,11 +99,6 @@ class Dropdownable extends React.Component<DropdownableProps, State> {
   }
 
   render() {
-    const Container = styled("div")`
-      position: relative;
-      display: inline-block;
-    `;
-
     return (
       <Container>
         <div ref={this.child}>{this.props.children}</div>

--- a/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
+++ b/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
@@ -259,19 +259,9 @@ exports[`Dropdownable is visible after opening 2`] = `
         className="emotion-1"
         overlayRoot={
           <body>
-            .emotion-0 {
-  top: 0px;
-  left: 0px;
-  position: absolute;
-  -webkit-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  opacity: 1;
-}
-
-<div>
+            <div>
               <div
-                class="emotion-0"
+                class="emotion-1"
               >
                 <div>
                   <p


### PR DESCRIPTION
There are a few more examples of this in Sidebar and Headerbar, but this in particular is much easier to fix and is affecting protoss performance