### PR TITLE
fix(storybook): add build to deployment step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
         withCredentials([
           string(credentialsId: 'd146870f-03b0-4f6a-ab70-1d09757a51fc', variable: 'GITHUB_TOKEN')
         ]) {
-          sh '''cd ui-kit && npm run deploy:storybook -- --ci --host-token-env-variable=GITHUB_TOKEN --out=storybook_static --existing-output-dir=storybook_static'''
+          sh '''cd ui-kit && npm run build:storybook && npm run deploy:storybook -- --ci --host-token-env-variable=GITHUB_TOKEN --out=storybook_static --existing-output-dir=storybook_static'''
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clean:design-tokens": "rm -rf ./dist/packages/design-tokens && rm -rf ./packages/design-tokens/dist/",
     "commitlint": "commitlint -e",
     "create:component": "./scripts/create-component",
-    "deploy:storybook": "storybook-to-ghpages --out=storybook_static --existing-output-dir=storybook_static",
+    "deploy:storybook": "storybook-to-ghpages",
     "prestart": "npm run build:design-tokens && npm run build:svg",
     "pretest": "npm run build:design-tokens && npm run build:svg",
     "predist": "npm run clean && npm run build:design-tokens && npm run build:svg",

--- a/webpack/webpack.base.js
+++ b/webpack/webpack.base.js
@@ -35,10 +35,7 @@ const webpackBase = {
     ];
 
     if (process.env.NODE_ENV === "production") {
-      plugins.concat([
-        new webpack.optimize.ModuleConcatenationPlugin(),
-        new webpack.optimize.UglifyJsPlugin()
-      ]);
+      plugins.concat([new webpack.optimize.ModuleConcatenationPlugin()]);
     }
 
     return plugins;


### PR DESCRIPTION
The last PR (https://github.com/dcos-labs/ui-kit/pull/325) to fix the Storybook deployment had a few issues:
- We weren't building before deploying, so there was no directory (`storybook_static`) to deploy
- Webpack 4 threw an error for using `UglifyJSPlugin` instead of `optimization.minimize`*
- Args were being passed to `storybook-to-ghpages` twice

This PR should _actually_ fix the issue. Thanks for being patient 🙏 