### PR TITLE
[spike] DCOS-54218: port Confirm from reactjs-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12731,6 +12731,12 @@
         "wide-align": "^1.1.0"
       }
     },
+    "gemini-scrollbar": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/gemini-scrollbar/-/gemini-scrollbar-1.5.3.tgz",
+      "integrity": "sha512-3Q4SrxkJ+ei+I5PlcRZCfPePv3EduP7xusOWp7Uw0+XywEWred7Nq9hoaP2IQh1vRjoidaVODV3rO3icFH/e5A==",
+      "dev": true
+    },
     "genfun": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
@@ -20736,6 +20742,15 @@
         "focus-lock": "^0.6.0",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.0"
+      }
+    },
+    "react-gemini-scrollbar": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/react-gemini-scrollbar/-/react-gemini-scrollbar-2.3.4.tgz",
+      "integrity": "sha1-3v1g3fJD2vqjVPw6TQ75crkTdzI=",
+      "dev": true,
+      "requires": {
+        "gemini-scrollbar": "^1.5.3"
       }
     },
     "react-helmet-async": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   },
   "peerDependencies": {
     "react": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0",
-    "react-dom": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0"
+    "react-dom": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0",
+    "react-gemini-scrollbar": "^2.1.5 || ^2.3.0"
   },
   "devDependencies": {
     "acorn": "^6.0.5",
@@ -101,6 +102,7 @@
     "file-loader": "2.0.0",
     "fork-ts-checker-webpack-plugin": "0.5.2",
     "fs-extra": "7.0.0",
+    "react-gemini-scrollbar": "2.3.x",
     "jest": "23.6.0",
     "jest-emotion": "9.2.11",
     "jest-runner-prettier": "0.2.6",

--- a/packages/legacy/index.ts
+++ b/packages/legacy/index.ts
@@ -1,3 +1,5 @@
+import { Confirm } from "./src/Confirm/Confirm";
+import { Modal } from "./src/Modal/Modal";
 import { Tooltip } from "./src/Tooltip/Tooltip";
 
-export { Tooltip };
+export { Confirm, Modal, Tooltip };

--- a/packages/legacy/src/Confirm/Confirm.tsx
+++ b/packages/legacy/src/Confirm/Confirm.tsx
@@ -1,0 +1,83 @@
+import classNames from "classnames";
+import React from "react";
+
+import { Modal, ModalProps } from "../Modal/Modal";
+
+interface ConfirmProps extends ModalProps {
+  children: React.ReactNode;
+  disabled?: boolean;
+  leftButtonText: React.ReactNode;
+  leftButtonClassName?: string;
+  leftButtonCallback: () => void;
+  open: boolean;
+  rightButtonText: React.ReactNode;
+  rightButtonClassName?: string;
+  rightButtonCallback: () => void;
+}
+
+export class Confirm extends React.Component<ConfirmProps, {}> {
+  public static defaultProps: Partial<ConfirmProps> = {
+    open: true,
+    leftButtonText: "Cancel",
+    leftButtonClassName: "button button-primary-link flush-left",
+    rightButtonText: "Confirm",
+    rightButtonClassName: "button button-primary"
+  };
+
+  getButtons() {
+    const disabledConfig = { disabled: this.props.disabled };
+
+    const leftButtonClassName = classNames(this.props.leftButtonClassName);
+    const rightButtonClassName = classNames(
+      this.props.rightButtonClassName,
+      disabledConfig
+    );
+
+    let extraAttributes = {};
+    if (this.props.disabled) {
+      extraAttributes = disabledConfig;
+    }
+
+    return (
+      <div className="flush-bottom flex flex-direction-top-to-bottom flex-align-items-stretch-screen-small flex-direction-left-to-right-screen-small flex-justify-items-space-between-screen-small">
+        <button
+          className={leftButtonClassName}
+          onClick={this.props.leftButtonCallback}
+        >
+          {this.props.leftButtonText}
+        </button>
+        <button
+          className={rightButtonClassName}
+          onClick={this.props.rightButtonCallback}
+          {...extraAttributes}
+        >
+          {this.props.rightButtonText}
+        </button>
+      </div>
+    );
+  }
+
+  render() {
+    const { children, disabled, ...other } = this.props;
+
+    delete other.leftButtonText;
+    delete other.leftButtonClassName;
+    delete other.leftButtonCallback;
+    delete other.rightButtonText;
+    delete other.rightButtonClassName;
+    delete other.rightButtonCallback;
+
+    return (
+      <Modal
+        closeByBackdropClick={!disabled}
+        modalClass="modal modal-small"
+        showCloseButton={false}
+        showFooter={true}
+        footer={this.getButtons()}
+        {...other}
+      >
+        {children}
+      </Modal>
+    );
+  }
+}

--- a/packages/legacy/src/Confirm/__tests__/Confirm.test.tsx
+++ b/packages/legacy/src/Confirm/__tests__/Confirm.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { mount } from "enzyme";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import { Confirm } from "../Confirm";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+describe("Confirm", () => {
+  describe("enabled", () => {
+    it("calls the left button callback", () => {
+      const leftButtonCallback = jest.fn();
+      const component = mount(
+        <Confirm
+          leftButtonCallback={leftButtonCallback}
+          leftButtonClassName="left-button"
+        >
+          content
+        </Confirm>
+      );
+
+      const button = component.find(".left-button");
+      button.simulate("click");
+      expect(leftButtonCallback).toHaveBeenCalled();
+    });
+
+    it("calls the right button callback", () => {
+      const rightButtonCallback = jest.fn();
+      const component = mount(
+        <Confirm
+          rightButtonCallback={rightButtonCallback}
+          rightButtonClassName="right-button"
+        >
+          content
+        </Confirm>
+      );
+
+      const button = component.find(".right-button");
+      button.simulate("click");
+      expect(rightButtonCallback).toHaveBeenCalled();
+    });
+  });
+
+  describe("disabled", () => {
+    it("does call the left button callback", () => {
+      const closeCallback = jest.fn();
+      const component = mount(
+        <Confirm
+          open={true}
+          disabled={true}
+          leftButtonCallback={closeCallback}
+          leftButtonClassName="left-button"
+        >
+          <div className="container-pod">
+            Would you like to perform this action?
+          </div>
+        </Confirm>
+      );
+
+      const button = component.find(".left-button");
+      button.simulate("click");
+      expect(closeCallback).toHaveBeenCalled();
+    });
+
+    it("does not call the right button callback", () => {
+      const confirmCallback = jest.fn();
+      const component = mount(
+        <Confirm
+          open={true}
+          disabled={true}
+          rightButtonCallback={confirmCallback}
+          rightButtonClassName="right-button"
+        >
+          <div className="container-pod">
+            Would you like to perform this action?
+          </div>
+        </Confirm>
+      );
+
+      const button = component.find(".right-button");
+      button.simulate("click");
+      expect(confirmCallback).not.toHaveBeenCalled();
+    });
+
+    it("sets the disabled class on buttons", () => {
+      const confirmCallback = jest.fn();
+      const closeCallback = jest.fn();
+      const component = mount(
+        <Confirm
+          open={true}
+          disabled={true}
+          rightButtonCallback={confirmCallback}
+          rightButtonClassName="right-button"
+          leftButtonCallback={closeCallback}
+          leftButtonClassName="left-button"
+        >
+          <div className="container-pod">
+            Would you like to perform this action?
+          </div>
+        </Confirm>
+      );
+
+      const rightButton = component.find(".right-button");
+      expect(rightButton.hasClass("disabled")).toBe(true);
+    });
+  });
+});

--- a/packages/legacy/src/Modal/Modal.tsx
+++ b/packages/legacy/src/Modal/Modal.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import ModalContents from "./ModalContents";
+import Overlay from "../../../shared/components/Overlay";
+import { injectModalCss } from "./style";
+
+export interface ModalProps {
+  backdropClass?: string;
+  bodyClass?: string;
+  closeByBackdropClick?: boolean;
+  closeButton?: React.ReactElement<any>;
+  closeButtonClass?: string;
+  modalWrapperClass?: string;
+  modalHeight?: number;
+  open?: boolean;
+  scrollContainerClass?: string;
+  showHeader?: boolean;
+  footer?: React.ReactElement<any>;
+  footerClass?: string;
+  geminiClass?: string;
+  header?: React.ReactElement<any>;
+  headerClass?: string;
+  subHeader?: React.ReactElement<any>;
+  isFullScreen?: boolean;
+  showFooter?: boolean;
+  showCloseButton?: boolean;
+  useGemini?: boolean;
+  onClose?: () => void;
+  modalClass?: string;
+  transitionAppear?: boolean;
+  transitionEnter?: boolean;
+  transitionExit?: boolean;
+  transitionNameModal?: string;
+  transitionEnterTimeout?: number;
+  transitionExitTimeout?: number;
+  transitionAppearTimeoutModal?: number;
+  transitionEnterTimeoutModal?: number;
+  transitionExitTimeoutModal?: number;
+}
+
+export interface ModalState {
+  height: number | null;
+}
+
+/**
+ * Wrapper for the Modal, to put it inside of a Portal.
+ * The Modal needs its own lifecycle and therefore this wrapper is necessary
+ */
+
+export class Modal extends React.Component<ModalProps, ModalState> {
+  render() {
+    injectModalCss();
+
+    return (
+      <Overlay>
+        <ModalContents {...this.props} />
+      </Overlay>
+    );
+  }
+}

--- a/packages/legacy/src/Modal/ModalContents.tsx
+++ b/packages/legacy/src/Modal/ModalContents.tsx
@@ -1,0 +1,411 @@
+// tslint:disable
+import classNames from "classnames/dedupe";
+// tslint:enable
+import GeminiScrollbar from "react-gemini-scrollbar";
+import React from "react";
+/**
+ * Lifecycle of a Modal:
+ * initial page load -> empty TransitionGroup
+ * interaction changes open to true -> render modal content without scrollbars
+ * get height of content -> rerender modal content and cap the height
+ */
+
+import { CSSTransition } from "react-transition-group";
+
+import DOMUtil from "../Util/DOMUtil";
+import { ModalProps, ModalState } from "./Modal";
+
+// This value is used to designate "off-limits" vertical space, so that the
+// modal never comes into contact with the edge of the viewport.
+const MODAL_VERTICAL_INSET_DISTANCE = 48;
+
+const METHODS_TO_BIND = [
+  "calculateContentHeight",
+  "closeModal",
+  "handleBackdropClick",
+  "handleKeyDown",
+  "handleWindowResize"
+];
+
+export default class ModalContents extends React.Component<
+  ModalProps,
+  ModalState
+> {
+  public static defaultProps: Partial<ModalProps> = {
+    closeByBackdropClick: true,
+    transitionNameModal: "modal",
+    transitionAppearTimeoutModal: 300,
+    transitionEnterTimeoutModal: 300,
+    transitionExitTimeoutModal: 300,
+    transitionAppear: true,
+    transitionEnter: true,
+    transitionExit: true,
+    useGemini: true,
+
+    // Default classes.
+    backdropClass: "modal-backdrop",
+    bodyClass: "modal-body-wrapper",
+    closeButtonClass: "modal-close",
+    footerClass: "modal-footer",
+    headerClass: "modal-header",
+    modalClass: "modal modal-large",
+    scrollContainerClass: "modal-body"
+  };
+
+  public lastConstrainedHeight;
+  public lastViewportHeight;
+  private footerRef = React.createRef<any>();
+  private geminiRef = React.createRef<any>();
+  private headerRef = React.createRef<any>();
+  private innerContentContainerRef = React.createRef<any>();
+  private innerContentRef = React.createRef<any>();
+  private modalRef = React.createRef<any>();
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      height: null
+    };
+
+    METHODS_TO_BIND.forEach(method => {
+      this[method] = this[method].bind(this);
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.open !== nextProps.open) {
+      document.body.classList.toggle("no-overflow");
+    }
+  }
+
+  componentDidUpdate() {
+    // If we don't already know the height of the content, we calculate it.
+    if (this.props.open) {
+      this.lastViewportHeight = Math.ceil(DOMUtil.getViewportHeight());
+      window.requestAnimationFrame(this.calculateContentHeight);
+    }
+  }
+
+  componentWillUpdate(nextProps) {
+    // Reset the height of the content to null when the modal is closing so
+    // that the height will be recalculated next time it opens.
+    if (this.props.open && !nextProps.open) {
+      this.setState({ height: null });
+      this.removeKeydownListener();
+    }
+
+    if (!this.props.open && nextProps.open) {
+      this.addKeydownListener();
+    }
+  }
+
+  componentWillMount() {
+    if (this.props.open) {
+      document.body.classList.add("no-overflow");
+    }
+
+    window.addEventListener("resize", this.handleWindowResize);
+  }
+
+  componentWillUnmount() {
+    document.body.classList.remove("no-overflow");
+    window.removeEventListener("resize", this.handleWindowResize);
+  }
+
+  handleBackdropClick() {
+    if (this.props.closeByBackdropClick) {
+      this.closeModal();
+    }
+  }
+
+  handleKeyDown(event) {
+    if (event.keyCode === 27) {
+      this.closeModal();
+    }
+  }
+
+  handleWindowResize() {
+    // Return early if the modal is closed or not using Gemini.
+    if (!this.props.open) {
+      return;
+    }
+
+    const viewportHeight = Math.ceil(DOMUtil.getViewportHeight());
+
+    // If the height of the viewport is getting shorter, or if it's growing
+    // while the height is currently constrained, then we reset the restrained
+    // height to null which will cause the height to be recalculated on the
+    // next render.
+    if (
+      viewportHeight < this.lastViewportHeight ||
+      (viewportHeight > this.lastViewportHeight && this.state.height !== null)
+    ) {
+      this.setState({ height: null });
+    }
+
+    this.lastViewportHeight = viewportHeight;
+    window.requestAnimationFrame(this.calculateContentHeight);
+  }
+
+  addKeydownListener() {
+    document.body.addEventListener("keydown", this.handleKeyDown);
+  }
+
+  removeKeydownListener() {
+    document.body.removeEventListener("keydown", this.handleKeyDown);
+  }
+
+  calculateContentHeight() {
+    // A full screen modal doesn't need to restrict its height.
+    if (this.props.isFullScreen) {
+      return;
+    }
+
+    let headerHeight = 0;
+    let footerHeight = 0;
+    let modalHeight = 0;
+    let innerContentHeight = 0;
+
+    if (this.headerRef != null && this.headerRef.current != null) {
+      headerHeight = Math.ceil(
+        this.headerRef.current.getBoundingClientRect().height
+      );
+    }
+
+    if (this.footerRef != null && this.footerRef.current != null) {
+      footerHeight = Math.ceil(
+        this.footerRef.current.getBoundingClientRect().height
+      );
+    }
+
+    if (this.modalRef != null && this.modalRef.current != null) {
+      modalHeight = Math.ceil(
+        this.modalRef.current.getBoundingClientRect().height
+      );
+    }
+
+    if (this.innerContentRef != null && this.innerContentRef.current != null) {
+      innerContentHeight = Math.ceil(
+        this.innerContentRef.current.getBoundingClientRect().height
+      );
+    }
+
+    const maxModalHeight =
+      this.lastViewportHeight - MODAL_VERTICAL_INSET_DISTANCE;
+
+    const totalModalContentHeight =
+      innerContentHeight + headerHeight + footerHeight;
+
+    // When the modal's content fits on the screen, both the modal and body
+    // height can be set to `auto` (default).
+    let nextInnerContentContainerHeight = "auto";
+    let nextModalHeight = "auto";
+
+    // When the modal's content is too large to fit on the screen, then we need
+    // to explicitly set the body's height to its exact pixel value and the
+    // modal's height to `100%`.
+    const shouldConstrainHeight =
+      totalModalContentHeight >= maxModalHeight ||
+      this.lastViewportHeight < this.lastConstrainedHeight;
+
+    if (shouldConstrainHeight) {
+      const availableContentHeight = modalHeight - headerHeight - footerHeight;
+      nextInnerContentContainerHeight = `${availableContentHeight}px`;
+      nextModalHeight = "100%";
+
+      // We need to keep track of the largest viewport height that results in a
+      // constrained modal.
+      if (
+        this.lastConstrainedHeight == null ||
+        this.lastViewportHeight > this.lastConstrainedHeight
+      ) {
+        this.lastConstrainedHeight = this.lastViewportHeight;
+      }
+
+      if (
+        this.props.useGemini &&
+        this.state.height !== availableContentHeight
+      ) {
+        this.setState({ height: availableContentHeight });
+      }
+    }
+
+    if (
+      this.innerContentContainerRef != null &&
+      this.innerContentContainerRef.current != null
+    ) {
+      this.innerContentContainerRef.current.style.height = nextInnerContentContainerHeight;
+    }
+    if (this.modalRef != null && this.modalRef.current != null) {
+      this.modalRef.current.style.height = nextModalHeight;
+    }
+
+    this.triggerGeminiUpdate();
+  }
+
+  closeModal() {
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  }
+
+  getCloseButton() {
+    if (this.props.closeButton) {
+      return this.props.closeButton;
+    }
+
+    return null;
+  }
+
+  getHeader() {
+    if (!this.props.showHeader) {
+      return null;
+    }
+
+    return (
+      <div className={this.props.headerClass} ref={this.headerRef}>
+        {this.props.header}
+        {this.props.subHeader}
+      </div>
+    );
+  }
+
+  getFooter() {
+    if (!this.props.showFooter) {
+      return null;
+    }
+
+    return (
+      <div className={this.props.footerClass} ref={this.footerRef}>
+        {this.props.footer}
+      </div>
+    );
+  }
+
+  getModalContent() {
+    const modalContent = (
+      <div
+        className={this.props.scrollContainerClass}
+        ref={this.innerContentRef}
+      >
+        {this.props.children}
+      </div>
+    );
+
+    // If the consume disables gemini or we don't know the height, then we
+    // don't render with Gemini, unless the consumer is using specifying a
+    // custom height.
+    if (
+      (!this.props.useGemini || this.state.height == null) &&
+      this.props.modalHeight == null
+    ) {
+      return modalContent;
+    }
+
+    const geminiClasses = classNames(
+      "container-scrollable",
+      this.props.geminiClass
+    );
+    const geminiContainerStyle = { height: this.state.height };
+
+    if (this.props.modalHeight) {
+      geminiContainerStyle.height = this.props.modalHeight;
+    }
+
+    return (
+      <GeminiScrollbar
+        autoshow={false}
+        className={geminiClasses}
+        ref={this.geminiRef}
+        style={geminiContainerStyle}
+      >
+        {modalContent}
+      </GeminiScrollbar>
+    );
+  }
+
+  getModal() {
+    const modalBodyStyle: any = {};
+
+    if (!this.props.open) {
+      return null;
+    }
+
+    if (this.state.height != null) {
+      modalBodyStyle.height = this.state.height;
+    }
+
+    return (
+      <div ref={this.modalRef} className={this.props.modalClass}>
+        {this.getCloseButton()}
+        {this.getHeader()}
+        <div
+          className={this.props.bodyClass}
+          style={modalBodyStyle}
+          ref={this.innerContentContainerRef}
+        >
+          {this.getModalContent()}
+        </div>
+        {this.getFooter()}
+      </div>
+    );
+  }
+
+  getBackdrop() {
+    if (!this.props.open) {
+      return null;
+    }
+
+    return (
+      // tslint:disable react-a11y-event-has-role
+      <div
+        className={this.props.backdropClass}
+        onClick={this.handleBackdropClick}
+      />
+      // tslint:enable
+    );
+  }
+
+  triggerGeminiUpdate() {
+    if (
+      this.geminiRef != null &&
+      this.geminiRef.current != null &&
+      this.geminiRef.current.scrollbar != null
+    ) {
+      this.geminiRef.current.scrollbar.update();
+    }
+  }
+
+  render() {
+    let modalContent: any = null;
+
+    if (this.props.open) {
+      modalContent = (
+        <div
+          className={classNames("modal-wrapper", this.props.modalWrapperClass)}
+        >
+          {this.getBackdrop()}
+          {this.getModal()}
+        </div>
+      );
+    }
+
+    return (
+      <CSSTransition
+        in={this.props.open}
+        appear={this.props.transitionAppear}
+        enter={this.props.transitionEnter}
+        exit={this.props.transitionExit}
+        classNames={this.props.transitionNameModal}
+        timeout={{
+          enter: this.props.transitionEnterTimeout,
+          exit: this.props.transitionExitTimeout,
+          appear: this.props.transitionAppearTimeoutModal
+        }}
+      >
+        <div>{modalContent}</div>
+      </CSSTransition>
+    );
+  }
+}

--- a/packages/legacy/src/Modal/style.ts
+++ b/packages/legacy/src/Modal/style.ts
@@ -1,0 +1,97 @@
+import { injectGlobal } from "emotion";
+
+const modalAnimationOffset = "50px";
+const modalAnimationDuration = "0.3s";
+const modalAnimationEasing = "ease";
+
+export const injectModalCss = () => injectGlobal`
+    .modal-wrapper {
+        position: fixed;
+        z-index: 1000;
+    }
+
+    .modal {
+        left: 50%;
+        position: fixed;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        z-index: auto;
+    }
+
+    .modal-body-wrapper {
+        flex: 1 1 auto;
+        min-height: 0;
+        position: relative;
+
+        .container-scrollable {
+            height: 100%;
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 100%;
+        }
+    }
+
+    .modal-backdrop {
+        height: 100%;
+        left: 0;
+        position: fixed;
+        top: 0;
+        width: 100%;
+        z-index: auto;
+    }
+
+    .modal-enter,
+    .modal-appear {
+
+        .modal {
+            opacity: 0;
+            transform: translate(-50%, calc(-50% ~' - ' ${modalAnimationOffset}));
+        }
+
+        .modal-backdrop {
+            opacity: 0;
+        }
+
+        &.modal-enter-active,
+        &.modal-appear-active {
+
+            .modal {
+                opacity: 1;
+                transform: translate(-50%, -50%);
+                transition: transform ${modalAnimationDuration} ${modalAnimationEasing}, opacity ${modalAnimationDuration} ${modalAnimationEasing};
+            }
+
+            .modal-backdrop {
+                opacity: 1;
+                transition: opacity ${modalAnimationDuration} ${modalAnimationEasing};
+            }
+        }
+    }
+
+    .modal-exit {
+
+        .modal {
+            opacity: 1;
+            transform: translate(-50%, -50%);
+        }
+
+        .modal-backdrop {
+            opacity: 1;
+        }
+
+        &.modal-exit-active {
+
+            .modal {
+                opacity: 0;
+                transform: translate(-50%, calc(-50% ~' - ' ${modalAnimationOffset}));
+                transition: transform ${modalAnimationDuration} ${modalAnimationEasing}, opacity ${modalAnimationDuration} ${modalAnimationEasing};
+            }
+
+            .modal-backdrop {
+                opacity: 0;
+                transition: opacity ${modalAnimationDuration} ${modalAnimationEasing};
+            }
+        }
+    }
+`;

--- a/packages/legacy/src/Modal/tests/ModalContents.test.tsx
+++ b/packages/legacy/src/Modal/tests/ModalContents.test.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import { mount } from "enzyme";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import toJson from "enzyme-to-json";
+import ModalContents from "../ModalContents";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+describe("ModalContents", () => {
+  it("renders", () => {
+    const onClose = jest.fn();
+    const component = mount(
+      <ModalContents open={true} onClose={onClose}>
+        content
+      </ModalContents>
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders with a footer", () => {
+    const onClose = jest.fn();
+    const component = mount(
+      <ModalContents open={true} onClose={onClose} showFooter={true}>
+        content
+      </ModalContents>
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders with a close button", () => {
+    const onClose = jest.fn();
+    const component = mount(
+      <ModalContents
+        open={true}
+        onClose={onClose}
+        closeButton={<button>Close</button>}
+      >
+        content
+      </ModalContents>
+    );
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  describe("#onClose", () => {
+    it("should call onClose when the modal closes", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents open={true} onClose={onClose}>
+          content
+        </ModalContents>
+      );
+
+      expect(onClose).not.toHaveBeenCalled();
+      component.find(".modal-backdrop").simulate("click");
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("does not call onClose if closeByBackdropClick is false", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents
+          open={true}
+          onClose={onClose}
+          closeByBackdropClick={false}
+        >
+          content
+        </ModalContents>
+      );
+
+      component.find(".modal-backdrop").simulate("click");
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("#handleWindowResize", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(window, "requestAnimationFrame")
+        .mockImplementation(cb => cb());
+    });
+
+    it("should store the last viewport height on the instance", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents open={true} onClose={onClose}>
+          content
+        </ModalContents>
+      );
+
+      const instance = component.instance() as ModalContents;
+      Object.defineProperty(window, "innerHeight", {
+        writable: true,
+        configurable: true,
+        value: 500
+      });
+      window.dispatchEvent(new Event("resize"));
+
+      expect(instance.lastViewportHeight).toEqual(500);
+    });
+
+    it("should reset the height stored in state to null when the viewport height is shrinking", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents open={true} onClose={onClose}>
+          content
+        </ModalContents>
+      );
+      const instance = component.instance() as ModalContents;
+
+      instance.setState({ height: 300 });
+
+      expect(component.state("height")).toBe(300);
+
+      Object.defineProperty(window, "innerHeight", {
+        writable: true,
+        configurable: true,
+        value: 500
+      });
+      window.dispatchEvent(new Event("resize"));
+
+      Object.defineProperty(window, "innerHeight", {
+        writable: true,
+        configurable: true,
+        value: 400
+      });
+      window.dispatchEvent(new Event("resize"));
+
+      expect(component.state("height")).toBe(null);
+    });
+  });
+
+  describe("overflow hidden on body", () => {
+    it("should toggle no-overflow on body when updated to open", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents open={true} onClose={onClose}>
+          content
+        </ModalContents>
+      );
+      const classToggleSpy = spyOn(document.body.classList, "toggle");
+      component.setProps({ open: false });
+
+      expect(classToggleSpy).toHaveBeenCalledWith("no-overflow");
+    });
+
+    it("should toggle no-overflow on body when updated to close", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents open={false} onClose={onClose}>
+          content
+        </ModalContents>
+      );
+      const classToggleSpy = spyOn(document.body.classList, "toggle");
+      component.setProps({ open: true });
+
+      expect(classToggleSpy).toHaveBeenCalledWith("no-overflow");
+    });
+
+    it("should not change class on body when mounted close", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents open={false} onClose={onClose}>
+          content
+        </ModalContents>
+      );
+      const classAddSpy = spyOn(document.body.classList, "add");
+      component.mount();
+
+      expect(classAddSpy).not.toHaveBeenCalledWith("no-overflow");
+    });
+
+    it("should remove no-overflow on body when unmounted", () => {
+      const onClose = jest.fn();
+      const component = mount(
+        <ModalContents open={true} onClose={onClose}>
+          content
+        </ModalContents>
+      );
+      const classRemoveSpy = spyOn(document.body.classList, "remove");
+      component.unmount();
+
+      expect(classRemoveSpy).toHaveBeenCalledWith("no-overflow");
+    });
+  });
+});

--- a/packages/legacy/src/Modal/tests/__snapshots__/ModalContents.test.tsx.snap
+++ b/packages/legacy/src/Modal/tests/__snapshots__/ModalContents.test.tsx.snap
@@ -1,0 +1,268 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalContents renders 1`] = `
+<ModalContents
+  backdropClass="modal-backdrop"
+  bodyClass="modal-body-wrapper"
+  closeButtonClass="modal-close"
+  closeByBackdropClick={true}
+  footerClass="modal-footer"
+  headerClass="modal-header"
+  modalClass="modal modal-large"
+  onClose={[MockFunction]}
+  open={true}
+  scrollContainerClass="modal-body"
+  transitionAppear={true}
+  transitionAppearTimeoutModal={300}
+  transitionEnter={true}
+  transitionEnterTimeoutModal={300}
+  transitionExit={true}
+  transitionExitTimeoutModal={300}
+  transitionNameModal="modal"
+  useGemini={true}
+>
+  <CSSTransition
+    appear={true}
+    classNames="modal"
+    enter={true}
+    exit={true}
+    in={true}
+    timeout={
+      Object {
+        "appear": 300,
+        "enter": undefined,
+        "exit": undefined,
+      }
+    }
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={
+        Object {
+          "appear": 300,
+          "enter": undefined,
+          "exit": undefined,
+        }
+      }
+      unmountOnExit={false}
+    >
+      <div>
+        <div
+          className="modal-wrapper"
+        >
+          <div
+            className="modal-backdrop"
+            onClick={[Function]}
+          />
+          <div
+            className="modal modal-large"
+          >
+            <div
+              className="modal-body-wrapper"
+              style={Object {}}
+            >
+              <div
+                className="modal-body"
+              >
+                content
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </CSSTransition>
+</ModalContents>
+`;
+
+exports[`ModalContents renders with a close button 1`] = `
+<ModalContents
+  backdropClass="modal-backdrop"
+  bodyClass="modal-body-wrapper"
+  closeButton={
+    <button>
+      Close
+    </button>
+  }
+  closeButtonClass="modal-close"
+  closeByBackdropClick={true}
+  footerClass="modal-footer"
+  headerClass="modal-header"
+  modalClass="modal modal-large"
+  onClose={[MockFunction]}
+  open={true}
+  scrollContainerClass="modal-body"
+  transitionAppear={true}
+  transitionAppearTimeoutModal={300}
+  transitionEnter={true}
+  transitionEnterTimeoutModal={300}
+  transitionExit={true}
+  transitionExitTimeoutModal={300}
+  transitionNameModal="modal"
+  useGemini={true}
+>
+  <CSSTransition
+    appear={true}
+    classNames="modal"
+    enter={true}
+    exit={true}
+    in={true}
+    timeout={
+      Object {
+        "appear": 300,
+        "enter": undefined,
+        "exit": undefined,
+      }
+    }
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={
+        Object {
+          "appear": 300,
+          "enter": undefined,
+          "exit": undefined,
+        }
+      }
+      unmountOnExit={false}
+    >
+      <div>
+        <div
+          className="modal-wrapper"
+        >
+          <div
+            className="modal-backdrop"
+            onClick={[Function]}
+          />
+          <div
+            className="modal modal-large"
+          >
+            <button>
+              Close
+            </button>
+            <div
+              className="modal-body-wrapper"
+              style={Object {}}
+            >
+              <div
+                className="modal-body"
+              >
+                content
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </CSSTransition>
+</ModalContents>
+`;
+
+exports[`ModalContents renders with a footer 1`] = `
+<ModalContents
+  backdropClass="modal-backdrop"
+  bodyClass="modal-body-wrapper"
+  closeButtonClass="modal-close"
+  closeByBackdropClick={true}
+  footerClass="modal-footer"
+  headerClass="modal-header"
+  modalClass="modal modal-large"
+  onClose={[MockFunction]}
+  open={true}
+  scrollContainerClass="modal-body"
+  showFooter={true}
+  transitionAppear={true}
+  transitionAppearTimeoutModal={300}
+  transitionEnter={true}
+  transitionEnterTimeoutModal={300}
+  transitionExit={true}
+  transitionExitTimeoutModal={300}
+  transitionNameModal="modal"
+  useGemini={true}
+>
+  <CSSTransition
+    appear={true}
+    classNames="modal"
+    enter={true}
+    exit={true}
+    in={true}
+    timeout={
+      Object {
+        "appear": 300,
+        "enter": undefined,
+        "exit": undefined,
+      }
+    }
+  >
+    <Transition
+      appear={true}
+      enter={true}
+      exit={true}
+      in={true}
+      mountOnEnter={false}
+      onEnter={[Function]}
+      onEntered={[Function]}
+      onEntering={[Function]}
+      onExit={[Function]}
+      onExited={[Function]}
+      onExiting={[Function]}
+      timeout={
+        Object {
+          "appear": 300,
+          "enter": undefined,
+          "exit": undefined,
+        }
+      }
+      unmountOnExit={false}
+    >
+      <div>
+        <div
+          className="modal-wrapper"
+        >
+          <div
+            className="modal-backdrop"
+            onClick={[Function]}
+          />
+          <div
+            className="modal modal-large"
+          >
+            <div
+              className="modal-body-wrapper"
+              style={Object {}}
+            >
+              <div
+                className="modal-body"
+              >
+                content
+              </div>
+            </div>
+            <div
+              className="modal-footer"
+            />
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </CSSTransition>
+</ModalContents>
+`;


### PR DESCRIPTION
This moves the legacy Confirm component over from reactjs-components.
Once we port all components reactjs-components to ui-kit, dcos-ui can import legacy components from ui-kit and drop reactjs-components as a dependency.

## How to test
### In dcos-ui:
0. In dcos-ui, update ui-kit to the latest version (currently 3.8.0) and run npm install.
1. In ui-kit, run `npm run dist`
2. Replace `dcos-ui/node_modules/@dcos/ui-kit/dist/packages/` with `ui-kit/dist/packages/`
3. Find a place in `dcos-ui` that uses a Confirm imported from `reactjs-components` and replace the import with
```
import { Legacy } from "@dcos/ui-kit";
```
4. Replace `<Confirm />` components with `<Legacy.Confirm />`
5. Start dcos-ui

Check that `<Legacy.Confirm />` looks and behaves like the `<Confirm>` from reactjs-components

### In Storybook (optional):
1. Import legacy components to a `*.stories.tsx` file:
```
import { Legacy } from "@dcos/ui-kit";
```
2. Add CNVS styles to `injectGlobalCss` in `packages/shared/styles/global.ts`
3. Add [reactjs-components gemini-scrollbar styles](https://github.com/mesosphere/reactjs-components/blob/master/src/overrides/gemini-scrollbar.less) to `injectGlobalCss` in `packages/shared/styles/global.ts`
4. Add gemini-scrollbar library styles from `'../../node_modules/gemini-scrollbar/gemini-scrollbar.css'` to `injectGlobalCss` in `packages/shared/styles/global.ts`
3. Add a story that uses the legacy Confirm (`<Legacy.Confirm />`)
4. `npm start` and navigate to the story in Storybook

## Screenshot
Switching tabs between a dcos-ui build that is using `Legacy.Confirm` from ui-kit, and one the daily cluster:
![ConfirmDemo](https://user-images.githubusercontent.com/2313998/58352505-b8318700-7e39-11e9-9afd-d1417799d05c.gif)
