### PR TITLE
DCOS-50412: account for scrollbars for Table col widths

### DIFF
--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -104,33 +104,22 @@ storiesOf("Table", module)
         <Column
           header={<HeaderCell>name</HeaderCell>}
           cellRenderer={nameCellRenderer}
-          growToFill={true}
-          minWidth={100}
-          maxWidth={150}
         />
         <Column
           header={<HeaderCell>role</HeaderCell>}
           cellRenderer={roleCellRenderer}
-          growToFill={true}
         />
         <Column
           header={<HeaderCell>state</HeaderCell>}
           cellRenderer={stateCellRenderer}
-          growToFill={true}
-          minWidth={100}
-          maxWidth={150}
         />
         <Column
           header={<HeaderCell>Very Long</HeaderCell>}
           cellRenderer={veryLongRenderer}
-          growToFill={true}
         />
         <Column
           header={<HeaderCell textAlign="right">zip code</HeaderCell>}
           cellRenderer={zipcodeCellRenderer}
-          growToFill={true}
-          minWidth={100}
-          maxWidth={150}
         />
       </Table>
     </div>

--- a/packages/table/style.ts
+++ b/packages/table/style.ts
@@ -43,6 +43,10 @@ export const cellAlignmentCss = (textAlign: string) => css`
     : null};
 `;
 
+export const tableWrapper = css`
+  height: 100%;
+`;
+
 export const tableCss = css`
   font-weight: normal;
 
@@ -118,3 +122,14 @@ export const styleArrowDirection = displaySortDirection => {
       `;
   }
 };
+
+export const scrollbarMeas = css`
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+`;

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -13,6 +13,10 @@ exports[`CheckboxTable renders default 1`] = `
   height: 1px;
 }
 
+.emotion-41 {
+  height: 100%;
+}
+
 .emotion-39 {
   font-weight: normal;
 }
@@ -33,6 +37,17 @@ exports[`CheckboxTable renders default 1`] = `
 
 .emotion-13::-webkit-scrollbar {
   display: none;
+}
+
+.emotion-40 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
 }
 
 .emotion-5 {
@@ -158,319 +173,326 @@ exports[`CheckboxTable renders default 1`] = `
 }
 
 <div
-  class="emotion-39"
-  style="overflow:visible;height:0;width:0"
+  class="emotion-41"
 >
   <div
-    style="height:768px;overflow:visible;width:1024px"
+    class="emotion-39"
+    style="overflow:visible;height:0;width:0"
   >
     <div
-      style="height:35px;position:relative;width:1024px"
+      style="height:768px;overflow:visible;width:1024px"
     >
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
-      >
-        <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
-        >
-          <div
-            class="emotion-7"
-            style="height:35px;left:0;position:absolute;top:0;width:24px"
-          >
-            <div
-              class="emotion-6"
-            >
-              <div
-                class="emotion-5"
-              >
-                <div>
-                  <label
-                    class="emotion-4"
-                    for="headerCheckbox"
-                  >
-                    <div
-                      class="emotion-2"
-                    >
-                      <div
-                        class="emotion-1"
-                      >
-                        <input
-                          aria-checked="0"
-                          class="emotion-0"
-                          id="headerCheckbox"
-                          type="checkbox"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="emotion-3"
-                    >
-                      Toggle all rows
-                    </div>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="emotion-7"
-            style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            name
-          </div>
-        </div>
-      </div>
-      <div
-        class="TopRightGrid_ScrollWrapper"
-        style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
+        style="height:35px;position:relative;width:1024px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-13"
+          class="ReactVirtualized__Grid"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-7"
-              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
-            >
-              role
-            </div>
-            <div
-              class="emotion-7"
-              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              state
-            </div>
-            <div
-              class="emotion-7"
-              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              zipcode
-            </div>
-            <div
-              class="emotion-7"
-              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              city
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      style="height:733px;overflow:visible;position:relative;width:1024px"
-    >
-      <div
-        class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
-      >
-        <div
-          aria-label="grid"
-          aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-13"
-          role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
-        >
-          <div
-            class="ReactVirtualized__Grid__innerScrollContainer"
-            role="rowgroup"
-            style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
-          >
-            <div
-              class="emotion-20"
-              data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:24px"
             >
               <div
-                class="emotion-19"
+                class="emotion-6"
               >
-                <div>
-                  <label
-                    class="emotion-4"
-                    for="0"
-                  >
-                    <div
-                      class="emotion-2"
+                <div
+                  class="emotion-5"
+                >
+                  <div>
+                    <label
+                      class="emotion-4"
+                      for="headerCheckbox"
                     >
                       <div
-                        class="emotion-1"
+                        class="emotion-2"
                       >
-                        <input
-                          aria-checked="false"
-                          class="emotion-0"
-                          id="0"
-                          type="checkbox"
-                        />
+                        <div
+                          class="emotion-1"
+                        >
+                          <input
+                            aria-checked="0"
+                            class="emotion-0"
+                            id="headerCheckbox"
+                            type="checkbox"
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="emotion-3"
-                    >
-                      Toggle row 0
-                    </div>
-                  </label>
+                      <div
+                        class="emotion-3"
+                      >
+                        Toggle all rows
+                      </div>
+                    </label>
+                  </div>
                 </div>
               </div>
             </div>
             <div
-              class="emotion-20"
-              data-rowindex="1"
+              class="emotion-7"
               style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
             >
-              <strong>
-                Brian Vaughn
-              </strong>
+              name
             </div>
+          </div>
+        </div>
+        <div
+          class="TopRightGrid_ScrollWrapper"
+          style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
+        >
+          <div
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-13"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          >
             <div
-              class="emotion-20"
-              data-rowindex="2"
-              style="height:35px;left:0;position:absolute;top:35px;width:24px"
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
             >
               <div
-                class="emotion-19"
+                class="emotion-7"
+                style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
               >
-                <div>
-                  <label
-                    class="emotion-4"
-                    for="1"
-                  >
-                    <div
-                      class="emotion-2"
-                    >
-                      <div
-                        class="emotion-1"
-                      >
-                        <input
-                          aria-checked="false"
-                          class="emotion-0"
-                          id="1"
-                          type="checkbox"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="emotion-3"
-                    >
-                      Toggle row 1
-                    </div>
-                  </label>
-                </div>
+                role
               </div>
-            </div>
-            <div
-              class="emotion-20"
-              data-rowindex="2"
-              style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
-            >
-              <strong>
-                Jon Doe
-              </strong>
+              <div
+                class="emotion-7"
+                style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                state
+              </div>
+              <div
+                class="emotion-7"
+                style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                zipcode
+              </div>
+              <div
+                class="emotion-7"
+                style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                city
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
-        tabindex="0"
+        style="height:733px;overflow:visible;position:relative;width:1024px"
       >
         <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          class="BottomLeftGrid_ScrollWrapper"
+          style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
         >
           <div
-            class="emotion-20"
-            data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-13"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
           >
-            <em>
-              Software Engineer
-            </em>
+            <div
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            >
+              <div
+                class="emotion-20"
+                data-rowindex="1"
+                style="height:35px;left:0;position:absolute;top:0;width:24px"
+              >
+                <div
+                  class="emotion-19"
+                >
+                  <div>
+                    <label
+                      class="emotion-4"
+                      for="0"
+                    >
+                      <div
+                        class="emotion-2"
+                      >
+                        <div
+                          class="emotion-1"
+                        >
+                          <input
+                            aria-checked="false"
+                            class="emotion-0"
+                            id="0"
+                            type="checkbox"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="emotion-3"
+                      >
+                        Toggle row 0
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-20"
+                data-rowindex="1"
+                style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                <strong>
+                  Brian Vaughn
+                </strong>
+              </div>
+              <div
+                class="emotion-20"
+                data-rowindex="2"
+                style="height:35px;left:0;position:absolute;top:35px;width:24px"
+              >
+                <div
+                  class="emotion-19"
+                >
+                  <div>
+                    <label
+                      class="emotion-4"
+                      for="1"
+                    >
+                      <div
+                        class="emotion-2"
+                      >
+                        <div
+                          class="emotion-1"
+                        >
+                          <input
+                            aria-checked="false"
+                            class="emotion-0"
+                            id="1"
+                            type="checkbox"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="emotion-3"
+                      >
+                        Toggle row 1
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-20"
+                data-rowindex="2"
+                style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
+              >
+                <strong>
+                  Jon Doe
+                </strong>
+              </div>
+            </div>
           </div>
+        </div>
+        <div
+          aria-label="grid"
+          aria-readonly="true"
+          class="ReactVirtualized__Grid"
+          role="grid"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
+          tabindex="0"
+        >
           <div
-            class="emotion-20"
-            data-rowindex="1"
-            style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+            class="ReactVirtualized__Grid__innerScrollContainer"
+            role="rowgroup"
+            style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-20"
-            data-rowindex="1"
-            style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-20"
-            data-rowindex="1"
-            style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            <strong>
-              San Jose
-            </strong>
-          </div>
-          <div
-            class="emotion-20"
-            data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <em>
-              Product engineer
-            </em>
-          </div>
-          <div
-            class="emotion-20"
-            data-rowindex="2"
-            style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-20"
-            data-rowindex="2"
-            style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-20"
-            data-rowindex="2"
-            style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <strong>
-              Mountain View
-            </strong>
+            <div
+              class="emotion-20"
+              data-rowindex="1"
+              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <em>
+                Software Engineer
+              </em>
+            </div>
+            <div
+              class="emotion-20"
+              data-rowindex="1"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-20"
+              data-rowindex="1"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-20"
+              data-rowindex="1"
+              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <strong>
+                San Jose
+              </strong>
+            </div>
+            <div
+              class="emotion-20"
+              data-rowindex="2"
+              style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <em>
+                Product engineer
+              </em>
+            </div>
+            <div
+              class="emotion-20"
+              data-rowindex="2"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-20"
+              data-rowindex="2"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-20"
+              data-rowindex="2"
+              style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <strong>
+                Mountain View
+              </strong>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+  <div
+    class="emotion-40"
+  />
 </div>
 `;
 
@@ -485,6 +507,10 @@ exports[`CheckboxTable renders with checked row 1`] = `
   padding: 0;
   width: 1px;
   height: 1px;
+}
+
+.emotion-45 {
+  height: 100%;
 }
 
 .emotion-43 {
@@ -507,6 +533,17 @@ exports[`CheckboxTable renders with checked row 1`] = `
 
 .emotion-15::-webkit-scrollbar {
   display: none;
+}
+
+.emotion-44 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
 }
 
 .emotion-7 {
@@ -691,354 +728,361 @@ exports[`CheckboxTable renders with checked row 1`] = `
 }
 
 <div
-  class="emotion-43"
-  style="overflow:visible;height:0;width:0"
+  class="emotion-45"
 >
   <div
-    style="height:768px;overflow:visible;width:1024px"
+    class="emotion-43"
+    style="overflow:visible;height:0;width:0"
   >
     <div
-      style="height:35px;position:relative;width:1024px"
+      style="height:768px;overflow:visible;width:1024px"
     >
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
-      >
-        <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
-        >
-          <div
-            class="emotion-9"
-            style="height:35px;left:0;position:absolute;top:0;width:24px"
-          >
-            <div
-              class="emotion-8"
-            >
-              <div
-                class="emotion-7"
-              >
-                <div>
-                  <label
-                    class="emotion-6"
-                    for="headerCheckbox"
-                  >
-                    <div
-                      class="emotion-4"
-                    >
-                      <div
-                        class="emotion-3"
-                      >
-                        <input
-                          aria-checked="mixed"
-                          class="emotion-0"
-                          id="headerCheckbox"
-                          type="checkbox"
-                        />
-                        <span
-                          class="emotion-2"
-                        >
-                          <svg
-                            aria-label="system-minus icon"
-                            class="emotion-1"
-                            height="16"
-                            preserveAspectRatio="xMinYMin meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
-                          >
-                            <use
-                              href="#system-minus"
-                            />
-                          </svg>
-                        </span>
-                      </div>
-                    </div>
-                    <div
-                      class="emotion-5"
-                    >
-                      Toggle all rows
-                    </div>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="emotion-9"
-            style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            name
-          </div>
-        </div>
-      </div>
-      <div
-        class="TopRightGrid_ScrollWrapper"
-        style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
+        style="height:35px;position:relative;width:1024px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-15"
+          class="ReactVirtualized__Grid"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-9"
-              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
-            >
-              role
-            </div>
-            <div
-              class="emotion-9"
-              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              state
-            </div>
-            <div
-              class="emotion-9"
-              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              zipcode
-            </div>
-            <div
-              class="emotion-9"
-              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              city
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      style="height:733px;overflow:visible;position:relative;width:1024px"
-    >
-      <div
-        class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
-      >
-        <div
-          aria-label="grid"
-          aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-15"
-          role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
-        >
-          <div
-            class="ReactVirtualized__Grid__innerScrollContainer"
-            role="rowgroup"
-            style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
-          >
-            <div
-              class="emotion-24"
-              data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:24px"
             >
               <div
-                class="emotion-23"
+                class="emotion-8"
               >
-                <div>
-                  <label
-                    class="emotion-6"
-                    for="0"
-                  >
-                    <div
-                      class="emotion-4"
+                <div
+                  class="emotion-7"
+                >
+                  <div>
+                    <label
+                      class="emotion-6"
+                      for="headerCheckbox"
                     >
                       <div
-                        class="emotion-3"
+                        class="emotion-4"
                       >
-                        <input
-                          aria-checked="true"
-                          checked=""
-                          class="emotion-0"
-                          id="0"
-                          type="checkbox"
-                        />
-                        <span
-                          class="emotion-2"
+                        <div
+                          class="emotion-3"
                         >
-                          <svg
-                            aria-label="system-check icon"
-                            class="emotion-1"
-                            height="16"
-                            preserveAspectRatio="xMinYMin meet"
-                            role="img"
-                            viewBox="0 0 16 16"
-                            width="16"
+                          <input
+                            aria-checked="mixed"
+                            class="emotion-0"
+                            id="headerCheckbox"
+                            type="checkbox"
+                          />
+                          <span
+                            class="emotion-2"
                           >
-                            <use
-                              href="#system-check"
-                            />
-                          </svg>
-                        </span>
+                            <svg
+                              aria-label="system-minus icon"
+                              class="emotion-1"
+                              height="16"
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                            >
+                              <use
+                                href="#system-minus"
+                              />
+                            </svg>
+                          </span>
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="emotion-5"
-                    >
-                      Toggle row 0
-                    </div>
-                  </label>
+                      <div
+                        class="emotion-5"
+                      >
+                        Toggle all rows
+                      </div>
+                    </label>
+                  </div>
                 </div>
               </div>
             </div>
             <div
-              class="emotion-24"
-              data-rowindex="1"
+              class="emotion-9"
               style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
             >
-              <strong>
-                Brian Vaughn
-              </strong>
+              name
             </div>
+          </div>
+        </div>
+        <div
+          class="TopRightGrid_ScrollWrapper"
+          style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
+        >
+          <div
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-15"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          >
             <div
-              class="emotion-32"
-              data-rowindex="2"
-              style="height:35px;left:0;position:absolute;top:35px;width:24px"
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
             >
               <div
-                class="emotion-23"
+                class="emotion-9"
+                style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
               >
-                <div>
-                  <label
-                    class="emotion-6"
-                    for="1"
-                  >
-                    <div
-                      class="emotion-4"
-                    >
-                      <div
-                        class="emotion-27"
-                      >
-                        <input
-                          aria-checked="false"
-                          class="emotion-0"
-                          id="1"
-                          type="checkbox"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="emotion-5"
-                    >
-                      Toggle row 1
-                    </div>
-                  </label>
-                </div>
+                role
               </div>
-            </div>
-            <div
-              class="emotion-32"
-              data-rowindex="2"
-              style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
-            >
-              <strong>
-                Jon Doe
-              </strong>
+              <div
+                class="emotion-9"
+                style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                state
+              </div>
+              <div
+                class="emotion-9"
+                style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                zipcode
+              </div>
+              <div
+                class="emotion-9"
+                style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                city
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
-        tabindex="0"
+        style="height:733px;overflow:visible;position:relative;width:1024px"
       >
         <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          class="BottomLeftGrid_ScrollWrapper"
+          style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
         >
           <div
-            class="emotion-24"
-            data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-15"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
           >
-            <em>
-              Software Engineer
-            </em>
+            <div
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            >
+              <div
+                class="emotion-24"
+                data-rowindex="1"
+                style="height:35px;left:0;position:absolute;top:0;width:24px"
+              >
+                <div
+                  class="emotion-23"
+                >
+                  <div>
+                    <label
+                      class="emotion-6"
+                      for="0"
+                    >
+                      <div
+                        class="emotion-4"
+                      >
+                        <div
+                          class="emotion-3"
+                        >
+                          <input
+                            aria-checked="true"
+                            checked=""
+                            class="emotion-0"
+                            id="0"
+                            type="checkbox"
+                          />
+                          <span
+                            class="emotion-2"
+                          >
+                            <svg
+                              aria-label="system-check icon"
+                              class="emotion-1"
+                              height="16"
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 16 16"
+                              width="16"
+                            >
+                              <use
+                                href="#system-check"
+                              />
+                            </svg>
+                          </span>
+                        </div>
+                      </div>
+                      <div
+                        class="emotion-5"
+                      >
+                        Toggle row 0
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-24"
+                data-rowindex="1"
+                style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                <strong>
+                  Brian Vaughn
+                </strong>
+              </div>
+              <div
+                class="emotion-32"
+                data-rowindex="2"
+                style="height:35px;left:0;position:absolute;top:35px;width:24px"
+              >
+                <div
+                  class="emotion-23"
+                >
+                  <div>
+                    <label
+                      class="emotion-6"
+                      for="1"
+                    >
+                      <div
+                        class="emotion-4"
+                      >
+                        <div
+                          class="emotion-27"
+                        >
+                          <input
+                            aria-checked="false"
+                            class="emotion-0"
+                            id="1"
+                            type="checkbox"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="emotion-5"
+                      >
+                        Toggle row 1
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-32"
+                data-rowindex="2"
+                style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
+              >
+                <strong>
+                  Jon Doe
+                </strong>
+              </div>
+            </div>
           </div>
+        </div>
+        <div
+          aria-label="grid"
+          aria-readonly="true"
+          class="ReactVirtualized__Grid"
+          role="grid"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
+          tabindex="0"
+        >
           <div
-            class="emotion-24"
-            data-rowindex="1"
-            style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+            class="ReactVirtualized__Grid__innerScrollContainer"
+            role="rowgroup"
+            style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-24"
-            data-rowindex="1"
-            style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-24"
-            data-rowindex="1"
-            style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            <strong>
-              San Jose
-            </strong>
-          </div>
-          <div
-            class="emotion-32"
-            data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <em>
-              Product engineer
-            </em>
-          </div>
-          <div
-            class="emotion-32"
-            data-rowindex="2"
-            style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-32"
-            data-rowindex="2"
-            style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-32"
-            data-rowindex="2"
-            style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <strong>
-              Mountain View
-            </strong>
+            <div
+              class="emotion-24"
+              data-rowindex="1"
+              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <em>
+                Software Engineer
+              </em>
+            </div>
+            <div
+              class="emotion-24"
+              data-rowindex="1"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-24"
+              data-rowindex="1"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-24"
+              data-rowindex="1"
+              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <strong>
+                San Jose
+              </strong>
+            </div>
+            <div
+              class="emotion-32"
+              data-rowindex="2"
+              style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <em>
+                Product engineer
+              </em>
+            </div>
+            <div
+              class="emotion-32"
+              data-rowindex="2"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-32"
+              data-rowindex="2"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-32"
+              data-rowindex="2"
+              style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <strong>
+                Mountain View
+              </strong>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+  <div
+    class="emotion-44"
+  />
 </div>
 `;
 
@@ -1053,6 +1097,10 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   padding: 0;
   width: 1px;
   height: 1px;
+}
+
+.emotion-35 {
+  height: 100%;
 }
 
 .emotion-33 {
@@ -1075,6 +1123,17 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
 
 .emotion-13::-webkit-scrollbar {
   display: none;
+}
+
+.emotion-34 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
 }
 
 .emotion-5 {
@@ -1218,287 +1277,294 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
 }
 
 <div
-  class="emotion-33"
-  style="overflow:visible;height:0;width:0"
+  class="emotion-35"
 >
   <div
-    style="height:768px;overflow:visible;width:1024px"
+    class="emotion-33"
+    style="overflow:visible;height:0;width:0"
   >
     <div
-      style="height:35px;position:relative;width:1024px"
+      style="height:768px;overflow:visible;width:1024px"
     >
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
+        style="height:35px;position:relative;width:1024px"
       >
         <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+          aria-label="grid"
+          aria-readonly="true"
+          class="ReactVirtualized__Grid"
+          role="grid"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
         >
           <div
-            class="emotion-7"
-            style="height:35px;left:0;position:absolute;top:0;width:24px"
+            class="ReactVirtualized__Grid__innerScrollContainer"
+            role="rowgroup"
+            style="width:194.66666666666666px;height:35px;max-width:194.66666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
-              class="emotion-6"
+              class="emotion-7"
+              style="height:35px;left:0;position:absolute;top:0;width:24px"
             >
               <div
-                class="emotion-5"
+                class="emotion-6"
               >
-                <div>
-                  <label
-                    class="emotion-4"
-                    for="headerCheckbox"
-                  >
-                    <div
-                      class="emotion-2"
+                <div
+                  class="emotion-5"
+                >
+                  <div>
+                    <label
+                      class="emotion-4"
+                      for="headerCheckbox"
                     >
                       <div
-                        class="emotion-1"
+                        class="emotion-2"
                       >
-                        <input
-                          aria-checked="0"
-                          class="emotion-0"
-                          id="headerCheckbox"
-                          type="checkbox"
-                        />
+                        <div
+                          class="emotion-1"
+                        >
+                          <input
+                            aria-checked="0"
+                            class="emotion-0"
+                            id="headerCheckbox"
+                            type="checkbox"
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div
-                      class="emotion-3"
-                    >
-                      Toggle all rows
-                    </div>
-                  </label>
+                      <div
+                        class="emotion-3"
+                      >
+                        Toggle all rows
+                      </div>
+                    </label>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="emotion-7"
-            style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            name
-          </div>
-        </div>
-      </div>
-      <div
-        class="TopRightGrid_ScrollWrapper"
-        style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
-      >
-        <div
-          aria-label="grid"
-          aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-13"
-          role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
-        >
-          <div
-            class="ReactVirtualized__Grid__innerScrollContainer"
-            role="rowgroup"
-            style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
-          >
             <div
               class="emotion-7"
-              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
-            >
-              role
-            </div>
-            <div
-              class="emotion-7"
-              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              state
-            </div>
-            <div
-              class="emotion-7"
-              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              zipcode
-            </div>
-            <div
-              class="emotion-7"
-              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
-            >
-              city
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      style="height:733px;overflow:visible;position:relative;width:1024px"
-    >
-      <div
-        class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
-      >
-        <div
-          aria-label="grid"
-          aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-13"
-          role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
-        >
-          <div
-            class="ReactVirtualized__Grid__innerScrollContainer"
-            role="rowgroup"
-            style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
-          >
-            <div
-              class="emotion-14"
-              data-rowindex="1"
-              style="height:35px;left:0;position:absolute;top:0;width:24px"
-            />
-            <div
-              class="emotion-14"
-              data-rowindex="1"
               style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
             >
-              <strong>
-                Brian Vaughn
-              </strong>
+              name
             </div>
+          </div>
+        </div>
+        <div
+          class="TopRightGrid_ScrollWrapper"
+          style="left:194.66666666666666px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:829.3333333333334px"
+        >
+          <div
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-13"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          >
             <div
-              class="emotion-22"
-              data-rowindex="2"
-              style="height:35px;left:0;position:absolute;top:35px;width:24px"
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:682.6666666666666px;height:35px;max-width:682.6666666666666px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
             >
               <div
-                class="emotion-21"
+                class="emotion-7"
+                style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
               >
-                <div>
-                  <label
-                    class="emotion-4"
-                    for="1"
-                  >
-                    <div
-                      class="emotion-2"
-                    >
-                      <div
-                        class="emotion-1"
-                      >
-                        <input
-                          aria-checked="false"
-                          class="emotion-0"
-                          id="1"
-                          type="checkbox"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="emotion-3"
-                    >
-                      Toggle row 1
-                    </div>
-                  </label>
-                </div>
+                role
               </div>
-            </div>
-            <div
-              class="emotion-22"
-              data-rowindex="2"
-              style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
-            >
-              <strong>
-                Jon Doe
-              </strong>
+              <div
+                class="emotion-7"
+                style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                state
+              </div>
+              <div
+                class="emotion-7"
+                style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                zipcode
+              </div>
+              <div
+                class="emotion-7"
+                style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                city
+              </div>
             </div>
           </div>
         </div>
       </div>
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
-        tabindex="0"
+        style="height:733px;overflow:visible;position:relative;width:1024px"
       >
         <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+          class="BottomLeftGrid_ScrollWrapper"
+          style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:194.66666666666666px"
         >
           <div
-            class="emotion-14"
-            data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-13"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:194.66666666666666px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
           >
-            <em>
-              Software Engineer
-            </em>
+            <div
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:194.66666666666666px;height:70px;max-width:194.66666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            >
+              <div
+                class="emotion-14"
+                data-rowindex="1"
+                style="height:35px;left:0;position:absolute;top:0;width:24px"
+              />
+              <div
+                class="emotion-14"
+                data-rowindex="1"
+                style="height:35px;left:24px;position:absolute;top:0;width:170.66666666666666px"
+              >
+                <strong>
+                  Brian Vaughn
+                </strong>
+              </div>
+              <div
+                class="emotion-22"
+                data-rowindex="2"
+                style="height:35px;left:0;position:absolute;top:35px;width:24px"
+              >
+                <div
+                  class="emotion-21"
+                >
+                  <div>
+                    <label
+                      class="emotion-4"
+                      for="1"
+                    >
+                      <div
+                        class="emotion-2"
+                      >
+                        <div
+                          class="emotion-1"
+                        >
+                          <input
+                            aria-checked="false"
+                            class="emotion-0"
+                            id="1"
+                            type="checkbox"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        class="emotion-3"
+                      >
+                        Toggle row 1
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="emotion-22"
+                data-rowindex="2"
+                style="height:35px;left:24px;position:absolute;top:35px;width:170.66666666666666px"
+              >
+                <strong>
+                  Jon Doe
+                </strong>
+              </div>
+            </div>
           </div>
+        </div>
+        <div
+          aria-label="grid"
+          aria-readonly="true"
+          class="ReactVirtualized__Grid"
+          role="grid"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:829.3333333333334px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:194.66666666666666px"
+          tabindex="0"
+        >
           <div
-            class="emotion-14"
-            data-rowindex="1"
-            style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+            class="ReactVirtualized__Grid__innerScrollContainer"
+            role="rowgroup"
+            style="width:682.6666666666666px;height:70px;max-width:682.6666666666666px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-14"
-            data-rowindex="1"
-            style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-14"
-            data-rowindex="1"
-            style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
-          >
-            <strong>
-              San Jose
-            </strong>
-          </div>
-          <div
-            class="emotion-22"
-            data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <em>
-              Product engineer
-            </em>
-          </div>
-          <div
-            class="emotion-22"
-            data-rowindex="2"
-            style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-22"
-            data-rowindex="2"
-            style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-22"
-            data-rowindex="2"
-            style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
-          >
-            <strong>
-              Mountain View
-            </strong>
+            <div
+              class="emotion-14"
+              data-rowindex="1"
+              style="height:35px;left:0;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <em>
+                Software Engineer
+              </em>
+            </div>
+            <div
+              class="emotion-14"
+              data-rowindex="1"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-14"
+              data-rowindex="1"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-14"
+              data-rowindex="1"
+              style="height:35px;left:512px;position:absolute;top:0;width:170.66666666666666px"
+            >
+              <strong>
+                San Jose
+              </strong>
+            </div>
+            <div
+              class="emotion-22"
+              data-rowindex="2"
+              style="height:35px;left:0;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <em>
+                Product engineer
+              </em>
+            </div>
+            <div
+              class="emotion-22"
+              data-rowindex="2"
+              style="height:35px;left:170.66666666666666px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-22"
+              data-rowindex="2"
+              style="height:35px;left:341.3333333333333px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-22"
+              data-rowindex="2"
+              style="height:35px;left:512px;position:absolute;top:35px;width:170.66666666666666px"
+            >
+              <strong>
+                Mountain View
+              </strong>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+  <div
+    class="emotion-34"
+  />
 </div>
 `;

--- a/packages/table/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Table.test.tsx.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table renders again with new data 1`] = `
+.emotion-3 {
+  height: 100%;
+}
+
 .emotion-0 {
   font-weight: normal;
 }
@@ -13,6 +17,17 @@ exports[`Table renders again with new data 1`] = `
   pointer-events: none;
   top: 0;
   width: 100%;
+}
+
+.emotion-2 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
 }
 
 <Table
@@ -24,65 +39,76 @@ exports[`Table renders again with new data 1`] = `
     ]
   }
 >
-  <AutoSizer
-    __dataThatTriggersARerenderWhenChanged={
-      Array [
-        1,
-        2,
-        3,
-      ]
-    }
-    className="emotion-0"
-    defaultHeight={768}
-    defaultWidth={1024}
-    disableHeight={false}
-    disableWidth={false}
-    onResize={[Function]}
-    style={Object {}}
+  <div
+    className="emotion-3"
   >
-    <div
-      className="emotion-0"
-      style={
-        Object {
-          "height": 0,
-          "overflow": "visible",
-          "width": 0,
-        }
+    <AutoSizer
+      __dataThatTriggersARerenderWhenChanged={
+        Array [
+          1,
+          2,
+          3,
+        ]
       }
+      className="emotion-0"
+      defaultHeight={768}
+      defaultWidth={1024}
+      disableHeight={false}
+      disableWidth={false}
+      onResize={[Function]}
+      style={Object {}}
     >
-      <MultiGrid
-        cellRenderer={[Function]}
-        classNameBottomLeftGrid="css-1oay0jc"
-        classNameBottomRightGrid=""
-        classNameTopLeftGrid=""
-        classNameTopRightGrid="css-1oay0jc"
-        columnCount={1}
-        columnWidth={[Function]}
-        enableFixedColumnScroll={true}
-        enableFixedRowScroll={true}
-        fixedColumnCount={1}
-        fixedRowCount={1}
-        height={0}
-        hideBottomLeftGridScrollbar={true}
-        hideTopRightGridScrollbar={true}
-        onScroll={[Function]}
-        rowCount={4}
-        rowHeight={35}
-        scrollToColumn={-1}
-        scrollToRow={-1}
-        style={Object {}}
-        styleBottomLeftGrid={Object {}}
-        styleBottomRightGrid={Object {}}
-        styleTopLeftGrid={Object {}}
-        styleTopRightGrid={Object {}}
-        width={0}
-      />
-    </div>
-  </AutoSizer>
+      <div
+        className="emotion-0"
+        style={
+          Object {
+            "height": 0,
+            "overflow": "visible",
+            "width": 0,
+          }
+        }
+      >
+        <MultiGrid
+          cellRenderer={[Function]}
+          classNameBottomLeftGrid="css-1oay0jc"
+          classNameBottomRightGrid=""
+          classNameTopLeftGrid=""
+          classNameTopRightGrid="css-1oay0jc"
+          columnCount={1}
+          columnWidth={[Function]}
+          enableFixedColumnScroll={true}
+          enableFixedRowScroll={true}
+          fixedColumnCount={1}
+          fixedRowCount={1}
+          height={0}
+          hideBottomLeftGridScrollbar={true}
+          hideTopRightGridScrollbar={true}
+          onScroll={[Function]}
+          rowCount={4}
+          rowHeight={35}
+          scrollToColumn={-1}
+          scrollToRow={-1}
+          style={Object {}}
+          styleBottomLeftGrid={Object {}}
+          styleBottomRightGrid={Object {}}
+          styleTopLeftGrid={Object {}}
+          styleTopRightGrid={Object {}}
+          width={0}
+        />
+      </div>
+    </AutoSizer>
+    <div
+      className="emotion-2"
+    />
+  </div>
 </Table>
 `;
 
 exports[`Table renders again with new data 2`] = `
+.emotion-3 {
+  height: 100%;
+}
+
 .emotion-0 {
   font-weight: normal;
 }
@@ -97,6 +123,17 @@ exports[`Table renders again with new data 2`] = `
   width: 100%;
 }
 
+.emotion-2 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+}
+
 <Table
   data={
     Array [
@@ -106,65 +143,76 @@ exports[`Table renders again with new data 2`] = `
     ]
   }
 >
-  <AutoSizer
-    __dataThatTriggersARerenderWhenChanged={
-      Array [
-        4,
-        5,
-        6,
-      ]
-    }
-    className="emotion-0"
-    defaultHeight={768}
-    defaultWidth={1024}
-    disableHeight={false}
-    disableWidth={false}
-    onResize={[Function]}
-    style={Object {}}
+  <div
+    className="emotion-3"
   >
-    <div
-      className="emotion-0"
-      style={
-        Object {
-          "height": 0,
-          "overflow": "visible",
-          "width": 0,
-        }
+    <AutoSizer
+      __dataThatTriggersARerenderWhenChanged={
+        Array [
+          4,
+          5,
+          6,
+        ]
       }
+      className="emotion-0"
+      defaultHeight={768}
+      defaultWidth={1024}
+      disableHeight={false}
+      disableWidth={false}
+      onResize={[Function]}
+      style={Object {}}
     >
-      <MultiGrid
-        cellRenderer={[Function]}
-        classNameBottomLeftGrid="css-1oay0jc"
-        classNameBottomRightGrid=""
-        classNameTopLeftGrid=""
-        classNameTopRightGrid="css-1oay0jc"
-        columnCount={1}
-        columnWidth={[Function]}
-        enableFixedColumnScroll={true}
-        enableFixedRowScroll={true}
-        fixedColumnCount={1}
-        fixedRowCount={1}
-        height={0}
-        hideBottomLeftGridScrollbar={true}
-        hideTopRightGridScrollbar={true}
-        onScroll={[Function]}
-        rowCount={4}
-        rowHeight={35}
-        scrollToColumn={-1}
-        scrollToRow={-1}
-        style={Object {}}
-        styleBottomLeftGrid={Object {}}
-        styleBottomRightGrid={Object {}}
-        styleTopLeftGrid={Object {}}
-        styleTopRightGrid={Object {}}
-        width={0}
-      />
-    </div>
-  </AutoSizer>
+      <div
+        className="emotion-0"
+        style={
+          Object {
+            "height": 0,
+            "overflow": "visible",
+            "width": 0,
+          }
+        }
+      >
+        <MultiGrid
+          cellRenderer={[Function]}
+          classNameBottomLeftGrid="css-1oay0jc"
+          classNameBottomRightGrid=""
+          classNameTopLeftGrid=""
+          classNameTopRightGrid="css-1oay0jc"
+          columnCount={1}
+          columnWidth={[Function]}
+          enableFixedColumnScroll={true}
+          enableFixedRowScroll={true}
+          fixedColumnCount={1}
+          fixedRowCount={1}
+          height={0}
+          hideBottomLeftGridScrollbar={true}
+          hideTopRightGridScrollbar={true}
+          onScroll={[Function]}
+          rowCount={4}
+          rowHeight={35}
+          scrollToColumn={-1}
+          scrollToRow={-1}
+          style={Object {}}
+          styleBottomLeftGrid={Object {}}
+          styleBottomRightGrid={Object {}}
+          styleTopLeftGrid={Object {}}
+          styleTopRightGrid={Object {}}
+          width={0}
+        />
+      </div>
+    </AutoSizer>
+    <div
+      className="emotion-2"
+    />
+  </div>
 </Table>
 `;
 
 exports[`Table renders default 1`] = `
+.emotion-16 {
+  height: 100%;
+}
+
 .emotion-14 {
   font-weight: normal;
 }
@@ -185,6 +233,17 @@ exports[`Table renders default 1`] = `
 
 .emotion-4::-webkit-scrollbar {
   display: none;
+}
+
+.emotion-15 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
 }
 
 .emotion-0 {
@@ -222,188 +281,199 @@ exports[`Table renders default 1`] = `
 }
 
 <div
-  class="emotion-14"
-  style="overflow:visible;height:0;width:0"
+  class="emotion-16"
 >
   <div
-    style="height:768px;overflow:visible;width:1024px"
+    class="emotion-14"
+    style="overflow:visible;height:0;width:0"
   >
     <div
-      style="height:35px;position:relative;width:1024px"
+      style="height:768px;overflow:visible;width:1024px"
     >
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:307.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
-      >
-        <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:307.2px;height:35px;max-width:307.2px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
-        >
-          <div
-            class="emotion-0"
-            style="height:35px;left:0;position:absolute;top:0;width:307.2px"
-          >
-            name
-          </div>
-        </div>
-      </div>
-      <div
-        class="TopRightGrid_ScrollWrapper"
-        style="left:307.2px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:716.8px"
+        style="height:35px;position:relative;width:1024px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-4"
+          class="ReactVirtualized__Grid"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:716.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:307.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:1021.5999999999999px;height:35px;max-width:1021.5999999999999px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:307.2px;height:35px;max-width:307.2px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-0"
               style="height:35px;left:0;position:absolute;top:0;width:307.2px"
             >
-              role
+              name
             </div>
+          </div>
+        </div>
+        <div
+          class="TopRightGrid_ScrollWrapper"
+          style="left:307.2px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:716.8px"
+        >
+          <div
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-4"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:716.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          >
             <div
-              class="emotion-0"
-              style="height:35px;left:307.2px;position:absolute;top:0;width:307.2px"
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:1021.5999999999999px;height:35px;max-width:1021.5999999999999px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
             >
-              state
-            </div>
-            <div
-              class="emotion-0"
-              style="height:35px;left:614.4px;position:absolute;top:0;width:307.2px"
-            >
-              zipcode
+              <div
+                class="emotion-0"
+                style="height:35px;left:0;position:absolute;top:0;width:307.2px"
+              >
+                role
+              </div>
+              <div
+                class="emotion-0"
+                style="height:35px;left:307.2px;position:absolute;top:0;width:307.2px"
+              >
+                state
+              </div>
+              <div
+                class="emotion-0"
+                style="height:35px;left:614.4px;position:absolute;top:0;width:307.2px"
+              >
+                zipcode
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      style="height:733px;overflow:visible;position:relative;width:1024px"
-    >
       <div
-        class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:307.2px"
+        style="height:733px;overflow:visible;position:relative;width:1024px"
       >
+        <div
+          class="BottomLeftGrid_ScrollWrapper"
+          style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:307.2px"
+        >
+          <div
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-4"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:307.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          >
+            <div
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:307.2px;height:70px;max-width:307.2px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            >
+              <div
+                class="emotion-5"
+                data-rowindex="1"
+                style="height:35px;left:0;position:absolute;top:0;width:307.2px"
+              >
+                <strong>
+                  Brian Vaughn
+                </strong>
+              </div>
+              <div
+                class="emotion-5"
+                data-rowindex="2"
+                style="height:35px;left:0;position:absolute;top:35px;width:307.2px"
+              >
+                <strong>
+                  Jon Doe
+                </strong>
+              </div>
+            </div>
+          </div>
+        </div>
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-4"
+          class="ReactVirtualized__Grid"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:307.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:716.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:307.2px"
+          tabindex="0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:307.2px;height:70px;max-width:307.2px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            style="width:1021.5999999999999px;height:70px;max-width:1021.5999999999999px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-5"
               data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:307.2px"
             >
-              <strong>
-                Brian Vaughn
-              </strong>
+              <em>
+                Software Engineer
+              </em>
+            </div>
+            <div
+              class="emotion-5"
+              data-rowindex="1"
+              style="height:35px;left:307.2px;position:absolute;top:0;width:307.2px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-5"
+              data-rowindex="1"
+              style="height:35px;left:614.4px;position:absolute;top:0;width:307.2px"
+            >
+              <span>
+                95125
+              </span>
             </div>
             <div
               class="emotion-5"
               data-rowindex="2"
               style="height:35px;left:0;position:absolute;top:35px;width:307.2px"
             >
-              <strong>
-                Jon Doe
-              </strong>
+              <em>
+                Product engineer
+              </em>
             </div>
-          </div>
-        </div>
-      </div>
-      <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:716.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:307.2px"
-        tabindex="0"
-      >
-        <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:1021.5999999999999px;height:70px;max-width:1021.5999999999999px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
-        >
-          <div
-            class="emotion-5"
-            data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:307.2px"
-          >
-            <em>
-              Software Engineer
-            </em>
-          </div>
-          <div
-            class="emotion-5"
-            data-rowindex="1"
-            style="height:35px;left:307.2px;position:absolute;top:0;width:307.2px"
-          >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-5"
-            data-rowindex="1"
-            style="height:35px;left:614.4px;position:absolute;top:0;width:307.2px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-5"
-            data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:307.2px"
-          >
-            <em>
-              Product engineer
-            </em>
-          </div>
-          <div
-            class="emotion-5"
-            data-rowindex="2"
-            style="height:35px;left:307.2px;position:absolute;top:35px;width:307.2px"
-          >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-5"
-            data-rowindex="2"
-            style="height:35px;left:614.4px;position:absolute;top:35px;width:307.2px"
-          >
-            <span>
-              95125
-            </span>
+            <div
+              class="emotion-5"
+              data-rowindex="2"
+              style="height:35px;left:307.2px;position:absolute;top:35px;width:307.2px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-5"
+              data-rowindex="2"
+              style="height:35px;left:614.4px;position:absolute;top:35px;width:307.2px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
+  <div
+    class="emotion-15"
+  />
 </div>
 `;
 
 exports[`Table renders with growToFill cols 1`] = `
+.emotion-19 {
+  height: 100%;
+}
+
 .emotion-17 {
   font-weight: normal;
 }
@@ -424,6 +494,17 @@ exports[`Table renders with growToFill cols 1`] = `
 
 .emotion-5::-webkit-scrollbar {
   display: none;
+}
+
+.emotion-18 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
 }
 
 .emotion-0 {
@@ -461,105 +542,169 @@ exports[`Table renders with growToFill cols 1`] = `
 }
 
 <div
-  class="emotion-17"
-  style="overflow:visible;height:0;width:0"
+  class="emotion-19"
 >
   <div
-    style="height:768px;overflow:visible;width:1024px"
+    class="emotion-17"
+    style="overflow:visible;height:0;width:0"
   >
     <div
-      style="height:35px;position:relative;width:1024px"
+      style="height:768px;overflow:visible;width:1024px"
     >
       <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:204.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
-      >
-        <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:204.8px;height:35px;max-width:204.8px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
-        >
-          <div
-            class="emotion-0"
-            style="height:35px;left:0;position:absolute;top:0;width:204.8px"
-          >
-            name
-          </div>
-        </div>
-      </div>
-      <div
-        class="TopRightGrid_ScrollWrapper"
-        style="left:204.8px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:819.2px"
+        style="height:35px;position:relative;width:1024px"
       >
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-5"
+          class="ReactVirtualized__Grid"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:819.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:204.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:hidden;left:0;top:0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:1024px;height:35px;max-width:1024px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
+            style="width:204.8px;height:35px;max-width:204.8px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-0"
               style="height:35px;left:0;position:absolute;top:0;width:204.8px"
             >
-              role
+              name
             </div>
+          </div>
+        </div>
+        <div
+          class="TopRightGrid_ScrollWrapper"
+          style="left:204.8px;overflow-x:hidden;overflow-y:hidden;position:absolute;top:0;height:35px;width:819.2px"
+        >
+          <div
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-5"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:35px;position:absolute;width:819.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:0;top:0"
+          >
             <div
-              class="emotion-0"
-              style="height:35px;left:204.8px;position:absolute;top:0;width:204.8px"
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:1024px;height:35px;max-width:1024px;max-height:35px;overflow:hidden;pointer-events:;position:relative"
             >
-              state
-            </div>
-            <div
-              class="emotion-0"
-              style="height:35px;left:409.6px;position:absolute;top:0;width:307.2px"
-            >
-              zipcode
-            </div>
-            <div
-              class="emotion-0"
-              style="height:35px;left:716.8px;position:absolute;top:0;width:307.2px"
-            >
-              city
+              <div
+                class="emotion-0"
+                style="height:35px;left:0;position:absolute;top:0;width:204.8px"
+              >
+                role
+              </div>
+              <div
+                class="emotion-0"
+                style="height:35px;left:204.8px;position:absolute;top:0;width:204.8px"
+              >
+                state
+              </div>
+              <div
+                class="emotion-0"
+                style="height:35px;left:409.6px;position:absolute;top:0;width:307.2px"
+              >
+                zipcode
+              </div>
+              <div
+                class="emotion-0"
+                style="height:35px;left:716.8px;position:absolute;top:0;width:307.2px"
+              >
+                city
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      style="height:733px;overflow:visible;position:relative;width:1024px"
-    >
       <div
-        class="BottomLeftGrid_ScrollWrapper"
-        style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:204.8px"
+        style="height:733px;overflow:visible;position:relative;width:1024px"
       >
+        <div
+          class="BottomLeftGrid_ScrollWrapper"
+          style="left:0;overflow-x:hidden;overflow-y:hidden;position:absolute;height:733px;width:204.8px"
+        >
+          <div
+            aria-label="grid"
+            aria-readonly="true"
+            class="ReactVirtualized__Grid emotion-5"
+            role="grid"
+            style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:204.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          >
+            <div
+              class="ReactVirtualized__Grid__innerScrollContainer"
+              role="rowgroup"
+              style="width:204.8px;height:70px;max-width:204.8px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            >
+              <div
+                class="emotion-6"
+                data-rowindex="1"
+                style="height:35px;left:0;position:absolute;top:0;width:204.8px"
+              >
+                <strong>
+                  Brian Vaughn
+                </strong>
+              </div>
+              <div
+                class="emotion-6"
+                data-rowindex="2"
+                style="height:35px;left:0;position:absolute;top:35px;width:204.8px"
+              >
+                <strong>
+                  Jon Doe
+                </strong>
+              </div>
+            </div>
+          </div>
+        </div>
         <div
           aria-label="grid"
           aria-readonly="true"
-          class="ReactVirtualized__Grid emotion-5"
+          class="ReactVirtualized__Grid"
           role="grid"
-          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:204.8px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:hidden;overflow-y:auto;left:0"
+          style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:819.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:204.8px"
+          tabindex="0"
         >
           <div
             class="ReactVirtualized__Grid__innerScrollContainer"
             role="rowgroup"
-            style="width:204.8px;height:70px;max-width:204.8px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
+            style="width:1024px;height:70px;max-width:1024px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
           >
             <div
               class="emotion-6"
               data-rowindex="1"
               style="height:35px;left:0;position:absolute;top:0;width:204.8px"
             >
+              <em>
+                Software Engineer
+              </em>
+            </div>
+            <div
+              class="emotion-6"
+              data-rowindex="1"
+              style="height:35px;left:204.8px;position:absolute;top:0;width:204.8px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-6"
+              data-rowindex="1"
+              style="height:35px;left:409.6px;position:absolute;top:0;width:307.2px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-6"
+              data-rowindex="1"
+              style="height:35px;left:716.8px;position:absolute;top:0;width:307.2px"
+            >
               <strong>
-                Brian Vaughn
+                San Jose
               </strong>
             </div>
             <div
@@ -567,101 +712,44 @@ exports[`Table renders with growToFill cols 1`] = `
               data-rowindex="2"
               style="height:35px;left:0;position:absolute;top:35px;width:204.8px"
             >
+              <em>
+                Product engineer
+              </em>
+            </div>
+            <div
+              class="emotion-6"
+              data-rowindex="2"
+              style="height:35px;left:204.8px;position:absolute;top:35px;width:204.8px"
+            >
+              <span>
+                CA
+              </span>
+            </div>
+            <div
+              class="emotion-6"
+              data-rowindex="2"
+              style="height:35px;left:409.6px;position:absolute;top:35px;width:307.2px"
+            >
+              <span>
+                95125
+              </span>
+            </div>
+            <div
+              class="emotion-6"
+              data-rowindex="2"
+              style="height:35px;left:716.8px;position:absolute;top:35px;width:307.2px"
+            >
               <strong>
-                Jon Doe
+                Mountain View
               </strong>
             </div>
           </div>
         </div>
       </div>
-      <div
-        aria-label="grid"
-        aria-readonly="true"
-        class="ReactVirtualized__Grid"
-        role="grid"
-        style="box-sizing:border-box;direction:ltr;height:733px;position:absolute;width:819.2px;-webkit-overflow-scrolling:touch;will-change:transform;overflow-x:auto;overflow-y:hidden;left:204.8px"
-        tabindex="0"
-      >
-        <div
-          class="ReactVirtualized__Grid__innerScrollContainer"
-          role="rowgroup"
-          style="width:1024px;height:70px;max-width:1024px;max-height:70px;overflow:hidden;pointer-events:;position:relative"
-        >
-          <div
-            class="emotion-6"
-            data-rowindex="1"
-            style="height:35px;left:0;position:absolute;top:0;width:204.8px"
-          >
-            <em>
-              Software Engineer
-            </em>
-          </div>
-          <div
-            class="emotion-6"
-            data-rowindex="1"
-            style="height:35px;left:204.8px;position:absolute;top:0;width:204.8px"
-          >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-6"
-            data-rowindex="1"
-            style="height:35px;left:409.6px;position:absolute;top:0;width:307.2px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-6"
-            data-rowindex="1"
-            style="height:35px;left:716.8px;position:absolute;top:0;width:307.2px"
-          >
-            <strong>
-              San Jose
-            </strong>
-          </div>
-          <div
-            class="emotion-6"
-            data-rowindex="2"
-            style="height:35px;left:0;position:absolute;top:35px;width:204.8px"
-          >
-            <em>
-              Product engineer
-            </em>
-          </div>
-          <div
-            class="emotion-6"
-            data-rowindex="2"
-            style="height:35px;left:204.8px;position:absolute;top:35px;width:204.8px"
-          >
-            <span>
-              CA
-            </span>
-          </div>
-          <div
-            class="emotion-6"
-            data-rowindex="2"
-            style="height:35px;left:409.6px;position:absolute;top:35px;width:307.2px"
-          >
-            <span>
-              95125
-            </span>
-          </div>
-          <div
-            class="emotion-6"
-            data-rowindex="2"
-            style="height:35px;left:716.8px;position:absolute;top:35px;width:307.2px"
-          >
-            <strong>
-              Mountain View
-            </strong>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
+  <div
+    class="emotion-18"
+  />
 </div>
 `;


### PR DESCRIPTION
Before, table column widths were being calculated based on the width of the area the table filled. However, on Windows and Linux, a scrollbar is displayed on the right and causes a horizontal scroll.

Now, we measure the scrollbar width and factor that into the column width calculations.

![TableScrollbarFix](https://user-images.githubusercontent.com/2313998/54728220-e56c6b00-4b52-11e9-9558-798b29e33c9b.gif)