### PR TITLE
[spike] DCOS-54216: port Dropdown from reactjs-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12731,6 +12731,12 @@
         "wide-align": "^1.1.0"
       }
     },
+    "gemini-scrollbar": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/gemini-scrollbar/-/gemini-scrollbar-1.5.3.tgz",
+      "integrity": "sha512-3Q4SrxkJ+ei+I5PlcRZCfPePv3EduP7xusOWp7Uw0+XywEWred7Nq9hoaP2IQh1vRjoidaVODV3rO3icFH/e5A==",
+      "dev": true
+    },
     "genfun": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
@@ -20736,6 +20742,15 @@
         "focus-lock": "^0.6.0",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.0"
+      }
+    },
+    "react-gemini-scrollbar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-gemini-scrollbar/-/react-gemini-scrollbar-2.3.4.tgz",
+      "integrity": "sha1-3v1g3fJD2vqjVPw6TQ75crkTdzI=",
+      "dev": true,
+      "requires": {
+        "gemini-scrollbar": "^1.5.3"
       }
     },
     "react-helmet-async": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   },
   "peerDependencies": {
     "react": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0",
-    "react-dom": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0"
+    "react-dom": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0",
+    "react-gemini-scrollbar": "^2.1.5 || ^2.3.0"
   },
   "devDependencies": {
     "acorn": "^6.0.5",
@@ -101,6 +102,7 @@
     "file-loader": "2.0.0",
     "fork-ts-checker-webpack-plugin": "0.5.2",
     "fs-extra": "7.0.0",
+    "react-gemini-scrollbar": "2.3.x",
     "jest": "23.6.0",
     "jest-emotion": "9.2.11",
     "jest-runner-prettier": "0.2.6",

--- a/packages/legacy/index.ts
+++ b/packages/legacy/index.ts
@@ -1,3 +1,4 @@
 import { Tooltip } from "./src/Tooltip/Tooltip";
+import { Dropdown } from "./src/Dropdown/Dropdown";
 
-export { Tooltip };
+export { Dropdown, Tooltip };

--- a/packages/legacy/src/Dropdown/Dropdown.tsx
+++ b/packages/legacy/src/Dropdown/Dropdown.tsx
@@ -1,0 +1,472 @@
+import classNames from "classnames";
+import GeminiScrollbar from "react-gemini-scrollbar";
+import React from "react";
+import { CSSTransition } from "react-transition-group";
+import ReactDOM from "react-dom";
+
+import DOMUtil from "../Util/DOMUtil";
+import DropdownListTrigger from "./DropdownListTrigger";
+import Overlay from "../../../shared/components/Overlay";
+
+import { injectGlobalDropdownStyles } from "./styles";
+
+export interface MenuItem {
+  className?: string;
+  html?: React.ReactNode;
+  id: string | number;
+  onClick?: () => void;
+  selectable?: boolean;
+  selectedHtml?: string | object;
+}
+
+interface DropdownProps {
+  anchorRight?: boolean;
+  persistentID?: string | number;
+  items: MenuItem[];
+  initialID?: string | number;
+  matchButtonWidth?: boolean;
+  onItemSelection?: (...args: any[]) => any;
+  scrollContainer?: object | string;
+  scrollContainerParentSelector?: string;
+  transition?: boolean;
+  transitionName?: string;
+  transitionEnterTimeout?: number;
+  transitionExitTimeout?: number;
+  trigger?: JSX.Element;
+  useGemini?: boolean;
+  disabled?: boolean;
+  buttonClassName?: string;
+  dropdownMenuClassName?: string;
+  dropdownMenuListClassName?: string;
+  dropdownMenuListItemClassName?: string;
+  wrapperClassName?: string;
+}
+
+const METHODS_TO_BIND = [
+  "closeDropdown",
+  "handleMenuToggle",
+  "handleExternalClick",
+  "handleKeyDown",
+  "handleWrapperBlur"
+];
+
+export class Dropdown extends React.Component<DropdownProps, any> {
+  public static defaultProps: Partial<DropdownProps> = {
+    scrollContainer: window,
+    transitionName: "dropdown-menu",
+    transitionEnterTimeout: 250,
+    transitionExitTimeout: 250,
+    onItemSelection: () => undefined,
+    useGemini: true,
+    trigger: <DropdownListTrigger />
+  };
+
+  private container;
+  private currentBlurTimeout;
+  private dropdownMenuRef = React.createRef<any>();
+  private dropdownWrapperRef = React.createRef<any>();
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      maxDropdownHeight: null,
+      menuDirection: "down",
+      menuHeight: null,
+      menuPositionStyle: null,
+      isOpen: false,
+      renderHidden: false,
+      selectedID: null
+    };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillMount() {
+    const props = this.props;
+    if (!props.persistentID) {
+      this.setState({ selectedID: props.initialID });
+    }
+  }
+
+  componentDidMount() {
+    this.container = this.getScrollContainer();
+    this.determineOptimalMenuLocation();
+  }
+
+  componentDidUpdate() {
+    if (this.state.isOpen) {
+      window.addEventListener("resize", this.closeDropdown);
+    } else {
+      window.removeEventListener("resize", this.closeDropdown);
+    }
+  }
+
+  componentWillUpdate(_, nextState) {
+    // If the open state changed, add or remove listener as needed.
+    if (nextState.isOpen !== this.state.isOpen) {
+      if (nextState.isOpen) {
+        this.addKeydownListener();
+        this.addScrollListener();
+      } else {
+        this.removeKeydownListener();
+        this.removeScrollListener();
+      }
+    }
+  }
+
+  handleExternalClick() {
+    this.closeDropdown();
+  }
+
+  handleKeyDown(event) {
+    // keycode 27 is ESC
+    if (event.keyCode === 27) {
+      this.closeDropdown();
+    }
+  }
+
+  handleItemClick(item) {
+    const props = this.props;
+    if (props.onItemSelection) {
+      props.onItemSelection(item);
+    }
+
+    const newState: any = { isOpen: false };
+    // Only set the selectedID if persistentID is not set
+    if (!props.persistentID) {
+      newState.selectedID = item.id;
+    }
+
+    this.setState(newState);
+    this.removeBlurTimeout();
+  }
+
+  handleWrapperBlur() {
+    this.removeBlurTimeout();
+
+    this.currentBlurTimeout = setTimeout(() => {
+      this.closeDropdown();
+    }, 150);
+
+    // We need to remove focus from the button to avoid this event firing again
+    // when we open the dropdown
+    window.focus();
+  }
+
+  handleMenuToggle(e) {
+    e.stopPropagation();
+
+    if (this.state.isOpen) {
+      this.closeDropdown();
+    } else {
+      this.openDropdown();
+    }
+
+    this.removeBlurTimeout();
+  }
+
+  addKeydownListener() {
+    document.body.addEventListener("keydown", this.handleKeyDown);
+  }
+
+  addScrollListener() {
+    if (this.container && this.container.current) {
+      this.container.current.addEventListener("scroll", this.closeDropdown);
+    }
+  }
+
+  removeKeydownListener() {
+    document.body.removeEventListener("keydown", this.handleKeyDown);
+  }
+
+  removeScrollListener() {
+    if (this.container && this.container.current) {
+      this.container.current.removeEventListener("scroll", this.closeDropdown);
+    }
+  }
+
+  removeBlurTimeout() {
+    if (this.currentBlurTimeout) {
+      global.clearTimeout(this.currentBlurTimeout);
+    }
+  }
+
+  determineOptimalMenuLocation() {
+    let height: any = null;
+    let menuDirection = this.state.menuDirection;
+    const menuPositionStyle: any = {};
+    const spaceAroundDropdownButton = DOMUtil.getNodeClearance(
+      this.dropdownWrapperRef.current
+    );
+    const dropdownChildHeight =
+      this.dropdownMenuRef && this.dropdownMenuRef.current
+        ? this.dropdownMenuRef.current.firstChild.clientHeight
+        : 0;
+    const menuHeight = this.state.menuHeight || dropdownChildHeight;
+    const isMenuTallerThanBottom =
+      menuHeight > spaceAroundDropdownButton.bottom;
+    const isMenuTallerThanTop = menuHeight > spaceAroundDropdownButton.top;
+    const isMenuShorterThanTop = !isMenuTallerThanTop;
+    const isTopTallerThanBottom =
+      spaceAroundDropdownButton.top > spaceAroundDropdownButton.bottom;
+    // If the menu height is larger than the space available on the bottom and
+    // less than the space available on top, then render it up. If the height
+    // of the menu exceeds the space below and above, but there is more space
+    // above than below, render it up. Otherwise, render down.
+    if (
+      (isMenuTallerThanBottom && isMenuShorterThanTop) ||
+      (isMenuTallerThanBottom && isMenuTallerThanTop && isTopTallerThanBottom)
+    ) {
+      menuDirection = "up";
+      menuPositionStyle.bottom =
+        spaceAroundDropdownButton.bottom +
+        spaceAroundDropdownButton.boundingRect.height;
+      menuPositionStyle.top = "auto";
+      height = spaceAroundDropdownButton.top;
+    } else {
+      menuDirection = "down";
+      menuPositionStyle.bottom = "auto";
+      menuPositionStyle.top =
+        spaceAroundDropdownButton.top +
+        spaceAroundDropdownButton.boundingRect.height;
+      height = spaceAroundDropdownButton.bottom;
+    }
+
+    if (this.props.matchButtonWidth) {
+      menuPositionStyle.left = spaceAroundDropdownButton.left;
+      menuPositionStyle.right = spaceAroundDropdownButton.right;
+    } else if (this.props.anchorRight) {
+      menuPositionStyle.left = "auto";
+      menuPositionStyle.right = spaceAroundDropdownButton.right;
+    } else {
+      menuPositionStyle.left = spaceAroundDropdownButton.left;
+      menuPositionStyle.right = "auto";
+    }
+
+    // We assume that 125 pixels is the smallest height we should render.
+    if (height < 125) {
+      height = 125;
+    }
+
+    this.setState({
+      menuDirection,
+      maxDropdownHeight: height,
+      menuHeight,
+      menuPositionStyle,
+      renderHidden: false
+    });
+  }
+
+  openDropdown() {
+    const state = { ...this.state };
+
+    state.isOpen = true;
+
+    // If we don't already know the menu height, we need to set the menu
+    // position to a default state to trigger its recalculation on the next
+    // render.
+    if (
+      this.state.menuHeight == null &&
+      this.dropdownWrapperRef &&
+      this.dropdownWrapperRef.current
+    ) {
+      const buttonPosition = this.dropdownWrapperRef.current.getBoundingClientRect();
+
+      state.menuDirection = "down";
+      state.menuPositionStyle = {
+        top: buttonPosition.top + buttonPosition.height,
+        left: buttonPosition.left
+      };
+    }
+
+    this.setState(state);
+  }
+
+  closeDropdown() {
+    if (this.state.isOpen) {
+      this.setState({ isOpen: false, renderHidden: false });
+    }
+  }
+
+  getMenuItems(items) {
+    const selectedID = this.getSelectedID();
+
+    return items.map(item => {
+      const classSet = classNames(
+        {
+          "is-selectable": item.selectable !== false,
+          "is-selected": item.id === selectedID
+        },
+        item.className,
+        this.props.dropdownMenuListItemClassName
+      );
+
+      let handleUserClick: any = null;
+
+      if (item.selectable !== false) {
+        handleUserClick = this.handleItemClick.bind(this, item);
+      }
+
+      return (
+        <li
+          className={classSet}
+          key={item.id}
+          onClick={handleUserClick}
+          role="button"
+        >
+          {item.html}
+        </li>
+      );
+    });
+  }
+
+  getScrollContainer() {
+    let { scrollContainer, scrollContainerParentSelector } = this.props;
+
+    if (typeof scrollContainer === "string") {
+      // Find the closest scrolling element by the specified selector.
+      scrollContainer =
+        DOMUtil.closest(ReactDOM.findDOMNode(this), scrollContainer) || window;
+
+      const { parentElement } = scrollContainer as any;
+
+      // If the user specified scrollContainerParentSelector, we check to see
+      // if the parent scrolling element matches the specified parent selector.
+      if (
+        scrollContainer !== window &&
+        scrollContainerParentSelector != null &&
+        parentElement != null &&
+        parentElement[DOMUtil.matchesFn](scrollContainerParentSelector)
+      ) {
+        scrollContainer = parentElement;
+      }
+    }
+
+    return scrollContainer;
+  }
+
+  getSelectedID() {
+    return this.props.persistentID || this.state.selectedID;
+  }
+
+  getSelectedItem() {
+    return this.props.items.find(item => item.id === this.getSelectedID());
+  }
+
+  render() {
+    // Set a key based on the menu height so that React knows to keep the
+    // the DOM element around while we are measuring it.
+    // const { props, state } = this;
+    let dropdownMenu = <div key="placeholder-element" />;
+    const dropdownMenuClassSet = classNames(
+      this.state.menuDirection,
+      this.props.dropdownMenuClassName
+    );
+    const { items, trigger = <DropdownListTrigger /> } = this.props;
+    const transitionName = `${this.props.transitionName}-${
+      this.state.menuDirection
+    }`;
+    const wrapperClassSet = classNames(
+      this.state.menuDirection,
+      this.props.wrapperClassName,
+      {
+        open: this.state.isOpen
+      }
+    );
+
+    if (this.state.isOpen) {
+      let dropdownMenuItems = (
+        <ul className="dropdown-menu-items">{this.getMenuItems(items)}</ul>
+      );
+
+      // Render with Gemini scrollbar if the dropdown's height should be
+      // constrainted.
+      if (this.state.menuHeight >= this.state.maxDropdownHeight) {
+        let height: number | string = "auto";
+
+        // Remove 30 pixels from the dropdown height to account for offset
+        // positioning from the dropdown button.
+        if (this.state.maxDropdownHeight > 30) {
+          height = this.state.maxDropdownHeight - 30;
+        }
+
+        const dropdownMenuStyle = { height };
+
+        if (this.props.useGemini && height !== "auto") {
+          dropdownMenuItems = (
+            <GeminiScrollbar
+              autoshow={true}
+              className="container-scrollable"
+              style={dropdownMenuStyle}
+            >
+              {dropdownMenuItems}
+            </GeminiScrollbar>
+          );
+        } else {
+          dropdownMenuItems = (
+            <div className="container-scrollable" style={dropdownMenuStyle}>
+              {dropdownMenuItems}
+            </div>
+          );
+        }
+      }
+
+      dropdownMenu = (
+        <span
+          key="dropdown-menu-key"
+          className={dropdownMenuClassSet}
+          role="menu"
+          ref={this.dropdownMenuRef}
+          style={this.state.menuPositionStyle}
+        >
+          <div className={this.props.dropdownMenuListClassName}>
+            {dropdownMenuItems}
+          </div>
+        </span>
+      );
+    }
+
+    if (this.state.renderHidden) {
+      dropdownMenu = (
+        <div key="concealer" className="dropdown-menu-concealer">
+          {dropdownMenu}
+        </div>
+      );
+    } else if (this.props.transition) {
+      dropdownMenu = (
+        <CSSTransition
+          in={this.state.isOpen}
+          classNames={transitionName}
+          timeout={{
+            enter: this.props.transitionEnterTimeout,
+            exit: this.props.transitionExitTimeout
+          }}
+        >
+          {dropdownMenu}
+        </CSSTransition>
+      );
+    }
+
+    injectGlobalDropdownStyles();
+
+    return (
+      <span
+        className={wrapperClassSet}
+        tabIndex={0}
+        onBlur={this.handleWrapperBlur}
+        ref={this.dropdownWrapperRef}
+      >
+        {React.cloneElement(trigger, {
+          selectedItem: this.getSelectedItem(),
+          onTrigger: this.handleMenuToggle,
+          className: this.props.buttonClassName,
+          disabled: this.props.disabled
+        })}
+        <Overlay>{dropdownMenu}</Overlay>
+      </span>
+    );
+  }
+}

--- a/packages/legacy/src/Dropdown/DropdownListTrigger.tsx
+++ b/packages/legacy/src/Dropdown/DropdownListTrigger.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import DropdownTrigger from "./DropdownTrigger";
+import { MenuItem } from "./Dropdown";
+
+interface DropdownListTriggerProps {
+  className?: string;
+  placeholder?: string;
+  selectedItem?: MenuItem;
+  onTrigger?: () => void;
+  disabled?: boolean;
+}
+
+export default class DropdownListTrigger extends DropdownTrigger<
+  DropdownListTriggerProps,
+  {}
+> {
+  render() {
+    const { className, disabled, selectedItem } = this.props;
+    const html = selectedItem
+      ? selectedItem.selectedHtml || selectedItem.html
+      : this.props.placeholder || null;
+
+    return (
+      <button
+        className={className}
+        disabled={disabled}
+        onClick={this.handleTrigger}
+        type="button"
+      >
+        {html}
+      </button>
+    );
+  }
+}

--- a/packages/legacy/src/Dropdown/DropdownTrigger.tsx
+++ b/packages/legacy/src/Dropdown/DropdownTrigger.tsx
@@ -1,0 +1,23 @@
+import { Component } from "react";
+
+interface DropdownTriggerProps {
+  onTrigger?: (event?: React.SyntheticEvent<HTMLElement>) => void;
+  disabled?: boolean;
+}
+
+export default class DropdownTrigger<
+  P extends DropdownTriggerProps,
+  S extends {}
+> extends Component<P, S> {
+  constructor(props) {
+    super(props);
+
+    this.handleTrigger = this.handleTrigger.bind(this);
+  }
+
+  handleTrigger(event) {
+    if (!this.props.disabled && this.props.onTrigger) {
+      this.props.onTrigger(event);
+    }
+  }
+}

--- a/packages/legacy/src/Dropdown/styles.ts
+++ b/packages/legacy/src/Dropdown/styles.ts
@@ -1,0 +1,208 @@
+import { injectGlobal } from "emotion";
+
+export const injectGlobalDropdownStyles = () => injectGlobal`
+@keyframes dropdown-down-enter {
+
+    0% {
+      transform: translateY(-30px);
+    }
+  
+    100% {
+      transform: translateY(0);
+    }
+  }
+  
+  @keyframes dropdown-down-exit {
+  
+    0% {
+      transform: translateY(0);
+    }
+  
+    100% {
+      transform: translateY(-30px);
+    }
+  }
+  
+  @keyframes dropdown-up-enter {
+  
+    0% {
+      transform: translateY(30px);
+    }
+  
+    100% {
+      transform: translateY(0);
+    }
+  }
+  
+  @keyframes dropdown-up-exit {
+  
+    0% {
+      transform: translateY(0);
+    }
+  
+    100% {
+      transform: translateY(30px);
+    }
+  }
+  
+  @keyframes dropdown-fade-in {
+  
+    0% {
+      opacity: 0;
+    }
+  
+    100% {
+      opacity: 1;
+    }
+  }
+  
+  @keyframes dropdown-fade-out {
+  
+    0% {
+      opacity: 1;
+    }
+  
+    100% {
+      opacity: 0;
+    }
+  }
+  
+  .dropdown {
+    display: inline-block;
+    outline: none;
+  
+    &.open {
+  
+      .dropdown-toggle {
+        z-index: 4;
+      }
+  
+      .dropdown-menu {
+        z-index: 3;
+  
+        &.inverse {
+  
+          li {
+  
+            &.is-selectable {
+              color: #fff;
+  
+              &:hover {
+                background: #51596a;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  
+  .dropdown-toggle {
+    position: relatlive;
+    z-index: 2;
+  
+    &:after {
+  
+      .open & {
+        // translate hack activates gpu to prevent jerky animation bug
+        transform: rotate(180deg) translate3d(0, 0, 0);
+      }
+    }
+  }
+  
+  .dropdown-menu {
+    // This can be removed when Canvas is updated to toggle visibility: visible
+    display: block !important;
+    padding-bottom: 0;
+    padding-top: 0;
+    position: fixed;
+    z-index: 1;
+  
+    &.up {
+      bottom: 100%;
+      margin-bottom: 5px;
+      top: auto;
+      transform-origin: bottom center;
+    }
+  
+    &.down {
+      bottom: auto;
+      margin-top: 5px;
+      top: 100%;
+      transform-origin: top center;
+    }
+  
+    em {
+      font-style: italic;
+    }
+  
+    .small {
+      font-size: 1em;
+    }
+  }
+  
+  .dropdown-menu-items {
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+  }
+  
+  .dropdown-menu-concealer {
+    pointer-events: none;
+    visibility: hidden;
+  }
+  
+  .dropdown-menu-down-enter,
+  .dropdown-menu-down-enter-active {
+    animation: dropdown-fade-in 250ms both, dropdown-down-enter 250ms both;
+  }
+  
+  .dropdown-menu-down-exit {
+    animation: dropdown-fade-out 250ms both, dropdown-down-exit 250ms both;
+    z-index: 3;
+  }
+  
+  .dropdown-menu-up-enter {
+    animation: dropdown-fade-in 250ms both, dropdown-up-enter 250ms both;
+  }
+  
+  .dropdown-menu-up-exit {
+    animation: dropdown-fade-out 250ms both, dropdown-up-exit 250ms both;
+    z-index: 3;
+  }
+  
+  .dropdown-menu-list {
+  
+    ul {
+      margin-bottom: 0;
+    }
+  
+    li {
+      cursor: default;
+  
+      &.is-selectable {
+        cursor: pointer;
+  
+        &:hover {
+          background: #f5f5f6;
+        }
+      }
+  
+      &.dropdown-menu-header {
+        color: #adb0b8;
+        font-size: 10px;
+        font-weight: 400;
+        margin: 14px 0 3px;
+        padding-bottom: 0;
+        padding-top: 0;
+        text-transform: uppercase;
+      }
+  
+      &.dropdown-menu-divider {
+        background: #ebebed;
+        height: 1px;
+        margin: 9px 0;
+        padding: 0;
+      }
+    }
+  }
+`;

--- a/packages/legacy/src/Dropdown/tests/Dropdown.test.tsx
+++ b/packages/legacy/src/Dropdown/tests/Dropdown.test.tsx
@@ -1,0 +1,241 @@
+import React from "react";
+import { mount } from "enzyme";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import toJson from "enzyme-to-json";
+import { Dropdown } from "../Dropdown";
+import { MockDropdownList } from "./fixtures/MockDropdownList";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+describe("Dropdown", () => {
+  it("should display a dropdown menu when the button is clicked", () => {
+    // Click on the dropdown button to open the menu
+    const component = mount(
+      <Dropdown
+        buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={MockDropdownList}
+        initialID="bar"
+        transition={false}
+        wrapperClassName="dropdown"
+      />
+    );
+    const button = component.find("button");
+    button.simulate("click");
+
+    expect(toJson(component)).toMatchSnapshot(); // rm this
+    expect(component.find(".dropdown-menu").length).toEqual(1);
+  });
+
+  it("should remove the dropdown menu when it loses focus", () => {
+    const component = mount(
+      <Dropdown
+        buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={MockDropdownList}
+        initialID="bar"
+        transition={false}
+        wrapperClassName="dropdown"
+      />
+    );
+    const button = component.find("button");
+    const eventMap = {
+      focus: () => undefined
+    };
+
+    document.addEventListener = jest.fn((event, cb) => {
+      eventMap[event] = cb;
+    });
+
+    button.simulate("click");
+
+    expect(component.state("isOpen")).toBe(true);
+    eventMap.focus();
+    // wait for timeout from handleWrapperBlur
+    setTimeout(() => {
+      expect(component.state("isOpen")).toBe(false);
+    }, 200);
+  });
+
+  it("should call the callback when selecting a selectable item", () => {
+    const itemSelectionCallback = jest.fn();
+    const component = mount(
+      <Dropdown
+        buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={MockDropdownList}
+        initialID="bar"
+        onItemSelection={itemSelectionCallback}
+        transition={false}
+        wrapperClassName="dropdown"
+      />
+    );
+
+    const button = component.find("button");
+    button.simulate("click");
+
+    const selectableElements = component.find(".dropdown-menu .is-selectable");
+
+    expect(itemSelectionCallback).not.toHaveBeenCalled();
+    selectableElements.first().simulate("click");
+    expect(itemSelectionCallback).toHaveBeenCalled();
+  });
+
+  it("renders an open menu", () => {
+    const component = mount(
+      <Dropdown
+        buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={MockDropdownList}
+        initialID="bar"
+        transition={false}
+        wrapperClassName="dropdown"
+      />
+    );
+
+    const button = component.find("button");
+    button.simulate("click");
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders trigger button with a persistentId", () => {
+    const component = mount(
+      <Dropdown
+        buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={MockDropdownList}
+        initialID="bar"
+        transition={false}
+        wrapperClassName="dropdown"
+        persistentID="quz"
+      />
+    );
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders disabled", () => {
+    const component = mount(
+      <Dropdown
+        buttonClassName="button dropdown-toggle"
+        dropdownMenuClassName="dropdown-menu"
+        dropdownMenuListClassName="dropdown-menu-list"
+        items={MockDropdownList}
+        initialID="bar"
+        transition={false}
+        wrapperClassName="dropdown"
+        disabled={true}
+      />
+    );
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  describe("#getSelectedID", function() {
+    it("should return initialID", function() {
+      const component = mount(
+        <Dropdown
+          buttonClassName="button dropdown-toggle"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          items={MockDropdownList}
+          initialID="bar"
+          transition={false}
+          wrapperClassName="dropdown"
+        />
+      );
+      const instance = component.instance() as Dropdown;
+
+      expect(instance.getSelectedID()).toEqual("bar");
+    });
+
+    it("should return persistentID over initialID", function() {
+      const component = mount(
+        <Dropdown
+          buttonClassName="button dropdown-toggle"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          items={MockDropdownList}
+          initialID="foo"
+          persistentID="bar"
+          transition={false}
+          wrapperClassName="dropdown"
+        />
+      );
+      const instance = component.instance() as Dropdown;
+
+      expect(instance.getSelectedID()).toEqual("bar");
+    });
+
+    it("should return persistentID over initialID after update", () => {
+      let component = mount(
+        <Dropdown
+          buttonClassName="button dropdown-toggle"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          items={MockDropdownList}
+          persistentID="quz"
+          initialID="foo"
+          transition={false}
+          wrapperClassName="dropdown"
+        />
+      );
+      component = mount(
+        <Dropdown
+          buttonClassName="button dropdown-toggle"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          items={MockDropdownList}
+          persistentID="foo"
+          initialID="foo"
+          transition={false}
+          wrapperClassName="dropdown"
+        />
+      );
+      const instance = component.instance() as Dropdown;
+
+      expect(instance.getSelectedID()).toEqual("foo");
+    });
+  });
+
+  describe("#getSelectedItem", () => {
+    it("returns item for initialID", () => {
+      const component = mount(
+        <Dropdown
+          buttonClassName="button dropdown-toggle"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          items={MockDropdownList}
+          initialID="bar"
+          transition={false}
+          wrapperClassName="dropdown"
+        />
+      );
+      const instance = component.instance() as Dropdown;
+
+      expect(instance.getSelectedItem()).toEqual(MockDropdownList[1]);
+    });
+    it("returns undefined if nothing is given", () => {
+      const component = mount(
+        <Dropdown
+          buttonClassName="button dropdown-toggle"
+          dropdownMenuClassName="dropdown-menu"
+          dropdownMenuListClassName="dropdown-menu-list"
+          items={MockDropdownList}
+          transition={false}
+          wrapperClassName="dropdown"
+        />
+      );
+      const instance = component.instance() as Dropdown;
+
+      expect(instance.getSelectedItem()).toEqual(undefined);
+    });
+  });
+});

--- a/packages/legacy/src/Dropdown/tests/DropdownListTrigger-test.js
+++ b/packages/legacy/src/Dropdown/tests/DropdownListTrigger-test.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-unused-vars */
+import React from "react";
+import ReactDOM from "react-dom";
+/* eslint-enable no-unused-vars */
+import DropdownListTrigger from "../DropdownListTrigger.js";
+
+var TestUtils;
+if (React.version.match(/15.[0-5]/)) {
+  TestUtils = require("react-addons-test-utils");
+} else {
+  TestUtils = require("react-dom/test-utils");
+}
+
+describe("DropdownListTrigger", function() {
+  it("renders with given props", function() {
+    expect(() =>
+      TestUtils.renderIntoDocument(
+        <DropdownListTrigger
+          onTrigger={this.callback}
+          placeholder="Placeholder"
+          disabled
+          className="class-1 class-2"
+          selectedItem={{
+            html: "html",
+            id: "id",
+            selectedHtml: "selectedHtml"
+          }}
+        />
+      )
+    ).not.toThrow();
+  });
+  it("renders correctly without props", function() {
+    expect(() =>
+      TestUtils.renderIntoDocument(<DropdownListTrigger />)
+    ).not.toThrow();
+  });
+  describe("#onTrigger", function() {
+    afterEach(function() {
+      Array.prototype.slice
+        .call(document.body.children)
+        .forEach(function(node) {
+          document.body.removeChild(node);
+        });
+    });
+    it("triggers onTrigger", function() {
+      const callback = jest.fn();
+      const instance = TestUtils.renderIntoDocument(
+        <DropdownListTrigger onTrigger={callback} />
+      );
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        instance,
+        "button"
+      );
+      TestUtils.Simulate.click(button);
+      expect(callback).toBeCalled();
+    });
+    it("triggers onTrigger", function() {
+      const callback = jest.fn();
+      const instance = TestUtils.renderIntoDocument(
+        <DropdownListTrigger disabled onTrigger={callback} />
+      );
+      const button = TestUtils.findRenderedDOMComponentWithTag(
+        instance,
+        "button"
+      );
+      TestUtils.Simulate.click(button);
+      expect(callback).not.toBeCalled();
+    });
+  });
+});

--- a/packages/legacy/src/Dropdown/tests/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/legacy/src/Dropdown/tests/__snapshots__/Dropdown.test.tsx.snap
@@ -1,0 +1,1299 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dropdown renders an open menu 1`] = `
+<Dropdown
+  buttonClassName="button dropdown-toggle"
+  dropdownMenuClassName="dropdown-menu"
+  dropdownMenuListClassName="dropdown-menu-list"
+  initialID="bar"
+  items={
+    Array [
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Foo",
+        "id": "foo",
+        "selectable": false,
+        "selectedHtml": "Foo",
+      },
+      Object {
+        "html": "Bar",
+        "id": "bar",
+        "selectedHtml": "Bar",
+      },
+      Object {
+        "html": "Baz",
+        "id": "baz",
+        "selectedHtml": "Baz",
+      },
+      Object {
+        "html": "Quz",
+        "id": "quz",
+        "selectedHtml": "Quz",
+      },
+      Object {
+        "className": "dropdown-menu-divider",
+        "id": "divider-a",
+        "selectable": false,
+      },
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Corge",
+        "id": "corge",
+        "selectable": false,
+      },
+      Object {
+        "html": "Grault",
+        "id": "grault",
+        "selectedHtml": "Grault",
+      },
+    ]
+  }
+  onItemSelection={[Function]}
+  scrollContainer={[Window]}
+  transition={false}
+  transitionEnterTimeout={250}
+  transitionExitTimeout={250}
+  transitionName="dropdown-menu"
+  trigger={<DropdownListTrigger />}
+  useGemini={true}
+  wrapperClassName="dropdown"
+>
+  <span
+    className="down dropdown open"
+    onBlur={[Function]}
+    tabIndex={0}
+  >
+    <DropdownListTrigger
+      className="button dropdown-toggle"
+      onTrigger={[Function]}
+      selectedItem={
+        Object {
+          "html": "Bar",
+          "id": "bar",
+          "selectedHtml": "Bar",
+        }
+      }
+    >
+      <button
+        className="button dropdown-toggle"
+        onClick={[Function]}
+        type="button"
+      >
+        Bar
+      </button>
+    </DropdownListTrigger>
+    <Overlay
+      overlayRoot={
+        <body>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+        </body>
+      }
+    >
+      <Portal
+        containerInfo={
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+        }
+      >
+        <div>
+          <span
+            className="down dropdown-menu"
+            key="dropdown-menu-key"
+            role="menu"
+            style={
+              Object {
+                "bottom": "auto",
+                "left": 0,
+                "right": "auto",
+                "top": 0,
+              }
+            }
+          >
+            <div
+              className="dropdown-menu-list"
+            >
+              <ul
+                className="dropdown-menu-items"
+              >
+                <li
+                  className="dropdown-menu-header"
+                  key="foo"
+                  onClick={null}
+                  role="button"
+                >
+                  Foo
+                </li>
+                <li
+                  className="is-selectable is-selected"
+                  key="bar"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Bar
+                </li>
+                <li
+                  className="is-selectable"
+                  key="baz"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Baz
+                </li>
+                <li
+                  className="is-selectable"
+                  key="quz"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Quz
+                </li>
+                <li
+                  className="dropdown-menu-divider"
+                  key="divider-a"
+                  onClick={null}
+                  role="button"
+                />
+                <li
+                  className="dropdown-menu-header"
+                  key="corge"
+                  onClick={null}
+                  role="button"
+                >
+                  Corge
+                </li>
+                <li
+                  className="is-selectable"
+                  key="grault"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Grault
+                </li>
+              </ul>
+            </div>
+          </span>
+        </div>
+      </Portal>
+    </Overlay>
+  </span>
+</Dropdown>
+`;
+
+exports[`Dropdown renders disabled 1`] = `
+<Dropdown
+  buttonClassName="button dropdown-toggle"
+  disabled={true}
+  dropdownMenuClassName="dropdown-menu"
+  dropdownMenuListClassName="dropdown-menu-list"
+  initialID="bar"
+  items={
+    Array [
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Foo",
+        "id": "foo",
+        "selectable": false,
+        "selectedHtml": "Foo",
+      },
+      Object {
+        "html": "Bar",
+        "id": "bar",
+        "selectedHtml": "Bar",
+      },
+      Object {
+        "html": "Baz",
+        "id": "baz",
+        "selectedHtml": "Baz",
+      },
+      Object {
+        "html": "Quz",
+        "id": "quz",
+        "selectedHtml": "Quz",
+      },
+      Object {
+        "className": "dropdown-menu-divider",
+        "id": "divider-a",
+        "selectable": false,
+      },
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Corge",
+        "id": "corge",
+        "selectable": false,
+      },
+      Object {
+        "html": "Grault",
+        "id": "grault",
+        "selectedHtml": "Grault",
+      },
+    ]
+  }
+  onItemSelection={[Function]}
+  scrollContainer={[Window]}
+  transition={false}
+  transitionEnterTimeout={250}
+  transitionExitTimeout={250}
+  transitionName="dropdown-menu"
+  trigger={<DropdownListTrigger />}
+  useGemini={true}
+  wrapperClassName="dropdown"
+>
+  <span
+    className="down dropdown"
+    onBlur={[Function]}
+    tabIndex={0}
+  >
+    <DropdownListTrigger
+      className="button dropdown-toggle"
+      disabled={true}
+      onTrigger={[Function]}
+      selectedItem={
+        Object {
+          "html": "Bar",
+          "id": "bar",
+          "selectedHtml": "Bar",
+        }
+      }
+    >
+      <button
+        className="button dropdown-toggle"
+        disabled={true}
+        onClick={[Function]}
+        type="button"
+      >
+        Bar
+      </button>
+    </DropdownListTrigger>
+    <Overlay
+      overlayRoot={
+        <body>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+        </body>
+      }
+    >
+      <Portal
+        containerInfo={
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+        }
+      >
+        <div>
+          <div
+            key="placeholder-element"
+          />
+        </div>
+      </Portal>
+    </Overlay>
+  </span>
+</Dropdown>
+`;
+
+exports[`Dropdown renders trigger button with a persistentId 1`] = `
+<Dropdown
+  buttonClassName="button dropdown-toggle"
+  dropdownMenuClassName="dropdown-menu"
+  dropdownMenuListClassName="dropdown-menu-list"
+  initialID="bar"
+  items={
+    Array [
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Foo",
+        "id": "foo",
+        "selectable": false,
+        "selectedHtml": "Foo",
+      },
+      Object {
+        "html": "Bar",
+        "id": "bar",
+        "selectedHtml": "Bar",
+      },
+      Object {
+        "html": "Baz",
+        "id": "baz",
+        "selectedHtml": "Baz",
+      },
+      Object {
+        "html": "Quz",
+        "id": "quz",
+        "selectedHtml": "Quz",
+      },
+      Object {
+        "className": "dropdown-menu-divider",
+        "id": "divider-a",
+        "selectable": false,
+      },
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Corge",
+        "id": "corge",
+        "selectable": false,
+      },
+      Object {
+        "html": "Grault",
+        "id": "grault",
+        "selectedHtml": "Grault",
+      },
+    ]
+  }
+  onItemSelection={[Function]}
+  persistentID="quz"
+  scrollContainer={[Window]}
+  transition={false}
+  transitionEnterTimeout={250}
+  transitionExitTimeout={250}
+  transitionName="dropdown-menu"
+  trigger={<DropdownListTrigger />}
+  useGemini={true}
+  wrapperClassName="dropdown"
+>
+  <span
+    className="down dropdown"
+    onBlur={[Function]}
+    tabIndex={0}
+  >
+    <DropdownListTrigger
+      className="button dropdown-toggle"
+      onTrigger={[Function]}
+      selectedItem={
+        Object {
+          "html": "Quz",
+          "id": "quz",
+          "selectedHtml": "Quz",
+        }
+      }
+    >
+      <button
+        className="button dropdown-toggle"
+        onClick={[Function]}
+        type="button"
+      >
+        Quz
+      </button>
+    </DropdownListTrigger>
+    <Overlay
+      overlayRoot={
+        <body>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+        </body>
+      }
+    >
+      <Portal
+        containerInfo={
+          <div>
+            <div>
+              <div />
+            </div>
+          </div>
+        }
+      >
+        <div>
+          <div
+            key="placeholder-element"
+          />
+        </div>
+      </Portal>
+    </Overlay>
+  </span>
+</Dropdown>
+`;
+
+exports[`Dropdown should display a dropdown menu when the button is clicked 1`] = `
+<Dropdown
+  buttonClassName="button dropdown-toggle"
+  dropdownMenuClassName="dropdown-menu"
+  dropdownMenuListClassName="dropdown-menu-list"
+  initialID="bar"
+  items={
+    Array [
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Foo",
+        "id": "foo",
+        "selectable": false,
+        "selectedHtml": "Foo",
+      },
+      Object {
+        "html": "Bar",
+        "id": "bar",
+        "selectedHtml": "Bar",
+      },
+      Object {
+        "html": "Baz",
+        "id": "baz",
+        "selectedHtml": "Baz",
+      },
+      Object {
+        "html": "Quz",
+        "id": "quz",
+        "selectedHtml": "Quz",
+      },
+      Object {
+        "className": "dropdown-menu-divider",
+        "id": "divider-a",
+        "selectable": false,
+      },
+      Object {
+        "className": "dropdown-menu-header",
+        "html": "Corge",
+        "id": "corge",
+        "selectable": false,
+      },
+      Object {
+        "html": "Grault",
+        "id": "grault",
+        "selectedHtml": "Grault",
+      },
+    ]
+  }
+  onItemSelection={[Function]}
+  scrollContainer={[Window]}
+  transition={false}
+  transitionEnterTimeout={250}
+  transitionExitTimeout={250}
+  transitionName="dropdown-menu"
+  trigger={<DropdownListTrigger />}
+  useGemini={true}
+  wrapperClassName="dropdown"
+>
+  <span
+    className="down dropdown open"
+    onBlur={[Function]}
+    tabIndex={0}
+  >
+    <DropdownListTrigger
+      className="button dropdown-toggle"
+      onTrigger={[Function]}
+      selectedItem={
+        Object {
+          "html": "Bar",
+          "id": "bar",
+          "selectedHtml": "Bar",
+        }
+      }
+    >
+      <button
+        className="button dropdown-toggle"
+        onClick={[Function]}
+        type="button"
+      >
+        Bar
+      </button>
+    </DropdownListTrigger>
+    <Overlay
+      overlayRoot={
+        <body>
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+        </body>
+      }
+    >
+      <Portal
+        containerInfo={
+          <div>
+            <div>
+              <span
+                class="down dropdown-menu"
+                role="menu"
+                style="top: 0px; left: 0px;"
+              >
+                <div
+                  class="dropdown-menu-list"
+                >
+                  <ul
+                    class="dropdown-menu-items"
+                  >
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Foo
+                    </li>
+                    <li
+                      class="is-selectable is-selected"
+                      role="button"
+                    >
+                      Bar
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Baz
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Quz
+                    </li>
+                    <li
+                      class="dropdown-menu-divider"
+                      role="button"
+                    />
+                    <li
+                      class="dropdown-menu-header"
+                      role="button"
+                    >
+                      Corge
+                    </li>
+                    <li
+                      class="is-selectable"
+                      role="button"
+                    >
+                      Grault
+                    </li>
+                  </ul>
+                </div>
+              </span>
+            </div>
+          </div>
+        }
+      >
+        <div>
+          <span
+            className="down dropdown-menu"
+            key="dropdown-menu-key"
+            role="menu"
+            style={
+              Object {
+                "bottom": "auto",
+                "left": 0,
+                "right": "auto",
+                "top": 0,
+              }
+            }
+          >
+            <div
+              className="dropdown-menu-list"
+            >
+              <ul
+                className="dropdown-menu-items"
+              >
+                <li
+                  className="dropdown-menu-header"
+                  key="foo"
+                  onClick={null}
+                  role="button"
+                >
+                  Foo
+                </li>
+                <li
+                  className="is-selectable is-selected"
+                  key="bar"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Bar
+                </li>
+                <li
+                  className="is-selectable"
+                  key="baz"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Baz
+                </li>
+                <li
+                  className="is-selectable"
+                  key="quz"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Quz
+                </li>
+                <li
+                  className="dropdown-menu-divider"
+                  key="divider-a"
+                  onClick={null}
+                  role="button"
+                />
+                <li
+                  className="dropdown-menu-header"
+                  key="corge"
+                  onClick={null}
+                  role="button"
+                >
+                  Corge
+                </li>
+                <li
+                  className="is-selectable"
+                  key="grault"
+                  onClick={[Function]}
+                  role="button"
+                >
+                  Grault
+                </li>
+              </ul>
+            </div>
+          </span>
+        </div>
+      </Portal>
+    </Overlay>
+  </span>
+</Dropdown>
+`;

--- a/packages/legacy/src/Dropdown/tests/fixtures/MockDropdownList.ts
+++ b/packages/legacy/src/Dropdown/tests/fixtures/MockDropdownList.ts
@@ -1,0 +1,40 @@
+export const MockDropdownList = [
+  {
+    className: "dropdown-menu-header",
+    html: "Foo",
+    id: "foo",
+    selectable: false,
+    selectedHtml: "Foo"
+  },
+  {
+    html: "Bar",
+    id: "bar",
+    selectedHtml: "Bar"
+  },
+  {
+    html: "Baz",
+    id: "baz",
+    selectedHtml: "Baz"
+  },
+  {
+    html: "Quz",
+    id: "quz",
+    selectedHtml: "Quz"
+  },
+  {
+    className: "dropdown-menu-divider",
+    id: "divider-a",
+    selectable: false
+  },
+  {
+    className: "dropdown-menu-header",
+    html: "Corge",
+    id: "corge",
+    selectable: false
+  },
+  {
+    html: "Grault",
+    id: "grault",
+    selectedHtml: "Grault"
+  }
+];


### PR DESCRIPTION
This moves the legacy Dropdown component over from reactjs-components.
Once we port all components reactjs-components to ui-kit, dcos-ui can import legacy components from ui-kit and drop reactjs-components as a dependency.

## How to test
### In dcos-ui:
0. In `dcos-ui`, update ui-kit to the latest version (currently 3.8.0) and run `npm install`.
1. In ui-kit, run `npm run dist`
2. Replace `dcos-ui/node_modules/@dcos/ui-kit/dist/packages/` with `ui-kit/dist/packages/`
3. Find a place in `dcos-ui` that uses a Dropdown imported from `reactjs-components` and replace the import with
```
import { Legacy } from "@dcos/ui-kit";
```
4. Replace `<Dropdown />` components with `<Legacy.Dropdown />`
5. Start dcos-ui

Check that `<Legacy.Dropdown />` looks and behaves like the `<Dropdown>` from reactjs-components

### In Storybook (optional):
1. Import legacy components to a `*.stories.tsx` file:
```
import { Legacy } from "@dcos/ui-kit";
```
2. Add CNVS styles to `injectGlobalCss` in `packages/shared/styles/global.ts`
3. Add a story that uses the legacy dropdown (`<Legacy.Dropdown />`)
4. `npm start` and navigate to the story in Storybook

## Screenshot
Switching tabs between a dcos-ui build that is using `Legacy.Dropdown` from ui-kit, and one the daily cluster:
![DropdownDemo](https://user-images.githubusercontent.com/2313998/58294712-9aace080-7d99-11e9-9f94-4287f5d37545.gif)
