### PR TITLE
DCOS-54215: port Tooltip from reactjs-components

### DIFF
--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,4 +1,6 @@
 import { injectGlobalCss } from "./shared/styles/global";
+import * as Legacy from "./legacy";
+
 export {
   AppChrome,
   HeaderBar,
@@ -54,5 +56,6 @@ export { ToggleInput } from "./toggleInput";
 export { ToggleInputList } from "./toggleInputList";
 export { Tooltip } from "./tooltip";
 export { Typeahead } from "./typeahead";
+export { Legacy };
 
 injectGlobalCss();

--- a/packages/legacy/README.md
+++ b/packages/legacy/README.md
@@ -1,0 +1,16 @@
+## Legacy components
+The contents of the `legacy/` directory have been ported over from [reactjs-components](https://github.com/mesosphere/reactjs-components).
+
+### These are temporary
+Once all components from reactjs-components as ported to ui-kit, dcos-ui can import legacy components from ui-kit and drop reactjs-components as a dependency.
+
+After that, dcos-ui can replace legacy components with new ui-kit components and we can remove slowly remove the contents of the `legacy` directory.
+
+### Documentation
+reactjs-components documentation: http://mesosphere.github.io/cnvs/
+There are no plans to move this documentation to ui-kit
+
+### Do not use this code as reference
+The JavaScript had to be converted to Typescript in order to be compiled by `tsc`, but the type-checking is extremely minimal and should not be used as an example for acceptable Typescript usage.
+
+The styles have been converted from LESS to Emotion, but have not been refactored to follow the best practices of styling with Emotion.

--- a/packages/legacy/index.ts
+++ b/packages/legacy/index.ts
@@ -1,0 +1,3 @@
+import { Tooltip } from "./src/Tooltip/Tooltip";
+
+export { Tooltip };

--- a/packages/legacy/src/Tooltip/Tooltip.tsx
+++ b/packages/legacy/src/Tooltip/Tooltip.tsx
@@ -1,0 +1,344 @@
+// original: https://github.com/mesosphere/reactjs-components/tree/master/src/Tooltip
+
+import classnames from "classnames";
+import React from "react";
+import Overlay from "../../../shared/components/Overlay";
+
+import DOMUtil from "../Util/DOMUtil";
+import { tooltip, tooltipWrapper } from "./style";
+
+const ARROW_SIZE = 7;
+
+interface TooltipProps {
+  anchor?: string;
+  children: React.ReactNode;
+  className?: string;
+  content: React.ReactNode;
+  elementTag?: string;
+  interactive?: boolean;
+  maxWidth?: number | string;
+  position?: string;
+  stayOpen?: boolean;
+  suppress?: boolean;
+  width?: number;
+  wrapperClassName?: string;
+  wrapText?: boolean;
+  contentClassName?: string;
+}
+
+const METHODS_TO_BIND = [
+  "dismissTooltip",
+  "getIdealLocation",
+  "handleMouseEnter",
+  "handleMouseLeave",
+  "handleTooltipMouseEnter",
+  "handleTooltipMouseLeave",
+  "triggerClose"
+];
+
+export class Tooltip extends React.Component<TooltipProps, any> {
+  public static defaultProps: Partial<TooltipProps> = {
+    anchor: "center",
+    className: `${tooltip} tooltip`,
+    contentClassName: "tooltip-content",
+    elementTag: "div",
+    position: "top",
+    wrapperClassName: `${tooltipWrapper} tooltip-wrapper text-align-center`
+  };
+  private tooltipNode = React.createRef<any>();
+  private triggerNode = React.createRef<any>();
+
+  constructor(props) {
+    super(props);
+
+    this.state = { isOpen: false, wasTriggeredClose: false };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+
+    this.tooltipNode = React.createRef();
+    this.triggerNode = React.createRef();
+  }
+
+  componentWillUnmount() {
+    this.removeScrollListener();
+  }
+
+  handleMouseEnter(options) {
+    if (this.props.suppress && !options.forceOpen) {
+      return;
+    }
+
+    const { anchor, position, coordinates } = this.getIdealLocation(
+      this.props.anchor,
+      this.props.position
+    );
+
+    this.setState({
+      anchor,
+      isOpen: true,
+      position,
+      coordinates,
+      wasTriggeredClose: false
+    });
+    this.addScrollListener();
+  }
+
+  handleMouseLeave() {
+    this.dismissTooltip();
+  }
+
+  handleTooltipMouseEnter() {
+    if (this.props.interactive && !this.state.wasTriggeredClose) {
+      this.setState({ isOpen: true });
+      this.addScrollListener();
+    }
+  }
+
+  handleTooltipMouseLeave() {
+    this.dismissTooltip();
+  }
+
+  addScrollListener() {
+    window.addEventListener("scroll", this.dismissTooltip, true);
+  }
+
+  dismissTooltip(options?: any) {
+    if ((!this.props.stayOpen || options.forceClose) && this.state.isOpen) {
+      this.setState({ isOpen: false });
+      this.removeScrollListener();
+    }
+  }
+
+  getAnchor(isVertical, anchor, clearance, tooltipWidth, tooltipHeight) {
+    // Calculate the ideal anchor.
+    if (isVertical) {
+      return this.transformAnchor(
+        anchor,
+        clearance.left,
+        clearance.right,
+        tooltipWidth,
+        clearance.boundingRect.width
+      );
+    }
+
+    return this.transformAnchor(
+      anchor,
+      clearance.top,
+      clearance.bottom,
+      tooltipHeight,
+      clearance.boundingRect.height
+    );
+  }
+
+  getCoordinates(position, clearance, tooltipWidth, tooltipHeight) {
+    // Calculate the coordinates of the tooltip content.
+    if (position === "top") {
+      return {
+        left: clearance.boundingRect.left + clearance.boundingRect.width / 2,
+        top: clearance.boundingRect.top - tooltipHeight + ARROW_SIZE
+      };
+    } else if (position === "right") {
+      return {
+        left: clearance.boundingRect.right,
+        top: clearance.boundingRect.top + clearance.boundingRect.height / 2
+      };
+    } else if (position === "bottom") {
+      return {
+        left: clearance.boundingRect.left + clearance.boundingRect.width / 2,
+        top: clearance.boundingRect.bottom
+      };
+    }
+
+    return {
+      left: clearance.boundingRect.left - tooltipWidth + ARROW_SIZE,
+      top: clearance.boundingRect.top + clearance.boundingRect.height / 2
+    };
+  }
+
+  isVertical(position) {
+    return position !== "left" && position !== "right";
+  }
+
+  getPosition(position, clearance, tooltipWidth, tooltipHeight) {
+    // Change the position if the tooltip will be rendered off the screen.
+    if (position === "left" && clearance.left < tooltipWidth) {
+      position = "right";
+    } else if (position === "right" && clearance.right < tooltipWidth) {
+      position = "left";
+    }
+
+    if (position === "top" && clearance.top < tooltipHeight) {
+      position = "bottom";
+    } else if (position === "bottom" && clearance.bottom < tooltipHeight) {
+      position = "top";
+    }
+
+    return position;
+  }
+
+  getIdealLocation(anchor, position) {
+    if (
+      !this.triggerNode ||
+      !this.triggerNode.current ||
+      !this.tooltipNode ||
+      !this.tooltipNode.current
+    ) {
+      return {
+        anchor: "center",
+        position: "top",
+        coordinates: { left: 0, top: 0 }
+      };
+    }
+
+    const isVertical = this.isVertical(position);
+    const clearance = DOMUtil.getNodeClearance(this.triggerNode.current);
+    const tooltipRect = this.tooltipNode.current.getBoundingClientRect();
+    const tooltipHeight = tooltipRect.height + ARROW_SIZE;
+    const tooltipWidth = tooltipRect.width + ARROW_SIZE;
+
+    anchor = this.getAnchor(
+      isVertical,
+      anchor,
+      clearance,
+      tooltipWidth,
+      tooltipHeight
+    );
+    position = this.getPosition(
+      position,
+      clearance,
+      tooltipWidth,
+      tooltipHeight
+    );
+
+    const coordinates = this.getCoordinates(
+      position,
+      clearance,
+      tooltipWidth,
+      tooltipHeight
+    );
+
+    return { anchor, position, coordinates };
+  }
+
+  removeScrollListener() {
+    window.removeEventListener("scroll", this.dismissTooltip, true);
+  }
+
+  triggerClose() {
+    this.setState({ wasTriggeredClose: true });
+    this.dismissTooltip({ forceClose: true });
+  }
+
+  triggerOpen() {
+    this.handleMouseEnter({ forceOpen: true });
+  }
+
+  transformAnchor(
+    anchor,
+    clearanceStart,
+    clearanceEnd,
+    tooltipDimension,
+    triggerDimension
+  ) {
+    // Change the provided anchor based on the clearance available.
+    if (anchor === "start" && clearanceEnd < tooltipDimension) {
+      return "end";
+    }
+
+    if (anchor === "end" && clearanceStart < tooltipDimension) {
+      return "start";
+    }
+
+    if (anchor === "center") {
+      const tooltipOverflow = (tooltipDimension - triggerDimension) / 2;
+
+      if (clearanceStart < tooltipOverflow) {
+        return "start";
+      }
+
+      if (clearanceEnd < tooltipOverflow) {
+        return "end";
+      }
+    }
+
+    return anchor;
+  }
+
+  render() {
+    const {
+      anchor,
+      children,
+      className,
+      content,
+      elementTag,
+      interactive,
+      maxWidth,
+      position,
+      stayOpen,
+      suppress,
+      width,
+      wrapperClassName,
+      wrapText,
+      contentClassName,
+      ...elementProps
+    } = this.props;
+    let tooltipStyle: any = {};
+
+    // Get the anchor and position from state if possible. If not, get it from
+    // the props.
+    const anchorValue = this.state.anchor || anchor;
+    const positionValue = this.state.position || position;
+
+    const tooltipClasses = classnames(
+      className,
+      `anchor-${anchorValue}`,
+      `position-${positionValue}`,
+      {
+        "is-interactive": interactive,
+        "is-open": this.state.isOpen,
+        "no-wrap": !wrapText
+      }
+    );
+    const ElementTag: any = elementTag;
+
+    if (this.state.coordinates) {
+      tooltipStyle = {
+        left: this.state.coordinates.left,
+        top: this.state.coordinates.top
+      };
+    }
+
+    if (width) {
+      tooltipStyle.width = width;
+    }
+
+    if (maxWidth) {
+      tooltipStyle.maxWidth = maxWidth;
+    }
+
+    return (
+      <ElementTag
+        className={wrapperClassName}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}
+        {...elementProps}
+        ref={this.triggerNode}
+      >
+        {children}
+        <Overlay>
+          <div
+            className={tooltipClasses}
+            ref={this.tooltipNode}
+            style={tooltipStyle}
+            onMouseEnter={this.handleTooltipMouseEnter}
+            onMouseLeave={this.handleTooltipMouseLeave}
+          >
+            <div className={contentClassName}>{content}</div>
+          </div>
+        </Overlay>
+      </ElementTag>
+    );
+  }
+}

--- a/packages/legacy/src/Tooltip/style.ts
+++ b/packages/legacy/src/Tooltip/style.ts
@@ -1,0 +1,195 @@
+import { css } from "emotion";
+import {
+  greyDarkLighten2,
+  white
+} from "../../../design-tokens/build/js/designTokens";
+
+const tooltipBackground = greyDarkLighten2;
+const tooltipLinkForeground = white;
+const tooltipArrowBorderWidth = "7px";
+const tooltipArrowOffset = "8px";
+const tooltipAnchorOffset = `${parseInt(tooltipArrowOffset, 10) +
+  parseInt(tooltipArrowBorderWidth, 10)}px`;
+
+export const tooltipWrapper = css`
+  display: inline-block;
+  position: relative;
+`;
+
+export const tooltip = css`
+  max-width: 600px;
+  opacity: 0;
+  pointer-events: none;
+  position: fixed;
+  transition: opacity 0.3s, visibility 0.3s;
+  visibility: hidden;
+  z-index: 9999;
+
+  .tooltip-content {
+    background: ${tooltipBackground};
+    border-radius: 2px;
+    color: white;
+    font-size: .9rem;
+    line-height: 1rem;
+    padding: 0.8rem 1rem;
+    position: relative;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    transition: translateZ(0);
+
+    &:after {
+      border-color: ${tooltipBackground};
+      border-style: solid;
+      border-width: ${tooltipArrowBorderWidth};
+      content: "";
+      position: absolute;
+    }
+  }
+
+  &.no-wrap {
+    white-space: nowrap;
+  }
+
+  &.is-interactive {
+    pointer-events: auto;
+  }
+
+  &.is-open {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  &.position-bottom,
+  &.position-top {
+    &.anchor-center {
+    transform: translateX(-50%);
+
+    .tooltip-content {
+        &:after {
+        left: 50%;
+        transform: translateX(-50%);
+        }
+    }
+    }
+
+    &.anchor-start {
+    transform: translateX(${tooltipAnchorOffset} * -1);
+
+    .tooltip-content {
+        &:after {
+        left: ${tooltipArrowOffset};
+        }
+    }
+    }
+
+    &.anchor-end {
+    transform: translateX(calc(~"-100% + @${tooltipAnchorOffset}}"));
+
+    .tooltip-content {
+        &:after {
+        right: ${tooltipArrowOffset};
+        }
+    }
+    }
+  }
+
+  &.position-bottom {
+    padding-top: ${tooltipArrowBorderWidth};
+
+    .tooltip-content {
+    &:after {
+        border-left-color: transparent;
+        border-right-color: transparent;
+        border-top: none;
+        bottom: 100%;
+    }
+    }
+  }
+
+  &.position-top {
+    padding-bottom: ${tooltipArrowBorderWidth};
+
+    .tooltip-content {
+    &:after {
+        border-bottom: none;
+        border-left-color: transparent;
+        border-right-color: transparent;
+        top: 100%;
+    }
+    }
+  }
+
+  &.position-left,
+  &.position-right {
+    &.anchor-center {
+    top: 50%;
+    transform: translateY(-50%);
+
+    .tooltip-content {
+        &:after {
+        top: 50%;
+        transform: translateY(-50%);
+        }
+    }
+    }
+
+    &.anchor-start {
+    transform: translateY(${tooltipAnchorOffset} * -1);
+
+    .tooltip-content {
+        &:after {
+        top: ${tooltipArrowOffset};
+        }
+    }
+    }
+
+    &.anchor-end {
+    transform: translateY(calc(~"-100% + @${tooltipAnchorOffset}}"));
+
+    .tooltip-content {
+        &:after {
+        bottom: ${tooltipArrowOffset};
+        }
+    }
+    }
+  }
+
+  &.position-left {
+    padding-right: ${tooltipArrowBorderWidth};
+
+    .tooltip-content {
+    &:after {
+        border-bottom-color: transparent;
+        border-right: none;
+        border-top-color: transparent;
+        left: 100%;
+    }
+    }
+  }
+
+  &.position-right {
+    padding-left: ${tooltipArrowBorderWidth};
+
+    .tooltip-content {
+    &:after {
+        border-bottom-color: transparent;
+        border-left: none;
+        border-top-color: transparent;
+        right: 100%;
+    }
+    }
+  }
+
+  a {
+    color: ${tooltipLinkForeground};
+    text-decoration: underline;
+
+    &:active {
+    text-decoration: underline;
+    }
+
+    &:hover {
+    color: ${tooltipLinkForeground};
+    }
+  }
+`;

--- a/packages/legacy/src/Tooltip/tests/Tooltip.test.tsx
+++ b/packages/legacy/src/Tooltip/tests/Tooltip.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { mount } from "enzyme";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import toJson from "enzyme-to-json";
+import { Tooltip } from "../../../";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+describe("Tooltip", () => {
+  it("renders", () => {
+    const component = mount(
+      <Tooltip
+        anchor="start"
+        className="foo"
+        content="I'm a tooltip!"
+        position="bottom"
+      >
+        <span>Tooltip Trigger</span>
+      </Tooltip>
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  describe("#handleMouseEnter", () => {
+    it("should set isOpen to true", () => {
+      const component = mount(
+        <Tooltip
+          anchor="start"
+          className="foo"
+          content="I'm a tooltip!"
+          position="bottom"
+        >
+          <span>Tooltip Trigger</span>
+        </Tooltip>
+      );
+      expect(component.state("isOpen")).toBe(false);
+      component.simulate("mouseEnter");
+      expect(component.state("isOpen")).toBe(true);
+    });
+
+    it("should set anchor to what was returned from #getIdealPosition", () => {
+      const component = mount(
+        <Tooltip
+          anchor="start"
+          className="foo"
+          content="I'm a tooltip!"
+          position="bottom"
+        >
+          <span>Tooltip Trigger</span>
+        </Tooltip>
+      );
+
+      expect(component.state("anchor")).toBe(undefined);
+      component.simulate("mouseEnter");
+      expect(component.state("anchor")).toBe("start");
+    });
+
+    it("should set position to what was returned from #getIdealPosition", () => {
+      const component = mount(
+        <Tooltip
+          anchor="start"
+          className="foo"
+          content="I'm a tooltip!"
+          position="bottom"
+        >
+          <span>Tooltip Trigger</span>
+        </Tooltip>
+      );
+
+      expect(component.state("position")).toBe(undefined);
+      component.simulate("mouseEnter");
+      expect(component.state("position")).toBe("bottom");
+    });
+  });
+
+  describe("#handleMouseLeave", () => {
+    const component = mount(
+      <Tooltip
+        anchor="start"
+        className="foo"
+        content="I'm a tooltip!"
+        position="bottom"
+      >
+        <span>Tooltip Trigger</span>
+      </Tooltip>
+    );
+
+    expect(component.state("isOpen")).toBe(false);
+    component.simulate("mouseEnter");
+    expect(component.state("isOpen")).toBe(true);
+    component.simulate("mouseLeave");
+    expect(component.state("isOpen")).toBe(false);
+  });
+});

--- a/packages/legacy/src/Tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/legacy/src/Tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tooltip renders 1`] = `
+.emotion-0 {
+  display: inline-block;
+  position: relative;
+}
+
+<Tooltip
+  anchor="start"
+  className="foo"
+  content="I'm a tooltip!"
+  contentClassName="tooltip-content"
+  elementTag="div"
+  position="bottom"
+  wrapperClassName="emotion-0 tooltip-wrapper text-align-center"
+>
+  <div
+    className="emotion-0 tooltip-wrapper text-align-center"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <span>
+      Tooltip Trigger
+    </span>
+    <Overlay
+      overlayRoot={
+        <body>
+          <div>
+            <div>
+              <div
+                class="foo anchor-start position-bottom no-wrap"
+                style="left: 0px; top: 0px;"
+              >
+                <div
+                  class="tooltip-content"
+                >
+                  I'm a tooltip!
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div>
+              <div
+                class="foo anchor-start position-bottom no-wrap"
+              >
+                <div
+                  class="tooltip-content"
+                >
+                  I'm a tooltip!
+                </div>
+              </div>
+            </div>
+          </div>
+        </body>
+      }
+    >
+      <Portal
+        containerInfo={
+          <div>
+            <div>
+              <div
+                class="foo anchor-start position-bottom no-wrap"
+              >
+                <div
+                  class="tooltip-content"
+                >
+                  I'm a tooltip!
+                </div>
+              </div>
+            </div>
+          </div>
+        }
+      >
+        <div>
+          <div
+            className="foo anchor-start position-bottom no-wrap"
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            style={Object {}}
+          >
+            <div
+              className="tooltip-content"
+            >
+              I'm a tooltip!
+            </div>
+          </div>
+        </div>
+      </Portal>
+    </Overlay>
+  </div>
+</Tooltip>
+`;

--- a/packages/legacy/src/Util/DOMUtil.ts
+++ b/packages/legacy/src/Util/DOMUtil.ts
@@ -1,0 +1,162 @@
+//tslint:disable
+var computeInnerBound = function(compstyle, acc, key) {
+  var val = parseInt(compstyle[key], 10);
+
+  if (isNaN(val)) {
+    return acc;
+  } else {
+    return acc - val;
+  }
+};
+
+const DOMUtil = {
+  closest(el, selector) {
+    var currentEl = el;
+    while (currentEl && currentEl.parentElement !== null) {
+      if (currentEl[this.matchesFn] && currentEl[this.matchesFn](selector)) {
+        return currentEl;
+      }
+      currentEl = currentEl.parentElement;
+    }
+    return null;
+  },
+
+  getPageHeight() {
+    var body = document.body;
+    var html = document.documentElement;
+
+    if (html && body) {
+      return Math.max(
+        body.scrollHeight,
+        body.offsetHeight,
+        html.clientHeight,
+        html.scrollHeight,
+        html.offsetHeight
+      );
+    }
+  },
+
+  getComputedDimensions(obj) {
+    var compstyle;
+    if (typeof window.getComputedStyle === "undefined") {
+      compstyle = obj.currentStyle;
+    } else {
+      compstyle = window.getComputedStyle(obj);
+    }
+
+    var width = [
+      "borderLeftWidth",
+      "borderRightWidth",
+      "marginLeft",
+      "marginRight",
+      "paddingLeft",
+      "paddingRight"
+    ].reduce(computeInnerBound.bind(this, compstyle), obj.offsetWidth);
+
+    var height = [
+      "borderTopWidth",
+      "borderBottomWidth",
+      "marginTop",
+      "marginBottom",
+      "paddingTop",
+      "paddingBottom"
+    ].reduce(computeInnerBound.bind(this, compstyle), obj.offsetHeight);
+
+    return {
+      width,
+      height
+    };
+  },
+
+  getNodeClearance(DOMNode) {
+    if (!DOMNode) {
+      return {
+        bottom: 0,
+        left: 0,
+        right: 0,
+        top: 0,
+        boundingRect: {
+          bottom: 0,
+          height: 0,
+          left: 0,
+          right: 0,
+          top: 0,
+          width: 0,
+          x: 0,
+          y: 0
+        }
+      };
+    }
+
+    const viewportHeight = DOMUtil.getViewportHeight();
+    const viewportWidth = DOMUtil.getViewportWidth();
+    const boundingRect = DOMNode.getBoundingClientRect();
+
+    return {
+      bottom: viewportHeight - boundingRect.bottom,
+      left: boundingRect.left,
+      right: viewportWidth - boundingRect.right,
+      top: boundingRect.top,
+      boundingRect
+    };
+  },
+
+  getViewportHeight() {
+    if (document.documentElement) {
+      return Math.max(
+        document.documentElement.clientHeight || 0,
+        window.innerHeight || 0
+      );
+    } else {
+      return 0;
+    }
+  },
+
+  getViewportWidth() {
+    if (document.documentElement) {
+      return Math.max(
+        document.documentElement.clientWidth || 0,
+        window.innerWidth || 0
+      );
+    } else {
+      return 0;
+    }
+  },
+
+  getScrollTop(element) {
+    if (
+      document.documentElement &&
+      (element === window || element === document)
+    ) {
+      return (
+        self.pageYOffset ||
+        document.documentElement.scrollTop ||
+        document.body.scrollTop
+      );
+    } else {
+      return element.scrollTop;
+    }
+  },
+
+  matchesFn: (function() {
+    const el = document.querySelector("body");
+    const names = [
+      "matches",
+      "matchesSelector",
+      "msMatchesSelector",
+      "oMatchesSelector",
+      "mozMatchesSelector",
+      "webkitMatchesSelector"
+    ];
+
+    for (let i = 0; i < names.length; i++) {
+      if (el && el[names[i]]) {
+        return names[i];
+      }
+    }
+
+    return names[0];
+  })()
+};
+
+export default DOMUtil;


### PR DESCRIPTION
This moves the legacy Tooltip component over from reactjs-components.
Once we port all components reactjs-components to ui-kit, dcos-ui can import legacy components from ui-kit and drop reactjs-components as a dependency.

## How to test
### In dcos-ui:
1. In ui-kit, run `npm run dist`
2. Replace `dcos-ui/node_modules/@dcos/ui-kit/dist/packages/` with `ui-kit/dist/packages/`
3. Find a place in `dcos-ui` that uses a Tooltip imported from `reactjs-components` and replace the import with
```
import { Legacy } from "@dcos/ui-kit";
```
4. Replace `<Tooltip />` components with `<Legacy.Tooltip />`
5. Start dcos-ui

Check that `<Legacy.Tooltip />` looks and behaves like the `<Tooltip>` from reactjs-components

### In Storybook (optional):
1. Import legacy components to a `*.stories.tsx` file:
```
import { Legacy } from "@dcos/ui-kit";
```
2. Add a story that uses the legacy tooltip (`<Legacy.Tooltip />`)
3. `npm start` and navigate to the story in Storybook

## Screenshot
Switching tabs between a dcos-ui build that is using `Legacy.Tooltip` from ui-kit, and one the daily cluster:
![LegacyTooltipDemo](https://user-images.githubusercontent.com/2313998/58212835-22252180-7cbe-11e9-9e5b-899761ec0db2.gif)
