### PR TITLE
DCOS-50093: table perf - remove content-based column width sizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -247,7 +247,7 @@
       "dependencies": {
         "conventional-changelog-angular": {
           "version": "1.6.6",
-          "resolved": "http://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
           "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
           "dev": true,
           "requires": {
@@ -257,7 +257,7 @@
         },
         "conventional-commits-parser": {
           "version": "2.1.7",
-          "resolved": "http://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
           "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
           "dev": true,
           "requires": {
@@ -765,7 +765,7 @@
     },
     "@storybook/podda": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/@storybook/podda/-/podda-1.2.3.tgz",
       "integrity": "sha512-g7dsdsn50AhlGZ8iIDKdF8bi7Am++iFOq+QN+hNKz3FvgLuf8Dz+mpC/BFl90eE9bEYxXqXKeMf87399Ec5Qhw==",
       "dev": true,
       "requires": {
@@ -856,7 +856,7 @@
     },
     "@storybook/storybook-deployer": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@storybook/storybook-deployer/-/storybook-deployer-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/@storybook/storybook-deployer/-/storybook-deployer-2.3.0.tgz",
       "integrity": "sha512-islhy4R8i8sxdLD71X2Wy1wo5ZgsDCVqHVN91+1lB+zAOweLTi1aQm2dcRh+me65jAopkJdFjmbiQ2TVgjAo2w==",
       "dev": true,
       "requires": {
@@ -894,7 +894,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -1578,7 +1578,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1652,7 +1652,7 @@
     },
     "autoprefixer": {
       "version": "7.2.6",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
+      "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
       "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
       "dev": true,
       "requires": {
@@ -1707,7 +1707,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1945,7 +1945,7 @@
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
       "dev": true
     },
@@ -2091,7 +2091,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -2213,7 +2213,7 @@
     },
     "babel-plugin-react-docgen": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.9.0.tgz",
       "integrity": "sha512-8lQ73p4BL+xcgba03NTiHrddl2X8J6PDMQHPpz73sesrRBf6JtAscQPLIjFWQR/abLokdv81HdshpjYGppOXgA==",
       "dev": true,
       "requires": {
@@ -2224,78 +2224,78 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
       "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
       "dev": true
     },
     "babel-plugin-syntax-class-constructor-call": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
       "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
       "dev": true
     },
     "babel-plugin-syntax-class-properties": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
       "dev": true
     },
     "babel-plugin-syntax-decorators": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
       "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
       "dev": true
     },
     "babel-plugin-syntax-do-expressions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.13.0.tgz",
       "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
       "dev": true
     },
     "babel-plugin-syntax-dynamic-import": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
       "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
     "babel-plugin-syntax-export-extensions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz",
       "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
       "dev": true
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
       "dev": true
     },
     "babel-plugin-syntax-function-bind": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz",
       "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
       "dev": true
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -3410,7 +3410,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -3447,7 +3447,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -3515,7 +3515,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -3647,7 +3647,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -3676,7 +3676,7 @@
         },
         "query-string": {
           "version": "5.1.1",
-          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
@@ -3963,7 +3963,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -3976,7 +3976,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -4092,7 +4092,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -4145,7 +4145,7 @@
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
@@ -4349,7 +4349,7 @@
     },
     "color": {
       "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
@@ -4395,7 +4395,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -4694,7 +4694,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -4707,7 +4707,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -4731,7 +4731,7 @@
       "dependencies": {
         "jest-worker": {
           "version": "22.4.3",
-          "resolved": "http://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
           "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
           "dev": true,
           "requires": {
@@ -4805,7 +4805,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -4821,7 +4821,7 @@
     },
     "css-loader": {
       "version": "0.28.11",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
+      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
       "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "dev": true,
       "requires": {
@@ -4855,7 +4855,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -4971,7 +4971,7 @@
     },
     "cssnano": {
       "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+      "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "dev": true,
       "requires": {
@@ -5047,7 +5047,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5404,7 +5404,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -5417,7 +5417,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -5519,7 +5519,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -5667,7 +5667,7 @@
     },
     "dotenv": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
       "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
       "dev": true
     },
@@ -5682,7 +5682,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -6489,7 +6489,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -6654,7 +6654,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         }
@@ -7659,7 +7659,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -7823,13 +7823,13 @@
       "dependencies": {
         "minimist": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
           "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
           "dev": true
         },
         "yargs": {
           "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
           "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
           "dev": true,
           "requires": {
@@ -7952,7 +7952,7 @@
     },
     "globby": {
       "version": "8.0.1",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
       "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
       "dev": true,
       "requires": {
@@ -8002,7 +8002,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -8449,7 +8449,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -8481,7 +8481,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -8930,7 +8930,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -8967,7 +8967,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -9160,7 +9160,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -9329,7 +9329,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -9783,7 +9783,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -10598,7 +10598,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -10900,7 +10900,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -11274,7 +11274,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11366,7 +11366,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11439,7 +11439,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12019,7 +12019,7 @@
       "dependencies": {
         "marked": {
           "version": "0.3.19",
-          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         }
@@ -12058,7 +12058,7 @@
       "dependencies": {
         "marked": {
           "version": "0.3.19",
-          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
           "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
           "dev": true
         }
@@ -12186,7 +12186,7 @@
         },
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -12199,7 +12199,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -12239,7 +12239,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -12384,7 +12384,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
@@ -12450,7 +12450,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -16243,7 +16243,7 @@
     },
     "ora": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "dev": true,
       "requires": {
@@ -16267,7 +16267,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16521,7 +16521,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
@@ -16819,7 +16819,7 @@
     },
     "postcss-calc": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "dev": true,
       "requires": {
@@ -16842,7 +16842,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16924,7 +16924,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17005,7 +17005,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17064,7 +17064,7 @@
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "dev": true,
       "requires": {
@@ -17085,7 +17085,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17165,7 +17165,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17224,7 +17224,7 @@
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "dev": true,
       "requires": {
@@ -17245,7 +17245,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17304,7 +17304,7 @@
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "dev": true,
       "requires": {
@@ -17325,7 +17325,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17384,7 +17384,7 @@
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "dev": true,
       "requires": {
@@ -17406,7 +17406,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17486,7 +17486,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17590,7 +17590,7 @@
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
@@ -17613,7 +17613,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17693,7 +17693,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17787,7 +17787,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17852,7 +17852,7 @@
     },
     "postcss-minify-font-values": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "dev": true,
       "requires": {
@@ -17875,7 +17875,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -17934,7 +17934,7 @@
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "dev": true,
       "requires": {
@@ -17956,7 +17956,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18015,7 +18015,7 @@
     },
     "postcss-minify-params": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "dev": true,
       "requires": {
@@ -18039,7 +18039,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18098,7 +18098,7 @@
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "dev": true,
       "requires": {
@@ -18122,7 +18122,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18220,7 +18220,7 @@
     },
     "postcss-normalize-charset": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "dev": true,
       "requires": {
@@ -18241,7 +18241,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18300,7 +18300,7 @@
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "dev": true,
       "requires": {
@@ -18324,7 +18324,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18417,7 +18417,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18476,7 +18476,7 @@
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "dev": true,
       "requires": {
@@ -18498,7 +18498,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18557,7 +18557,7 @@
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "dev": true,
       "requires": {
@@ -18578,7 +18578,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18637,7 +18637,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
@@ -18660,7 +18660,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18730,7 +18730,7 @@
     },
     "postcss-svgo": {
       "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "dev": true,
       "requires": {
@@ -18754,7 +18754,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18850,7 +18850,7 @@
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "dev": true,
       "requires": {
@@ -18873,7 +18873,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -18938,7 +18938,7 @@
     },
     "postcss-zindex": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
@@ -18961,7 +18961,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -19287,7 +19287,7 @@
       "dependencies": {
         "inline-style-prefixer": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
+          "resolved": "http://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz",
           "integrity": "sha1-wVPH6I/YT+9cYC6VqBaLJ3BnH+c=",
           "dev": true,
           "requires": {
@@ -19528,7 +19528,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -19849,7 +19849,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -19952,7 +19952,7 @@
     },
     "reduce-css-calc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
       "requires": {
@@ -20475,7 +20475,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -20756,7 +20756,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -21588,7 +21588,7 @@
     },
     "style-loader": {
       "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
+      "resolved": "http://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
       "integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
       "dev": true,
       "requires": {
@@ -21699,7 +21699,7 @@
         },
         "colors": {
           "version": "1.1.2",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
         },
@@ -21877,7 +21877,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
@@ -21976,7 +21976,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -22119,7 +22119,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -22341,7 +22341,7 @@
     },
     "ts-loader": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-3.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/ts-loader/-/ts-loader-3.5.0.tgz",
       "integrity": "sha512-JTia3kObhTk36wPFgy0RnkZReiusYx7Le9IhcUWRrCTcFcr6Dy1zGsFd3x8DG4gevlbN65knI8W50FfoykXcng==",
       "dev": true,
       "requires": {
@@ -23142,7 +23142,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -23176,7 +23176,7 @@
     },
     "webpack": {
       "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
+      "resolved": "http://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
@@ -23255,7 +23255,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -23341,7 +23341,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -23515,7 +23515,7 @@
     },
     "webpack-cli": {
       "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.9.tgz",
+      "resolved": "http://registry.npmjs.org/webpack-cli/-/webpack-cli-2.0.9.tgz",
       "integrity": "sha512-KIkOFHhrq8W7ovg5u8M7Xbduzr1aQ1Ch1aGGY0TvL5neO81T6/aCZ/NeG7R92UaXIF/BK4KCkla35wtoOoxyDQ==",
       "dev": true,
       "requires": {
@@ -23614,7 +23614,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -23672,7 +23672,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -23773,7 +23773,7 @@
         },
         "recast": {
           "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.13.2.tgz",
+          "resolved": "http://registry.npmjs.org/recast/-/recast-0.13.2.tgz",
           "integrity": "sha512-Xqo0mKljGUWGUhnkdbODk7oJGFrMcpgKQ9cCyZ4y+G9VfoTKdum8nHbf/SxIdKx5aBSZ29VpVy20bTyt7jyC8w==",
           "dev": true,
           "requires": {
@@ -23877,7 +23877,7 @@
     },
     "webpack-dev-server": {
       "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+      "resolved": "http://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
       "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
       "dev": true,
       "requires": {
@@ -23978,7 +23978,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -23991,7 +23991,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
@@ -24128,7 +24128,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -24211,7 +24211,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -24271,7 +24271,7 @@
         },
         "external-editor": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
           "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
           "dev": true,
           "requires": {
@@ -24321,7 +24321,7 @@
         },
         "inquirer": {
           "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
           "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
           "dev": true,
           "requires": {
@@ -24352,7 +24352,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -24373,7 +24373,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -24716,7 +24716,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/packages/table/components/CheckboxTable.tsx
+++ b/packages/table/components/CheckboxTable.tsx
@@ -3,6 +3,9 @@ import { ThemeProvider } from "emotion-theming";
 import { Table, Column, Cell, HeaderCell } from "..";
 import { TableProps } from "./Table";
 import CheckboxInput from "../../checkboxInput/components/CheckboxInput";
+import { WidthArgs } from "./Column";
+import { display } from "../../shared/styles/styleUtils";
+import { spaceM } from "../../design-tokens/build/js/designTokens";
 
 export interface CheckboxTableProps extends TableProps {
   /**
@@ -48,6 +51,7 @@ class CheckboxTable extends React.PureComponent<
           data.length - Object.keys(disabledRows).length
     };
   }
+  private checkboxRef = React.createRef<HTMLDivElement>();
 
   constructor(props) {
     super(props);
@@ -59,6 +63,7 @@ class CheckboxTable extends React.PureComponent<
     this.getSelectedRows = this.getSelectedRows.bind(this);
     this.checkboxCellRenderer = this.checkboxCellRenderer.bind(this);
     this.getHeaderCheckbox = this.getHeaderCheckbox.bind(this);
+    this.getCheckboxColWidth = this.getCheckboxColWidth.bind(this);
   }
 
   render() {
@@ -74,11 +79,20 @@ class CheckboxTable extends React.PureComponent<
           <Column
             header={<HeaderCell>{this.getHeaderCheckbox()}</HeaderCell>}
             cellRenderer={this.checkboxCellRenderer}
+            width={this.getCheckboxColWidth}
           />
           {this.props.children as any}
         </Table>
       </ThemeProvider>
     );
+  }
+
+  private getCheckboxColWidth(_args: WidthArgs) {
+    const checkbox = this.checkboxRef.current;
+
+    return checkbox
+      ? checkbox.getBoundingClientRect().width + parseInt(spaceM, 10)
+      : 24;
   }
 
   private checkboxCellRenderer(rowData) {
@@ -140,20 +154,22 @@ class CheckboxTable extends React.PureComponent<
     };
 
     return (
-      <CheckboxInput
-        id="headerCheckbox"
-        inputLabel="Toggle all rows"
-        showInputLabel={false}
-        checked={
-          (Boolean(selectedLength) && selectedLength === maxSelectedLength) ||
-          this.state.headerChecked
-        }
-        indeterminate={
-          Boolean(selectedLength) && selectedLength < maxSelectedLength
-        }
-        disabled={!Boolean(maxSelectedLength)}
-        onChange={handleChange}
-      />
+      <div ref={this.checkboxRef} className={display("inline-block")}>
+        <CheckboxInput
+          id="headerCheckbox"
+          inputLabel="Toggle all rows"
+          showInputLabel={false}
+          checked={
+            (Boolean(selectedLength) && selectedLength === maxSelectedLength) ||
+            this.state.headerChecked
+          }
+          indeterminate={
+            Boolean(selectedLength) && selectedLength < maxSelectedLength
+          }
+          disabled={!Boolean(maxSelectedLength)}
+          onChange={handleChange}
+        />
+      </div>
     );
   }
 

--- a/packages/table/components/Column.tsx
+++ b/packages/table/components/Column.tsx
@@ -17,6 +17,8 @@ export interface ColumnProps {
   cellRenderer: (data: any, width: number) => React.ReactNode;
   /**
    * width should return a column width in pixels.
+   * If no function is provided, columns will distribute
+   * their width evenly
    */
   width?: (args: WidthArgs) => number;
   /**

--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -1,13 +1,7 @@
 import * as React from "react";
 import { cx, css } from "emotion";
 import styled from "react-emotion";
-import {
-  AutoSizer,
-  MultiGrid,
-  GridCellProps,
-  CellMeasurer,
-  CellMeasurerCache
-} from "react-virtualized";
+import { AutoSizer, MultiGrid, GridCellProps } from "react-virtualized";
 
 import {
   headerCss,
@@ -152,9 +146,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
               currentIndex,
               remainingWidth
             })
-          : this.cellMeasureCache.columnWidth({ index: currentIndex }) + 1;
-        // Adding 1 pixel to the calculated columnWidth for when we use `text-overflow: ellipsis`.
-        // In rare cases, the browser will try and truncate the text too soon
+          : width / totalColumns;
 
         const clampedWidth = clampWidth(
           calculatedWidth,
@@ -173,12 +165,6 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
     }
   );
 
-  private cellMeasureCache = new CellMeasurerCache({
-    defaultHeight: this.props.rowHeight || ROW_HEIGHT,
-    defaultWidth: 150,
-    fixedHeight: true
-  });
-
   constructor(props) {
     super(props);
 
@@ -193,16 +179,6 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
       isScrolling: false,
       hoveredRowIndex: -1
     };
-  }
-
-  public componentDidUpdate(prevProps: TableProps) {
-    if (
-      this.props.children !== prevProps.children ||
-      this.props.data !== prevProps.data
-    ) {
-      this.cellMeasureCache.clearAll();
-      this.updateGridSize();
-    }
   }
 
   public render() {
@@ -285,19 +261,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
   }
 
   private cellRenderer(args: GridCellProps) {
-    const { columnIndex, rowIndex, key, parent } = args;
-
-    return (
-      <CellMeasurer
-        cache={this.cellMeasureCache}
-        columnIndex={columnIndex}
-        key={key}
-        parent={parent}
-        rowIndex={rowIndex}
-      >
-        {this.getCell(args)}
-      </CellMeasurer>
-    );
+    return this.getCell(args);
   }
 
   private getCell(args: GridCellProps) {

--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -92,7 +92,7 @@ storiesOf("Table", module)
       </Table>
     </div>
   ))
-  .addWithInfo("column width match content", () => (
+  .addWithInfo("default column widths", () => (
     <div
       style={{
         height: "175px",
@@ -104,28 +104,33 @@ storiesOf("Table", module)
         <Column
           header={<HeaderCell>name</HeaderCell>}
           cellRenderer={nameCellRenderer}
+          growToFill={true}
+          minWidth={100}
+          maxWidth={150}
         />
         <Column
           header={<HeaderCell>role</HeaderCell>}
           cellRenderer={roleCellRenderer}
+          growToFill={true}
         />
         <Column
           header={<HeaderCell>state</HeaderCell>}
           cellRenderer={stateCellRenderer}
+          growToFill={true}
+          minWidth={100}
+          maxWidth={150}
         />
         <Column
           header={<HeaderCell>Very Long</HeaderCell>}
           cellRenderer={veryLongRenderer}
-          maxWidth={300}
+          growToFill={true}
         />
         <Column
           header={<HeaderCell textAlign="right">zip code</HeaderCell>}
           cellRenderer={zipcodeCellRenderer}
-        />
-        <Column
-          header={<HeaderCell>city</HeaderCell>}
-          cellRenderer={cityCellRenderer}
-          maxWidth={200}
+          growToFill={true}
+          minWidth={100}
+          maxWidth={150}
         />
       </Table>
     </div>
@@ -142,6 +147,9 @@ storiesOf("Table", module)
         <Column
           header={<HeaderCell>name</HeaderCell>}
           cellRenderer={nameCellRenderer}
+          growToFill={true}
+          minWidth={100}
+          maxWidth={150}
         />
         <Column
           header={<HeaderCell>role</HeaderCell>}
@@ -151,20 +159,21 @@ storiesOf("Table", module)
         <Column
           header={<HeaderCell>state</HeaderCell>}
           cellRenderer={stateCellRenderer}
+          growToFill={true}
+          minWidth={100}
+          maxWidth={150}
         />
         <Column
           header={<HeaderCell>Very Long</HeaderCell>}
           cellRenderer={veryLongRenderer}
-          maxWidth={300}
+          growToFill={true}
         />
         <Column
           header={<HeaderCell textAlign="right">zip code</HeaderCell>}
           cellRenderer={zipcodeCellRenderer}
-        />
-        <Column
-          header={<HeaderCell>city</HeaderCell>}
-          cellRenderer={cityCellRenderer}
           growToFill={true}
+          minWidth={100}
+          maxWidth={150}
         />
       </Table>
     </div>

--- a/packages/table/tests/CheckboxTable.test.tsx
+++ b/packages/table/tests/CheckboxTable.test.tsx
@@ -177,7 +177,7 @@ describe("CheckboxTable", () => {
 
     expect(onChangeFn).not.toHaveBeenCalled();
     checkboxComponent
-      .find("input")
+      .find("#headerCheckbox")
       .simulate("change", { target: { checked: true } });
 
     expect(onChangeFn).toHaveBeenCalledWith(
@@ -187,7 +187,7 @@ describe("CheckboxTable", () => {
       }, {})
     );
     checkboxComponent
-      .find("input")
+      .find("#headerCheckbox")
       .simulate("change", { target: { checked: false } });
     expect(onChangeFn).toHaveBeenCalledWith({});
   });

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -13,11 +13,11 @@ exports[`CheckboxTable renders default 1`] = `
   height: 1px;
 }
 
-.emotion-38 {
+.emotion-39 {
   font-weight: normal;
 }
 
-.emotion-38::after {
+.emotion-39::after {
   content: "";
   height: 100%;
   left: 0;
@@ -27,15 +27,19 @@ exports[`CheckboxTable renders default 1`] = `
   width: 100%;
 }
 
-.emotion-12 {
+.emotion-13 {
   -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-12::-webkit-scrollbar {
+.emotion-13::-webkit-scrollbar {
   display: none;
 }
 
-.emotion-6 {
+.emotion-5 {
+  display: inline-block;
+}
+
+.emotion-7 {
   box-sizing: border-box;
   border-top: 1px solid #000;
   border-bottom: 1px solid #000;
@@ -52,7 +56,7 @@ exports[`CheckboxTable renders default 1`] = `
   justify-content: center;
 }
 
-.emotion-5 {
+.emotion-6 {
   display: inline-block;
   height: auto;
   box-sizing: border-box;
@@ -128,7 +132,7 @@ exports[`CheckboxTable renders default 1`] = `
   height: 1px;
 }
 
-.emotion-19 {
+.emotion-20 {
   box-sizing: border-box;
   border-bottom: 1px solid #DADDE2;
   white-space: nowrap;
@@ -145,7 +149,7 @@ exports[`CheckboxTable renders default 1`] = `
   justify-content: center;
 }
 
-.emotion-18 {
+.emotion-19 {
   display: inline-block;
   height: auto;
   box-sizing: border-box;
@@ -154,7 +158,7 @@ exports[`CheckboxTable renders default 1`] = `
 }
 
 <div
-  class="emotion-38"
+  class="emotion-39"
   style="overflow:visible;height:0;width:0"
 >
   <div
@@ -168,51 +172,55 @@ exports[`CheckboxTable renders default 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:302px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
+        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:302px;height:35px;max-width:302px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+          style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
-            class="emotion-6"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            class="emotion-7"
+            style="height:35px;left:0;position:absolute;top:0;width:24px"
           >
             <div
-              class="emotion-5"
+              class="emotion-6"
             >
-              <div>
-                <label
-                  class="emotion-4"
-                  for="headerCheckbox"
-                >
-                  <div
-                    class="emotion-2"
+              <div
+                class="emotion-5"
+              >
+                <div>
+                  <label
+                    class="emotion-4"
+                    for="headerCheckbox"
                   >
                     <div
-                      class="emotion-1"
+                      class="emotion-2"
                     >
-                      <input
-                        aria-checked="0"
-                        class="emotion-0"
-                        id="headerCheckbox"
-                        type="checkbox"
-                      />
+                      <div
+                        class="emotion-1"
+                      >
+                        <input
+                          aria-checked="0"
+                          class="emotion-0"
+                          id="headerCheckbox"
+                          type="checkbox"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="emotion-3"
-                  >
-                    Toggle all rows
-                  </div>
-                </label>
+                    <div
+                      class="emotion-3"
+                    >
+                      Toggle all rows
+                    </div>
+                  </label>
+                </div>
               </div>
             </div>
           </div>
           <div
-            class="emotion-6"
-            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            class="emotion-7"
+            style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
           >
             name
           </div>
@@ -220,41 +228,41 @@ exports[`CheckboxTable renders default 1`] = `
       </div>
       <div
         class="TopRightGrid_ScrollWrapper"
-        style="left:302px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:722px"
+        style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-12"
+          class="ReactVirtualized__Grid emotion-13"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:722px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:604px;height:35px;max-width:604px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
-              class="emotion-6"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
             >
               role
             </div>
             <div
-              class="emotion-6"
-              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
             >
               state
             </div>
             <div
-              class="emotion-6"
-              style="height:35px;left:302px;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
             >
               zipcode
             </div>
             <div
-              class="emotion-6"
-              style="height:35px;left:453px;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
             >
               city
             </div>
@@ -267,27 +275,27 @@ exports[`CheckboxTable renders default 1`] = `
     >
       <div
         class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:302px"
+        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-12"
+          class="ReactVirtualized__Grid emotion-13"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:302px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:302px;height:70px;max-width:302px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
-              class="emotion-19"
+              class="emotion-20"
               data-rowindex="1"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              style="height:35px;left:0;position:absolute;top:0;width:24px"
             >
               <div
-                class="emotion-18"
+                class="emotion-19"
               >
                 <div>
                   <label
@@ -318,21 +326,21 @@ exports[`CheckboxTable renders default 1`] = `
               </div>
             </div>
             <div
-              class="emotion-19"
+              class="emotion-20"
               data-rowindex="1"
-              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+              style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
             >
               <strong>
                 Brian Vaughn
               </strong>
             </div>
             <div
-              class="emotion-19"
+              class="emotion-20"
               data-rowindex="2"
-              style="height:35px;left:0;position:absolute;top:35px;width:151px"
+              style="height:35px;left:0;position:absolute;top:35px;width:24px"
             >
               <div
-                class="emotion-18"
+                class="emotion-19"
               >
                 <div>
                   <label
@@ -363,9 +371,9 @@ exports[`CheckboxTable renders default 1`] = `
               </div>
             </div>
             <div
-              class="emotion-19"
+              class="emotion-20"
               data-rowindex="2"
-              style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+              style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
             >
               <strong>
                 Jon Doe
@@ -379,81 +387,81 @@ exports[`CheckboxTable renders default 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:722px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:302px"
+        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
         tabindex="0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:604px;height:70px;max-width:604px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
           >
             <em>
               Software Engineer
             </em>
           </div>
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="1"
-            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
           >
             <span>
               CA
             </span>
           </div>
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="1"
-            style="height:35px;left:302px;position:absolute;top:0;width:151px"
+            style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
           >
             <span>
               95125
             </span>
           </div>
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="1"
-            style="height:35px;left:453px;position:absolute;top:0;width:151px"
+            style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
           >
             <strong>
               San Jose
             </strong>
           </div>
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:151px"
+            style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
           >
             <em>
               Product engineer
             </em>
           </div>
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="2"
-            style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <span>
               CA
             </span>
           </div>
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="2"
-            style="height:35px;left:302px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <span>
               95125
             </span>
           </div>
           <div
-            class="emotion-19"
+            class="emotion-20"
             data-rowindex="2"
-            style="height:35px;left:453px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <strong>
               Mountain View
@@ -479,11 +487,11 @@ exports[`CheckboxTable renders with checked row 1`] = `
   height: 1px;
 }
 
-.emotion-42 {
+.emotion-43 {
   font-weight: normal;
 }
 
-.emotion-42::after {
+.emotion-43::after {
   content: "";
   height: 100%;
   left: 0;
@@ -493,15 +501,19 @@ exports[`CheckboxTable renders with checked row 1`] = `
   width: 100%;
 }
 
-.emotion-14 {
+.emotion-15 {
   -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-14::-webkit-scrollbar {
+.emotion-15::-webkit-scrollbar {
   display: none;
 }
 
-.emotion-8 {
+.emotion-7 {
+  display: inline-block;
+}
+
+.emotion-9 {
   box-sizing: border-box;
   border-top: 1px solid #000;
   border-bottom: 1px solid #000;
@@ -518,7 +530,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
   justify-content: center;
 }
 
-.emotion-7 {
+.emotion-8 {
   display: inline-block;
   height: auto;
   box-sizing: border-box;
@@ -528,7 +540,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
   font-weight: bold;
 }
 
-.emotion-26 {
+.emotion-27 {
   border-color: #DADDE2;
   background-color: #FFF;
   border-style: solid;
@@ -594,7 +606,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
   height: 1px;
 }
 
-.emotion-31 {
+.emotion-32 {
   box-sizing: border-box;
   border-bottom: 1px solid #DADDE2;
   white-space: nowrap;
@@ -611,7 +623,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
   justify-content: center;
 }
 
-.emotion-22 {
+.emotion-23 {
   display: inline-block;
   height: auto;
   box-sizing: border-box;
@@ -658,7 +670,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
   pointer-events: none;
 }
 
-.emotion-23 {
+.emotion-24 {
   background-color: #F7F8F9;
   mix-blend-mode: multiply;
   will-change: left;
@@ -679,7 +691,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
 }
 
 <div
-  class="emotion-42"
+  class="emotion-43"
   style="overflow:visible;height:0;width:0"
 >
   <div
@@ -693,68 +705,72 @@ exports[`CheckboxTable renders with checked row 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:302px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
+        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:302px;height:35px;max-width:302px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+          style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
-            class="emotion-8"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            class="emotion-9"
+            style="height:35px;left:0;position:absolute;top:0;width:24px"
           >
             <div
-              class="emotion-7"
+              class="emotion-8"
             >
-              <div>
-                <label
-                  class="emotion-6"
-                  for="headerCheckbox"
-                >
-                  <div
-                    class="emotion-4"
+              <div
+                class="emotion-7"
+              >
+                <div>
+                  <label
+                    class="emotion-6"
+                    for="headerCheckbox"
                   >
                     <div
-                      class="emotion-3"
+                      class="emotion-4"
                     >
-                      <input
-                        aria-checked="mixed"
-                        class="emotion-0"
-                        id="headerCheckbox"
-                        type="checkbox"
-                      />
-                      <span
-                        class="emotion-2"
+                      <div
+                        class="emotion-3"
                       >
-                        <svg
-                          aria-label="system-minus icon"
-                          class="emotion-1"
-                          height="16"
-                          preserveAspectRatio="xMinYMin meet"
-                          role="img"
-                          viewBox="0 0 16 16"
-                          width="16"
+                        <input
+                          aria-checked="mixed"
+                          class="emotion-0"
+                          id="headerCheckbox"
+                          type="checkbox"
+                        />
+                        <span
+                          class="emotion-2"
                         >
-                          <use
-                            href="#system-minus"
-                          />
-                        </svg>
-                      </span>
+                          <svg
+                            aria-label="system-minus icon"
+                            class="emotion-1"
+                            height="16"
+                            preserveAspectRatio="xMinYMin meet"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <use
+                              href="#system-minus"
+                            />
+                          </svg>
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="emotion-5"
-                  >
-                    Toggle all rows
-                  </div>
-                </label>
+                    <div
+                      class="emotion-5"
+                    >
+                      Toggle all rows
+                    </div>
+                  </label>
+                </div>
               </div>
             </div>
           </div>
           <div
-            class="emotion-8"
-            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            class="emotion-9"
+            style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
           >
             name
           </div>
@@ -762,41 +778,41 @@ exports[`CheckboxTable renders with checked row 1`] = `
       </div>
       <div
         class="TopRightGrid_ScrollWrapper"
-        style="left:302px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:722px"
+        style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-14"
+          class="ReactVirtualized__Grid emotion-15"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:722px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:604px;height:35px;max-width:604px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
-              class="emotion-8"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              class="emotion-9"
+              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
             >
               role
             </div>
             <div
-              class="emotion-8"
-              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+              class="emotion-9"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
             >
               state
             </div>
             <div
-              class="emotion-8"
-              style="height:35px;left:302px;position:absolute;top:0;width:151px"
+              class="emotion-9"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
             >
               zipcode
             </div>
             <div
-              class="emotion-8"
-              style="height:35px;left:453px;position:absolute;top:0;width:151px"
+              class="emotion-9"
+              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
             >
               city
             </div>
@@ -809,27 +825,27 @@ exports[`CheckboxTable renders with checked row 1`] = `
     >
       <div
         class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:302px"
+        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-14"
+          class="ReactVirtualized__Grid emotion-15"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:302px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:302px;height:70px;max-width:302px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
-              class="emotion-23"
+              class="emotion-24"
               data-rowindex="1"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              style="height:35px;left:0;position:absolute;top:0;width:24px"
             >
               <div
-                class="emotion-22"
+                class="emotion-23"
               >
                 <div>
                   <label
@@ -878,21 +894,21 @@ exports[`CheckboxTable renders with checked row 1`] = `
               </div>
             </div>
             <div
-              class="emotion-23"
+              class="emotion-24"
               data-rowindex="1"
-              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+              style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
             >
               <strong>
                 Brian Vaughn
               </strong>
             </div>
             <div
-              class="emotion-31"
+              class="emotion-32"
               data-rowindex="2"
-              style="height:35px;left:0;position:absolute;top:35px;width:151px"
+              style="height:35px;left:0;position:absolute;top:35px;width:24px"
             >
               <div
-                class="emotion-22"
+                class="emotion-23"
               >
                 <div>
                   <label
@@ -903,7 +919,7 @@ exports[`CheckboxTable renders with checked row 1`] = `
                       class="emotion-4"
                     >
                       <div
-                        class="emotion-26"
+                        class="emotion-27"
                       >
                         <input
                           aria-checked="false"
@@ -923,9 +939,9 @@ exports[`CheckboxTable renders with checked row 1`] = `
               </div>
             </div>
             <div
-              class="emotion-31"
+              class="emotion-32"
               data-rowindex="2"
-              style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+              style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
             >
               <strong>
                 Jon Doe
@@ -939,81 +955,81 @@ exports[`CheckboxTable renders with checked row 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:722px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:302px"
+        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
         tabindex="0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:604px;height:70px;max-width:604px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
-            class="emotion-23"
+            class="emotion-24"
             data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
           >
             <em>
               Software Engineer
             </em>
           </div>
           <div
-            class="emotion-23"
+            class="emotion-24"
             data-rowindex="1"
-            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
           >
             <span>
               CA
             </span>
           </div>
           <div
-            class="emotion-23"
+            class="emotion-24"
             data-rowindex="1"
-            style="height:35px;left:302px;position:absolute;top:0;width:151px"
+            style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
           >
             <span>
               95125
             </span>
           </div>
           <div
-            class="emotion-23"
+            class="emotion-24"
             data-rowindex="1"
-            style="height:35px;left:453px;position:absolute;top:0;width:151px"
+            style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
           >
             <strong>
               San Jose
             </strong>
           </div>
           <div
-            class="emotion-31"
+            class="emotion-32"
             data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:151px"
+            style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
           >
             <em>
               Product engineer
             </em>
           </div>
           <div
-            class="emotion-31"
+            class="emotion-32"
             data-rowindex="2"
-            style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <span>
               CA
             </span>
           </div>
           <div
-            class="emotion-31"
+            class="emotion-32"
             data-rowindex="2"
-            style="height:35px;left:302px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <span>
               95125
             </span>
           </div>
           <div
-            class="emotion-31"
+            class="emotion-32"
             data-rowindex="2"
-            style="height:35px;left:453px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <strong>
               Mountain View
@@ -1039,11 +1055,11 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   height: 1px;
 }
 
-.emotion-32 {
+.emotion-33 {
   font-weight: normal;
 }
 
-.emotion-32::after {
+.emotion-33::after {
   content: "";
   height: 100%;
   left: 0;
@@ -1053,15 +1069,19 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   width: 100%;
 }
 
-.emotion-12 {
+.emotion-13 {
   -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.emotion-12::-webkit-scrollbar {
+.emotion-13::-webkit-scrollbar {
   display: none;
 }
 
-.emotion-6 {
+.emotion-5 {
+  display: inline-block;
+}
+
+.emotion-7 {
   box-sizing: border-box;
   border-top: 1px solid #000;
   border-bottom: 1px solid #000;
@@ -1078,7 +1098,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   justify-content: center;
 }
 
-.emotion-5 {
+.emotion-6 {
   display: inline-block;
   height: auto;
   box-sizing: border-box;
@@ -1154,7 +1174,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   height: 1px;
 }
 
-.emotion-21 {
+.emotion-22 {
   box-sizing: border-box;
   border-bottom: 1px solid #DADDE2;
   white-space: nowrap;
@@ -1171,7 +1191,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   justify-content: center;
 }
 
-.emotion-20 {
+.emotion-21 {
   display: inline-block;
   height: auto;
   box-sizing: border-box;
@@ -1179,7 +1199,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   text-align: left;
 }
 
-.emotion-13 {
+.emotion-14 {
   color: #76797E;
   box-sizing: border-box;
   border-bottom: 1px solid #DADDE2;
@@ -1198,7 +1218,7 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
 }
 
 <div
-  class="emotion-32"
+  class="emotion-33"
   style="overflow:visible;height:0;width:0"
 >
   <div
@@ -1212,51 +1232,55 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:302px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
+        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:302px;height:35px;max-width:302px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+          style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
-            class="emotion-6"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            class="emotion-7"
+            style="height:35px;left:0;position:absolute;top:0;width:24px"
           >
             <div
-              class="emotion-5"
+              class="emotion-6"
             >
-              <div>
-                <label
-                  class="emotion-4"
-                  for="headerCheckbox"
-                >
-                  <div
-                    class="emotion-2"
+              <div
+                class="emotion-5"
+              >
+                <div>
+                  <label
+                    class="emotion-4"
+                    for="headerCheckbox"
                   >
                     <div
-                      class="emotion-1"
+                      class="emotion-2"
                     >
-                      <input
-                        aria-checked="0"
-                        class="emotion-0"
-                        id="headerCheckbox"
-                        type="checkbox"
-                      />
+                      <div
+                        class="emotion-1"
+                      >
+                        <input
+                          aria-checked="0"
+                          class="emotion-0"
+                          id="headerCheckbox"
+                          type="checkbox"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="emotion-3"
-                  >
-                    Toggle all rows
-                  </div>
-                </label>
+                    <div
+                      class="emotion-3"
+                    >
+                      Toggle all rows
+                    </div>
+                  </label>
+                </div>
               </div>
             </div>
           </div>
           <div
-            class="emotion-6"
-            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            class="emotion-7"
+            style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
           >
             name
           </div>
@@ -1264,41 +1288,41 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
       </div>
       <div
         class="TopRightGrid_ScrollWrapper"
-        style="left:302px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:722px"
+        style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-12"
+          class="ReactVirtualized__Grid emotion-13"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:722px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:604px;height:35px;max-width:604px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
-              class="emotion-6"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
             >
               role
             </div>
             <div
-              class="emotion-6"
-              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
             >
               state
             </div>
             <div
-              class="emotion-6"
-              style="height:35px;left:302px;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
             >
               zipcode
             </div>
             <div
-              class="emotion-6"
-              style="height:35px;left:453px;position:absolute;top:0;width:151px"
+              class="emotion-7"
+              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
             >
               city
             </div>
@@ -1311,41 +1335,41 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
     >
       <div
         class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:302px"
+        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-12"
+          class="ReactVirtualized__Grid emotion-13"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:302px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:302px;height:70px;max-width:302px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
-              class="emotion-13"
+              class="emotion-14"
               data-rowindex="1"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              style="height:35px;left:0;position:absolute;top:0;width:24px"
             />
             <div
-              class="emotion-13"
+              class="emotion-14"
               data-rowindex="1"
-              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+              style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
             >
               <strong>
                 Brian Vaughn
               </strong>
             </div>
             <div
-              class="emotion-21"
+              class="emotion-22"
               data-rowindex="2"
-              style="height:35px;left:0;position:absolute;top:35px;width:151px"
+              style="height:35px;left:0;position:absolute;top:35px;width:24px"
             >
               <div
-                class="emotion-20"
+                class="emotion-21"
               >
                 <div>
                   <label
@@ -1376,9 +1400,9 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
               </div>
             </div>
             <div
-              class="emotion-21"
+              class="emotion-22"
               data-rowindex="2"
-              style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+              style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
             >
               <strong>
                 Jon Doe
@@ -1392,81 +1416,81 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:722px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:302px"
+        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
         tabindex="0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:604px;height:70px;max-width:604px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
-            class="emotion-13"
+            class="emotion-14"
             data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
           >
             <em>
               Software Engineer
             </em>
           </div>
           <div
-            class="emotion-13"
+            class="emotion-14"
             data-rowindex="1"
-            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
           >
             <span>
               CA
             </span>
           </div>
           <div
-            class="emotion-13"
+            class="emotion-14"
             data-rowindex="1"
-            style="height:35px;left:302px;position:absolute;top:0;width:151px"
+            style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
           >
             <span>
               95125
             </span>
           </div>
           <div
-            class="emotion-13"
+            class="emotion-14"
             data-rowindex="1"
-            style="height:35px;left:453px;position:absolute;top:0;width:151px"
+            style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
           >
             <strong>
               San Jose
             </strong>
           </div>
           <div
-            class="emotion-21"
+            class="emotion-22"
             data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:151px"
+            style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
           >
             <em>
               Product engineer
             </em>
           </div>
           <div
-            class="emotion-21"
+            class="emotion-22"
             data-rowindex="2"
-            style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <span>
               CA
             </span>
           </div>
           <div
-            class="emotion-21"
+            class="emotion-22"
             data-rowindex="2"
-            style="height:35px;left:302px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <span>
               95125
             </span>
           </div>
           <div
-            class="emotion-21"
+            class="emotion-22"
             data-rowindex="2"
-            style="height:35px;left:453px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
           >
             <strong>
               Mountain View

--- a/packages/table/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Table.test.tsx.snap
@@ -475,16 +475,16 @@ exports[`Table renders with growToFill cols 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:151px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
+        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:204.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:151px;height:35px;max-width:151px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+          style="width:204.8px;height:35px;max-width:204.8px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
             class="emotion-0"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            style="height:35px;left:0;position:absolute;top:0;width:204.8px"
           >
             name
           </div>
@@ -492,41 +492,41 @@ exports[`Table renders with growToFill cols 1`] = `
       </div>
       <div
         class="TopRightGrid_ScrollWrapper"
-        style="left:151px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:873px"
+        style="left:204.8px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:819.2px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
           class="ReactVirtualized__Grid emotion-5"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:873px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:819.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:916.4000000000001px;height:35px;max-width:916.4000000000001px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:1024px;height:35px;max-width:1024px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-0"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              style="height:35px;left:0;position:absolute;top:0;width:204.8px"
             >
               role
             </div>
             <div
               class="emotion-0"
-              style="height:35px;left:151px;position:absolute;top:0;width:151px"
+              style="height:35px;left:204.8px;position:absolute;top:0;width:204.8px"
             >
               state
             </div>
             <div
               class="emotion-0"
-              style="height:35px;left:302px;position:absolute;top:0;width:307.2px"
+              style="height:35px;left:409.6px;position:absolute;top:0;width:307.2px"
             >
               zipcode
             </div>
             <div
               class="emotion-0"
-              style="height:35px;left:609.2px;position:absolute;top:0;width:307.2px"
+              style="height:35px;left:716.8px;position:absolute;top:0;width:307.2px"
             >
               city
             </div>
@@ -539,24 +539,24 @@ exports[`Table renders with growToFill cols 1`] = `
     >
       <div
         class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:151px"
+        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:204.8px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
           class="ReactVirtualized__Grid emotion-5"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:151px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:204.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:151px;height:70px;max-width:151px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            style="width:204.8px;height:70px;max-width:204.8px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-6"
               data-rowindex="1"
-              style="height:35px;left:0;position:absolute;top:0;width:151px"
+              style="height:35px;left:0;position:absolute;top:0;width:204.8px"
             >
               <strong>
                 Brian Vaughn
@@ -565,7 +565,7 @@ exports[`Table renders with growToFill cols 1`] = `
             <div
               class="emotion-6"
               data-rowindex="2"
-              style="height:35px;left:0;position:absolute;top:35px;width:151px"
+              style="height:35px;left:0;position:absolute;top:35px;width:204.8px"
             >
               <strong>
                 Jon Doe
@@ -579,18 +579,18 @@ exports[`Table renders with growToFill cols 1`] = `
         aria-readonly="true"
         class="ReactVirtualized__Grid"
         role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:873px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:151px"
+        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:819.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:204.8px"
         tabindex="0"
       >
         <div
           class="ReactVirtualized__Grid__innerScrollContainer"
           role="rowgroup"
-          style="width:916.4000000000001px;height:70px;max-width:916.4000000000001px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          style="width:1024px;height:70px;max-width:1024px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
         >
           <div
             class="emotion-6"
             data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:151px"
+            style="height:35px;left:0;position:absolute;top:0;width:204.8px"
           >
             <em>
               Software Engineer
@@ -599,7 +599,7 @@ exports[`Table renders with growToFill cols 1`] = `
           <div
             class="emotion-6"
             data-rowindex="1"
-            style="height:35px;left:151px;position:absolute;top:0;width:151px"
+            style="height:35px;left:204.8px;position:absolute;top:0;width:204.8px"
           >
             <span>
               CA
@@ -608,7 +608,7 @@ exports[`Table renders with growToFill cols 1`] = `
           <div
             class="emotion-6"
             data-rowindex="1"
-            style="height:35px;left:302px;position:absolute;top:0;width:307.2px"
+            style="height:35px;left:409.6px;position:absolute;top:0;width:307.2px"
           >
             <span>
               95125
@@ -617,7 +617,7 @@ exports[`Table renders with growToFill cols 1`] = `
           <div
             class="emotion-6"
             data-rowindex="1"
-            style="height:35px;left:609.2px;position:absolute;top:0;width:307.2px"
+            style="height:35px;left:716.8px;position:absolute;top:0;width:307.2px"
           >
             <strong>
               San Jose
@@ -626,7 +626,7 @@ exports[`Table renders with growToFill cols 1`] = `
           <div
             class="emotion-6"
             data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:151px"
+            style="height:35px;left:0;position:absolute;top:35px;width:204.8px"
           >
             <em>
               Product engineer
@@ -635,7 +635,7 @@ exports[`Table renders with growToFill cols 1`] = `
           <div
             class="emotion-6"
             data-rowindex="2"
-            style="height:35px;left:151px;position:absolute;top:35px;width:151px"
+            style="height:35px;left:204.8px;position:absolute;top:35px;width:204.8px"
           >
             <span>
               CA
@@ -644,7 +644,7 @@ exports[`Table renders with growToFill cols 1`] = `
           <div
             class="emotion-6"
             data-rowindex="2"
-            style="height:35px;left:302px;position:absolute;top:35px;width:307.2px"
+            style="height:35px;left:409.6px;position:absolute;top:35px;width:307.2px"
           >
             <span>
               95125
@@ -653,7 +653,7 @@ exports[`Table renders with growToFill cols 1`] = `
           <div
             class="emotion-6"
             data-rowindex="2"
-            style="height:35px;left:609.2px;position:absolute;top:35px;width:307.2px"
+            style="height:35px;left:716.8px;position:absolute;top:35px;width:307.2px"
           >
             <strong>
               Mountain View


### PR DESCRIPTION
This removes the Table's ability to measure all cells and calculate column widths based on content sizing. We're removing this because that functionality was making the Table's performance very poor in dcos-ui.

I investigated alternatives that would allow us to keep the content-based column width sizing, but could not find a way to do it that didn't seriously hurt Table performance.