### PR TITLE
fix: extend DropdownMenuItem bg color with text

### DIFF
--- a/packages/dropdowMenu/components/DropdownMenuItem.tsx
+++ b/packages/dropdowMenu/components/DropdownMenuItem.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 import { cx } from "emotion";
 import {
+  menuListItem,
   menuListItemActive,
   menuListItemSelected,
   menuListItemSelectedActive
 } from "../style";
-import { padding, margin } from "../../shared/styles/styleUtils";
+import { padding, margin, display } from "../../shared/styles/styleUtils";
 
 export interface DropdownMenuItemProps extends React.HTMLProps<HTMLDivElement> {
   children: React.ReactNode;
@@ -20,13 +21,19 @@ const DropdownMenuItem = (props: DropdownMenuItemProps) => {
   const { isActive, isSelected, index, listLength, disabled, ...other } = props;
   return (
     <div
-      className={cx(padding("horiz"), padding("vert", "xs"), {
-        [menuListItemActive]: isActive,
-        [menuListItemSelected]: isSelected,
-        [menuListItemSelectedActive]: isActive && isSelected,
-        [margin("top", "xs")]: index === 0,
-        [margin("bottom", "xs")]: index === listLength - 1
-      })}
+      className={cx(
+        menuListItem,
+        padding("horiz"),
+        padding("vert", "xs"),
+        display("inline-block"),
+        {
+          [menuListItemActive]: isActive,
+          [menuListItemSelected]: isSelected,
+          [menuListItemSelectedActive]: isActive && isSelected,
+          [margin("top", "xs")]: index === 0,
+          [margin("bottom", "xs")]: index === listLength - 1
+        }
+      )}
       {...other}
     />
   );

--- a/packages/dropdowMenu/style.ts
+++ b/packages/dropdowMenu/style.ts
@@ -14,6 +14,10 @@ export const menuList = css`
   overflow-y: scroll;
 `;
 
+export const menuListItem = css`
+  min-width: 100%;
+`;
+
 export const menuListItemActive = css`
   background-color: ${greyLightLighten5};
 `;

--- a/packages/dropdowMenu/tests/__snapshots__/DropdownMenuItem.test.tsx.snap
+++ b/packages/dropdowMenu/tests/__snapshots__/DropdownMenuItem.test.tsx.snap
@@ -2,10 +2,12 @@
 
 exports[`DropdownMenuItem renders 1`] = `
 .emotion-0 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-top: 8px;
   margin-bottom: 8px;
 }
@@ -19,10 +21,12 @@ exports[`DropdownMenuItem renders 1`] = `
 
 exports[`DropdownMenuItem renders active 1`] = `
 .emotion-0 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   background-color: #F7F8F9;
   margin-top: 8px;
   margin-bottom: 8px;
@@ -37,10 +41,12 @@ exports[`DropdownMenuItem renders active 1`] = `
 
 exports[`DropdownMenuItem renders active and selected 1`] = `
 .emotion-0 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   background-color: #F7F8F9;
   background-color: #7D58FF;
   color: #FFF;
@@ -58,10 +64,12 @@ exports[`DropdownMenuItem renders active and selected 1`] = `
 
 exports[`DropdownMenuItem renders disabled 1`] = `
 .emotion-0 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-top: 8px;
   margin-bottom: 8px;
 }
@@ -75,10 +83,12 @@ exports[`DropdownMenuItem renders disabled 1`] = `
 
 exports[`DropdownMenuItem renders selected 1`] = `
 .emotion-0 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   background-color: #7D58FF;
   color: #FFF;
   margin-top: 8px;

--- a/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
+++ b/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
@@ -120,25 +120,31 @@ exports[`Typeahead renders 1`] = `
 }
 
 .emotion-4 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-top: 8px;
 }
 
 .emotion-5 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
 }
 
 .emotion-6 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-bottom: 8px;
 }
 
@@ -363,25 +369,31 @@ exports[`Typeahead renders 1`] = `
 }
 
 .emotion-0 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-top: 8px;
 }
 
 .emotion-1 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
 }
 
 .emotion-2 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-bottom: 8px;
 }
 
@@ -739,25 +751,31 @@ exports[`Typeahead renders a menu with a max height 1`] = `
 }
 
 .emotion-4 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-top: 8px;
 }
 
 .emotion-5 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
 }
 
 .emotion-6 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-bottom: 8px;
 }
 
@@ -1031,25 +1049,31 @@ exports[`Typeahead renders a menu with a max height 1`] = `
 }
 
 .emotion-0 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-top: 8px;
 }
 
 .emotion-1 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
 }
 
 .emotion-2 {
+  min-width: 100%;
   padding-left: 16px;
   padding-right: 16px;
   padding-bottom: 8px;
   padding-top: 8px;
+  display: inline-block;
   margin-bottom: 8px;
 }
 


### PR DESCRIPTION
If a menu item's text is one long string with no spaces, the background color would only extend to the width of the menu.

This seems like an unlikely scenario, but we discovered it by testing a Typeahead that could contain long ID strings.

## Screenshots
Background has been changed to pink for demonstration purposes

Before:
![TypeaheadTextHighlight_before](https://user-images.githubusercontent.com/2313998/58333418-5bb77300-7e0b-11e9-9b6b-a85d5a7f8471.gif)

After:
![TypeaheadTextHighlight_after](https://user-images.githubusercontent.com/2313998/58333427-6114bd80-7e0b-11e9-8574-a6d383e0f97d.gif)
