### PR TITLE
DCOS-54461 feat(pageheader): add minimal component implementation

### DIFF
--- a/packages/pageheader/README.md
+++ b/packages/pageheader/README.md
@@ -1,0 +1,1 @@
+# PageHeader

--- a/packages/pageheader/components/PageHeader.tsx
+++ b/packages/pageheader/components/PageHeader.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { default as Breadcrumb } from "../../breadcrumb/components/Breadcrumb";
+
+import { flush } from "../../shared/styles/styleUtils";
+
+import { style } from "../style";
+
+export interface PageHeaderProps {
+  breadcrumbElements: React.ReactNodeArray;
+  actions?: Array<React.ReactElement<any>>;
+}
+
+class PageHeader extends React.PureComponent<PageHeaderProps, {}> {
+  public render() {
+    const { breadcrumbElements, actions = [] } = this.props;
+
+    return (
+      <div className={style}>
+        <Breadcrumb>{breadcrumbElements}</Breadcrumb>
+        <ul className={flush("all")}>
+          {actions.map(action => {
+            return <li key={`${action.key}`}>{action}</li>;
+          })}
+        </ul>
+      </div>
+    );
+  }
+}
+
+export default PageHeader;

--- a/packages/pageheader/index.ts
+++ b/packages/pageheader/index.ts
@@ -1,0 +1,1 @@
+export { default as PageHeader } from "./components/PageHeader";

--- a/packages/pageheader/stories/PageHeader.stories.tsx
+++ b/packages/pageheader/stories/PageHeader.stories.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+
+import { PageHeader } from "../index";
+import { Clickable } from "../../clickable";
+
+const readme = require("../README.md");
+const action = () => alert("Action 1 triggered");
+
+storiesOf("PageHeader", module)
+  .addDecorator(withReadme([readme]))
+  .add("default", () => (
+    <PageHeader
+      breadcrumbElements={[
+        <span key="ElementOne">One</span>,
+        <span key="ElementTwo">Two</span>
+      ]}
+      actions={[
+        <Clickable key="Action1" action={action}>
+          <div>Action 1</div>
+        </Clickable>
+      ]}
+    />
+  ));

--- a/packages/pageheader/style.ts
+++ b/packages/pageheader/style.ts
@@ -1,0 +1,6 @@
+import { css } from "emotion";
+
+export const style = css`
+  display: grid;
+  grid-template-columns: repeat(2, 50%);
+`;

--- a/packages/pageheader/tests/PageHeader.test.tsx
+++ b/packages/pageheader/tests/PageHeader.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render } from "enzyme";
+import toJSON from "enzyme-to-json";
+
+import { PageHeader } from "../";
+import { Clickable } from "../../clickable";
+
+describe("PageHeader", () => {
+  it("default", () => {
+    const action = () => 1;
+    expect(
+      toJSON(
+        render(
+          <PageHeader
+            breadcrumbElements={[
+              <span key="One">One</span>,
+              <span key="Two">Two</span>
+            ]}
+            actions={[
+              <Clickable key="Action1" action={action}>
+                <div>Action 1</div>
+              </Clickable>
+            ]}
+          />
+        )
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PageHeader default 1`] = `
+<div
+  class="css-jiaax5"
+>
+  <div
+    class="css-ewxxaj"
+  >
+    <span>
+      One
+    </span>
+    <span>
+      Two
+    </span>
+  </div>
+  <ul
+    class="css-10pfh7o"
+  >
+    <li>
+      <div
+        class="css-1h5x3dy"
+        role="button"
+        tabindex="-1"
+      >
+        Action 1
+      </div>
+    </li>
+  </ul>
+</div>
+`;


### PR DESCRIPTION
This adds a minimal implementation for a page header.

CLOSES DCOS-54461

Depends on #331

![image](https://user-images.githubusercontent.com/156010/58431934-4e6ee280-80b0-11e9-85ce-7bd6b750e087.png)
