### PR TITLE
rm table wrapper div that breaks integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "react-virtualized": "9.20.1"
   },
   "peerDependencies": {
-    "react": ">=15.4.1 <16.9.0 || 16.7.0-alpha.0",
-    "react-dom": ">=15.4.1 <16.9.0 || 16.7.0-alpha.0"
+    "react": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0",
+    "react-dom": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0"
   },
   "devDependencies": {
     "acorn": "^6.0.5",

--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -22,7 +22,6 @@ import {
   topLeftGrid,
   hideScrollbarCss,
   rowHoverStyles,
-  tableWrapper,
   scrollbarMeas,
   dragHandle,
   unsetContainerOverflow,
@@ -268,7 +267,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
 
   public render() {
     return (
-      <div className={tableWrapper}>
+      <React.Fragment>
         <AutoSizer
           __dataThatTriggersARerenderWhenChanged={this.props.data} // passed to notify react-virtualized about updates
           className={tableCss}
@@ -285,7 +284,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
           accurately calculate column widths
         */}
         <div className={scrollbarMeas} ref={this.scrollMeasRef} />
-      </div>
+      </React.Fragment>
     );
   }
 

--- a/packages/table/style.ts
+++ b/packages/table/style.ts
@@ -63,10 +63,6 @@ export const preventSortOverlap = (iconSize: string) => css`
   }
 `;
 
-export const tableWrapper = css`
-  height: 100%;
-`;
-
 export const tableCss = css`
   font-weight: normal;
 

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CheckboxTable renders default 1`] = `
-.emotion-0 {
+Array [
+  .emotion-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -11,10 +12,6 @@ exports[`CheckboxTable renders default 1`] = `
   padding: 0;
   width: 1px;
   height: 1px;
-}
-
-.emotion-61 {
-  height: 100%;
 }
 
 .emotion-59 {
@@ -41,17 +38,6 @@ exports[`CheckboxTable renders default 1`] = `
 
 .emotion-49::-webkit-scrollbar {
   display: none;
-}
-
-.emotion-60 {
-  height: 100px;
-  overflow: scroll;
-  msoverflowstyle: scrollbar;
-  opacity: 0;
-  position: absolute;
-  top: -100000px;
-  visibility: hidden;
-  width: 100px;
 }
 
 .emotion-5 {
@@ -259,9 +245,6 @@ exports[`CheckboxTable renders default 1`] = `
 }
 
 <div
-  class="emotion-61"
->
-  <div
     class="emotion-59"
     style="overflow:visible;height:0;width:0"
   >
@@ -641,15 +624,27 @@ exports[`CheckboxTable renders default 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="emotion-60"
-  />
-</div>
+  </div>,
+  .emotion-0 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+}
+
+<div
+    class="emotion-0"
+  />,
+]
 `;
 
 exports[`CheckboxTable renders with checked row 1`] = `
-.emotion-0 {
+Array [
+  .emotion-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -659,10 +654,6 @@ exports[`CheckboxTable renders with checked row 1`] = `
   padding: 0;
   width: 1px;
   height: 1px;
-}
-
-.emotion-65 {
-  height: 100%;
 }
 
 .emotion-63 {
@@ -689,17 +680,6 @@ exports[`CheckboxTable renders with checked row 1`] = `
 
 .emotion-53::-webkit-scrollbar {
   display: none;
-}
-
-.emotion-64 {
-  height: 100px;
-  overflow: scroll;
-  msoverflowstyle: scrollbar;
-  opacity: 0;
-  position: absolute;
-  top: -100000px;
-  visibility: hidden;
-  width: 100px;
 }
 
 .emotion-7 {
@@ -966,9 +946,6 @@ exports[`CheckboxTable renders with checked row 1`] = `
 }
 
 <div
-  class="emotion-65"
->
-  <div
     class="emotion-63"
     style="overflow:visible;height:0;width:0"
   >
@@ -1383,15 +1360,27 @@ exports[`CheckboxTable renders with checked row 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="emotion-64"
-  />
-</div>
+  </div>,
+  .emotion-0 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+}
+
+<div
+    class="emotion-0"
+  />,
+]
 `;
 
 exports[`CheckboxTable renders with disabled and muted row 1`] = `
-.emotion-0 {
+Array [
+  .emotion-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -1401,10 +1390,6 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
   padding: 0;
   width: 1px;
   height: 1px;
-}
-
-.emotion-55 {
-  height: 100%;
 }
 
 .emotion-53 {
@@ -1431,17 +1416,6 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
 
 .emotion-43::-webkit-scrollbar {
   display: none;
-}
-
-.emotion-54 {
-  height: 100px;
-  overflow: scroll;
-  msoverflowstyle: scrollbar;
-  opacity: 0;
-  position: absolute;
-  top: -100000px;
-  visibility: hidden;
-  width: 100px;
 }
 
 .emotion-5 {
@@ -1667,9 +1641,6 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
 }
 
 <div
-  class="emotion-55"
->
-  <div
     class="emotion-53"
     style="overflow:visible;height:0;width:0"
   >
@@ -2018,9 +1989,20 @@ exports[`CheckboxTable renders with disabled and muted row 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="emotion-54"
-  />
-</div>
+  </div>,
+  .emotion-0 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+}
+
+<div
+    class="emotion-0"
+  />,
+]
 `;

--- a/packages/table/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Table.test.tsx.snap
@@ -1,11 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table renders a table with resizable columns 1`] = `
-.emotion-42 {
-  height: 100%;
-}
-
-.emotion-40 {
+Array [
+  .emotion-40 {
   font-weight: normal;
 }
 
@@ -29,17 +26,6 @@ exports[`Table renders a table with resizable columns 1`] = `
 
 .emotion-32::-webkit-scrollbar {
   display: none;
-}
-
-.emotion-41 {
-  height: 100px;
-  overflow: scroll;
-  msoverflowstyle: scrollbar;
-  opacity: 0;
-  position: absolute;
-  top: -100000px;
-  visibility: hidden;
-  width: 100px;
 }
 
 .emotion-3 {
@@ -194,9 +180,6 @@ exports[`Table renders a table with resizable columns 1`] = `
 }
 
 <div
-  class="emotion-42"
->
-  <div
     class="emotion-40"
     style="overflow:visible;height:0;width:0"
   >
@@ -511,18 +494,25 @@ exports[`Table renders a table with resizable columns 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="emotion-41"
-  />
-</div>
+  </div>,
+  .emotion-0 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+}
+
+<div
+    class="emotion-0"
+  />,
+]
 `;
 
 exports[`Table renders again with new data 1`] = `
-.emotion-3 {
-  height: 100%;
-}
-
 .emotion-0 {
   font-weight: normal;
 }
@@ -557,77 +547,69 @@ exports[`Table renders again with new data 1`] = `
     ]
   }
 >
-  <div
-    className="emotion-3"
+  <AutoSizer
+    __dataThatTriggersARerenderWhenChanged={
+      Array [
+        1,
+        2,
+        3,
+      ]
+    }
+    className="emotion-0"
+    defaultHeight={768}
+    defaultWidth={1024}
+    disableHeight={false}
+    disableWidth={false}
+    onResize={[Function]}
+    style={Object {}}
   >
-    <AutoSizer
-      __dataThatTriggersARerenderWhenChanged={
-        Array [
-          1,
-          2,
-          3,
-        ]
-      }
-      className="emotion-0"
-      defaultHeight={768}
-      defaultWidth={1024}
-      disableHeight={false}
-      disableWidth={false}
-      onResize={[Function]}
-      style={Object {}}
-    >
-      <div
-        className="emotion-0"
-        style={
-          Object {
-            "height": 0,
-            "overflow": "visible",
-            "width": 0,
-          }
-        }
-      >
-        <MultiGrid
-          cellRangeRenderer={[Function]}
-          cellRenderer={[Function]}
-          classNameBottomLeftGrid="css-1oay0jc"
-          classNameBottomRightGrid="css-1abf74x"
-          classNameTopLeftGrid="css-4bzelf"
-          classNameTopRightGrid="css-1n6cz8p"
-          columnCount={1}
-          columnWidth={[Function]}
-          enableFixedColumnScroll={true}
-          enableFixedRowScroll={true}
-          fixedColumnCount={1}
-          fixedRowCount={1}
-          height={0}
-          hideBottomLeftGridScrollbar={true}
-          hideTopRightGridScrollbar={true}
-          onScroll={[Function]}
-          rowCount={4}
-          rowHeight={35}
-          scrollToColumn={-1}
-          scrollToRow={-1}
-          style={Object {}}
-          styleBottomLeftGrid={Object {}}
-          styleBottomRightGrid={Object {}}
-          styleTopLeftGrid={Object {}}
-          styleTopRightGrid={Object {}}
-          width={0}
-        />
-      </div>
-    </AutoSizer>
     <div
-      className="emotion-2"
-    />
-  </div>
+      className="emotion-0"
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
+    >
+      <MultiGrid
+        cellRangeRenderer={[Function]}
+        cellRenderer={[Function]}
+        classNameBottomLeftGrid="css-1oay0jc"
+        classNameBottomRightGrid="css-1abf74x"
+        classNameTopLeftGrid="css-4bzelf"
+        classNameTopRightGrid="css-1n6cz8p"
+        columnCount={1}
+        columnWidth={[Function]}
+        enableFixedColumnScroll={true}
+        enableFixedRowScroll={true}
+        fixedColumnCount={1}
+        fixedRowCount={1}
+        height={0}
+        hideBottomLeftGridScrollbar={true}
+        hideTopRightGridScrollbar={true}
+        onScroll={[Function]}
+        rowCount={4}
+        rowHeight={35}
+        scrollToColumn={-1}
+        scrollToRow={-1}
+        style={Object {}}
+        styleBottomLeftGrid={Object {}}
+        styleBottomRightGrid={Object {}}
+        styleTopLeftGrid={Object {}}
+        styleTopRightGrid={Object {}}
+        width={0}
+      />
+    </div>
+  </AutoSizer>
+  <div
+    className="emotion-2"
+  />
 </Table>
 `;
 
 exports[`Table renders again with new data 2`] = `
-.emotion-3 {
-  height: 100%;
-}
-
 .emotion-0 {
   font-weight: normal;
 }
@@ -662,78 +644,71 @@ exports[`Table renders again with new data 2`] = `
     ]
   }
 >
-  <div
-    className="emotion-3"
+  <AutoSizer
+    __dataThatTriggersARerenderWhenChanged={
+      Array [
+        4,
+        5,
+        6,
+      ]
+    }
+    className="emotion-0"
+    defaultHeight={768}
+    defaultWidth={1024}
+    disableHeight={false}
+    disableWidth={false}
+    onResize={[Function]}
+    style={Object {}}
   >
-    <AutoSizer
-      __dataThatTriggersARerenderWhenChanged={
-        Array [
-          4,
-          5,
-          6,
-        ]
-      }
-      className="emotion-0"
-      defaultHeight={768}
-      defaultWidth={1024}
-      disableHeight={false}
-      disableWidth={false}
-      onResize={[Function]}
-      style={Object {}}
-    >
-      <div
-        className="emotion-0"
-        style={
-          Object {
-            "height": 0,
-            "overflow": "visible",
-            "width": 0,
-          }
-        }
-      >
-        <MultiGrid
-          cellRangeRenderer={[Function]}
-          cellRenderer={[Function]}
-          classNameBottomLeftGrid="css-1oay0jc"
-          classNameBottomRightGrid="css-1abf74x"
-          classNameTopLeftGrid="css-4bzelf"
-          classNameTopRightGrid="css-1n6cz8p"
-          columnCount={1}
-          columnWidth={[Function]}
-          enableFixedColumnScroll={true}
-          enableFixedRowScroll={true}
-          fixedColumnCount={1}
-          fixedRowCount={1}
-          height={0}
-          hideBottomLeftGridScrollbar={true}
-          hideTopRightGridScrollbar={true}
-          onScroll={[Function]}
-          rowCount={4}
-          rowHeight={35}
-          scrollToColumn={-1}
-          scrollToRow={-1}
-          style={Object {}}
-          styleBottomLeftGrid={Object {}}
-          styleBottomRightGrid={Object {}}
-          styleTopLeftGrid={Object {}}
-          styleTopRightGrid={Object {}}
-          width={0}
-        />
-      </div>
-    </AutoSizer>
     <div
-      className="emotion-2"
-    />
-  </div>
+      className="emotion-0"
+      style={
+        Object {
+          "height": 0,
+          "overflow": "visible",
+          "width": 0,
+        }
+      }
+    >
+      <MultiGrid
+        cellRangeRenderer={[Function]}
+        cellRenderer={[Function]}
+        classNameBottomLeftGrid="css-1oay0jc"
+        classNameBottomRightGrid="css-1abf74x"
+        classNameTopLeftGrid="css-4bzelf"
+        classNameTopRightGrid="css-1n6cz8p"
+        columnCount={1}
+        columnWidth={[Function]}
+        enableFixedColumnScroll={true}
+        enableFixedRowScroll={true}
+        fixedColumnCount={1}
+        fixedRowCount={1}
+        height={0}
+        hideBottomLeftGridScrollbar={true}
+        hideTopRightGridScrollbar={true}
+        onScroll={[Function]}
+        rowCount={4}
+        rowHeight={35}
+        scrollToColumn={-1}
+        scrollToRow={-1}
+        style={Object {}}
+        styleBottomLeftGrid={Object {}}
+        styleBottomRightGrid={Object {}}
+        styleTopLeftGrid={Object {}}
+        styleTopRightGrid={Object {}}
+        width={0}
+      />
+    </div>
+  </AutoSizer>
+  <div
+    className="emotion-2"
+  />
 </Table>
 `;
 
 exports[`Table renders default 1`] = `
-.emotion-30 {
-  height: 100%;
-}
-
-.emotion-28 {
+Array [
+  .emotion-28 {
   font-weight: normal;
 }
 
@@ -757,17 +732,6 @@ exports[`Table renders default 1`] = `
 
 .emotion-20::-webkit-scrollbar {
   display: none;
-}
-
-.emotion-29 {
-  height: 100px;
-  overflow: scroll;
-  msoverflowstyle: scrollbar;
-  opacity: 0;
-  position: absolute;
-  top: -100000px;
-  visibility: hidden;
-  width: 100px;
 }
 
 .emotion-17 {
@@ -883,9 +847,6 @@ exports[`Table renders default 1`] = `
 }
 
 <div
-  class="emotion-30"
->
-  <div
     class="emotion-28"
     style="overflow:visible;height:0;width:0"
   >
@@ -1108,19 +1069,27 @@ exports[`Table renders default 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="emotion-29"
-  />
-</div>
+  </div>,
+  .emotion-0 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+}
+
+<div
+    class="emotion-0"
+  />,
+]
 `;
 
 exports[`Table renders with growToFill cols 1`] = `
-.emotion-36 {
-  height: 100%;
-}
-
-.emotion-34 {
+Array [
+  .emotion-34 {
   font-weight: normal;
 }
 
@@ -1144,17 +1113,6 @@ exports[`Table renders with growToFill cols 1`] = `
 
 .emotion-24::-webkit-scrollbar {
   display: none;
-}
-
-.emotion-35 {
-  height: 100px;
-  overflow: scroll;
-  msoverflowstyle: scrollbar;
-  opacity: 0;
-  position: absolute;
-  top: -100000px;
-  visibility: hidden;
-  width: 100px;
 }
 
 .emotion-21 {
@@ -1270,9 +1228,6 @@ exports[`Table renders with growToFill cols 1`] = `
 }
 
 <div
-  class="emotion-36"
->
-  <div
     class="emotion-34"
     style="overflow:visible;height:0;width:0"
   >
@@ -1530,9 +1485,20 @@ exports[`Table renders with growToFill cols 1`] = `
         </div>
       </div>
     </div>
-  </div>
-  <div
-    class="emotion-35"
-  />
-</div>
+  </div>,
+  .emotion-0 {
+  height: 100px;
+  overflow: scroll;
+  msoverflowstyle: scrollbar;
+  opacity: 0;
+  position: absolute;
+  top: -100000px;
+  visibility: hidden;
+  width: 100px;
+}
+
+<div
+    class="emotion-0"
+  />,
+]
 `;


### PR DESCRIPTION
For some reason, when the table is wrapped in a div, it will not be rendered by Cypress' browser until you explicitly set the correct height on that wrapper div.

Using a `Fragment` instead of a DOM node will also fix this issue.