### PR TITLE
feat(ui): onClose callback on tooltip

### DIFF
--- a/packages/tooltip/components/Tooltip.tsx
+++ b/packages/tooltip/components/Tooltip.tsx
@@ -16,6 +16,7 @@ export interface TooltipProps extends BaseTooltipProps {
   open?: boolean;
   suppress?: boolean;
   trigger: React.ReactNode;
+  onClose?: () => void;
 }
 
 export interface TooltipState {
@@ -99,7 +100,11 @@ class Tooltip extends React.PureComponent<TooltipProps, TooltipState> {
       return;
     }
 
-    this.setState({ open: false });
+    this.setState({ open: false }, () => {
+      if (this.props.onClose) {
+        this.props.onClose();
+      }
+    });
   }
 }
 

--- a/packages/tooltip/tests/Tooltip.test.tsx
+++ b/packages/tooltip/tests/Tooltip.test.tsx
@@ -73,4 +73,18 @@ describe("Tooltip", () => {
     component.simulate("mouseEnter");
     expect(component.state("open")).toBe(false);
   });
+
+  it("calls onClose prop when closed", () => {
+    const handleClose = jest.fn();
+
+    const component = mount(
+      <Tooltip id="hoverOpen" trigger="trigger" onClose={handleClose}>
+        content
+      </Tooltip>
+    );
+
+    component.simulate("mouseEnter");
+    component.simulate("mouseLeave");
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
It would be nice to know whenever the tooltip is closed, in case I want to reset its contents.

Example

"Copy to Clipboard" > "Copied!" > "Copy to Clipboard"