### PR TITLE
DCOS-43353: add style utility typography components

### DIFF
--- a/packages/breadcrumb/tests/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/breadcrumb/tests/__snapshots__/Breadcrumb.test.tsx.snap
@@ -5,14 +5,14 @@ exports[`Breadcrumb default 1`] = `
   class="css-1v0xyde"
 >
   <div
-    class="css-3phh5d"
+    class="css-1mdqktp"
   >
     <span>
       One
     </span>
   </div>
   <div
-    class="css-3phh5d"
+    class="css-1mdqktp"
   >
     <svg
       aria-label="system-caret-right icon"
@@ -29,7 +29,7 @@ exports[`Breadcrumb default 1`] = `
     </svg>
   </div>
   <div
-    class="css-n2rkn1"
+    class="css-1ixtlzk"
   >
     <span>
       Two

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -1520,7 +1520,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                         class="css-1byz17q"
                       >
                         <div
-                          class="css-95z8m4"
+                          class="css-16jj0m8"
                         >
                           Title
                         </div>

--- a/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
@@ -11,14 +11,14 @@ exports[`PageHeader default 1`] = `
       class="css-1v0xyde"
     >
       <div
-        class="css-3phh5d"
+        class="css-1mdqktp"
       >
         <span>
           One
         </span>
       </div>
       <div
-        class="css-3phh5d"
+        class="css-1mdqktp"
       >
         <svg
           aria-label="system-caret-right icon"
@@ -35,7 +35,7 @@ exports[`PageHeader default 1`] = `
         </svg>
       </div>
       <div
-        class="css-n2rkn1"
+        class="css-1ixtlzk"
       >
         <span>
           Two

--- a/packages/shared/styles/styleUtils/typography/color.ts
+++ b/packages/shared/styles/styleUtils/typography/color.ts
@@ -9,15 +9,17 @@ import {
 // TODO: when we do the design tokens lib,
 // generate a type for _only_ our colors
 // instead of just accepting any string
-export const tintText = (color: string) => css`
+export const tintText = (color: React.CSSProperties["color"]) => css`
   color: ${color};
 `;
 
-export const tintSVG = (color: string) => css`
+export const tintSVG = (color: React.CSSProperties["fill"]) => css`
   fill: ${color};
 `;
 
-export const tintContent = (color: string) => css`
+export const tintContent = (
+  color: React.CSSProperties["color"] | React.CSSProperties["fill"]
+) => css`
   ${tintText(color)};
   ${tintSVG(color)};
 `;

--- a/packages/shared/styles/styleUtils/typography/textSize.ts
+++ b/packages/shared/styles/styleUtils/typography/textSize.ts
@@ -1,8 +1,17 @@
-import { css } from "react-emotion";
 import { fontSizes } from "../../typography";
+import { getResponsiveStyle } from "../";
+import { BreakpointConfig } from "../../breakpoints";
 
-type FontSizes = keyof typeof fontSizes;
+export type FontSize = BreakpointConfig<keyof typeof fontSizes>;
 
-export const textSize = (size: FontSizes) => css`
-  font-size: ${fontSizes[size]};
-`;
+export const textSize = (size: FontSize) => {
+  const fontSizeValue =
+    typeof size !== "object"
+      ? fontSizes[size]
+      : Object.entries(size).reduce((acc, [breakpoint, value]) => {
+          acc[breakpoint] = fontSizes[value];
+          return acc;
+        }, {});
+
+  return getResponsiveStyle("font-size", fontSizeValue);
+};

--- a/packages/shared/styles/styleUtils/typography/weight.ts
+++ b/packages/shared/styles/styleUtils/typography/weight.ts
@@ -1,7 +1,7 @@
 import { css } from "emotion";
 import { fontWeights } from "../../typography";
 
-type FontWeights = keyof typeof fontWeights;
+export type FontWeights = keyof typeof fontWeights;
 
 export const textWeight = (weight: FontWeights) => css`
   font-weight: ${fontWeights[weight]};

--- a/packages/styleUtils/typography/README.md
+++ b/packages/styleUtils/typography/README.md
@@ -1,0 +1,32 @@
+# Typography components
+Components for our design system's typography
+
+## Text
+The base typography component. When used without any props, it renders like our default/body text style
+
+## HeadingText1
+Our "loudest" heading. Used for text at the highest level of hierarchy, or used to treat typography like imagery. Sometimes referred to by designers as "display type"
+
+## HeadingText2
+A large and "loud" heading, but a level of hierarchy below `HeadingText1`. Commonly used for page titles or major section headings
+
+## HeadingText3
+Our quietest heading. It stands out more than body text, but is used to label things with a lower level of hierarchy
+
+## CaptionText
+Used for caption text or hint text for a form field. Typically used for text that isn't mandatory for a user to read in order to successfully accomplish a task
+
+## DangerText
+Used for text that is communicating something is wrong. Typically used for things like errors
+
+## WarningText
+Used for text that is warning a user of a potential hazard that could occur. Used for cases that aren't serious enough for `DangerText`
+
+## SuccessText
+Used for text that informs the user that something is in a optimal state, or an action they have taken was successful
+
+## MonospaceText
+Changes text to be in a monospace font. Used for things like keys, values, or blocks of code
+
+## SmallText
+It's exactly what it sounds like - just smaller text

--- a/packages/styleUtils/typography/components/CaptionText.tsx
+++ b/packages/styleUtils/typography/components/CaptionText.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import SmallText from "./SmallText";
+import { SharedTextProps } from "../textTypes";
+import { themeTextColorSecondary } from "../../../design-tokens/build/js/designTokens";
+
+const CaptionText = (props: SharedTextProps) => (
+  <SmallText weight="normal" color={themeTextColorSecondary} {...props} />
+);
+
+CaptionText.defaultProps = {
+  align: "left",
+  tag: "p"
+};
+
+export default CaptionText;

--- a/packages/styleUtils/typography/components/DangerText.tsx
+++ b/packages/styleUtils/typography/components/DangerText.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import Text from "./Text";
+import { BasicTextProps } from "../textTypes";
+import { themeError } from "../../../design-tokens/build/js/designTokens";
+
+const DangerText = (props: BasicTextProps) => (
+  <Text color={themeError} {...props} />
+);
+
+DangerText.defaultProps = {
+  align: "left",
+  weight: "normal",
+  size: "m",
+  wrap: "wrap",
+  tag: "p"
+};
+
+export default DangerText;

--- a/packages/styleUtils/typography/components/HeadingText1.tsx
+++ b/packages/styleUtils/typography/components/HeadingText1.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import Text from "./Text";
+import { HeadingTextProps } from "../textTypes";
+import { themeTextColorPrimary } from "../../../design-tokens/build/js/designTokens";
+
+const HeadingText1 = (props: HeadingTextProps) => (
+  <Text weight="medium" size="xl" {...props} />
+);
+
+HeadingText1.defaultProps = {
+  align: "left",
+  color: themeTextColorPrimary,
+  wrap: "wrap",
+  tag: "h3"
+};
+
+export default HeadingText1;

--- a/packages/styleUtils/typography/components/HeadingText2.tsx
+++ b/packages/styleUtils/typography/components/HeadingText2.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { heading2 } from "../style";
+import Text from "./Text";
+import { HeadingTextProps } from "../textTypes";
+import { themeTextColorPrimary } from "../../../design-tokens/build/js/designTokens";
+
+const HeadingText2 = (props: HeadingTextProps) => (
+  <Text weight="medium" size="l" className={heading2} {...props} />
+);
+
+HeadingText2.defaultProps = {
+  align: "left",
+  color: themeTextColorPrimary,
+  wrap: "wrap",
+  tag: "h2"
+};
+
+export default HeadingText2;

--- a/packages/styleUtils/typography/components/HeadingText3.tsx
+++ b/packages/styleUtils/typography/components/HeadingText3.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import Text from "./Text";
+import { HeadingTextProps } from "../textTypes";
+import { themeTextColorPrimary } from "../../../design-tokens/build/js/designTokens";
+
+const HeadingText3 = (props: HeadingTextProps) => (
+  <Text weight="medium" size="m" {...props} />
+);
+
+HeadingText3.defaultProps = {
+  align: "left",
+  color: themeTextColorPrimary,
+  wrap: "wrap",
+  tag: "h3"
+};
+
+export default HeadingText3;

--- a/packages/styleUtils/typography/components/InteractiveText.tsx
+++ b/packages/styleUtils/typography/components/InteractiveText.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { css } from "emotion";
+import Text from "./Text";
+import { BasicTextProps } from "../textTypes";
+import { themeTextColorInteractive } from "../../../design-tokens/build/js/designTokens";
+
+const InteractiveText = (props: BasicTextProps) => (
+  <Text
+    className={css`
+      cursor: pointer;
+    `}
+    color={themeTextColorInteractive}
+    {...props}
+  />
+);
+
+InteractiveText.defaultProps = {
+  align: "left",
+  weight: "normal",
+  size: "m",
+  wrap: "wrap",
+  tag: "p"
+};
+
+export default InteractiveText;

--- a/packages/styleUtils/typography/components/MonospaceText.tsx
+++ b/packages/styleUtils/typography/components/MonospaceText.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import Text from "./Text";
+import { BasicTextProps } from "../textTypes";
+import { css } from "emotion";
+import { themeTextColorPrimary } from "../../../design-tokens/build/js/designTokens";
+
+export interface MonospaceTextProps extends BasicTextProps {
+  /**
+   * The color of the text
+   */
+  color: React.CSSProperties["color"];
+}
+
+const MonospaceText = (props: MonospaceTextProps) => (
+  <Text
+    className={css`
+      font-family: monospace;
+    `}
+    {...props}
+  />
+);
+
+MonospaceText.defaultProps = {
+  color: themeTextColorPrimary,
+  tag: "code",
+  size: "m",
+  weight: "medium",
+  align: "left",
+  wrap: "wrap"
+};
+
+export default MonospaceText;

--- a/packages/styleUtils/typography/components/SmallText.tsx
+++ b/packages/styleUtils/typography/components/SmallText.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import Text from "./Text";
+import { SharedTextProps } from "../textTypes";
+import { FontWeights } from "../../../shared/styles/styleUtils/typography/weight";
+import { themeTextColorPrimary } from "../../../design-tokens/build/js/designTokens";
+
+export interface SmallTextProps extends SharedTextProps {
+  /**
+   * The color of the text
+   */
+  color: React.CSSProperties["color"];
+  /**
+   * Which HTML tag to render the text in
+   */
+  tag: keyof React.ReactHTML;
+  /**
+   * The font weight of the text
+   */
+  weight: FontWeights;
+}
+
+const SmallText = (props: SmallTextProps) => <Text size="s" {...props} />;
+
+SmallText.defaultProps = {
+  align: "left",
+  color: themeTextColorPrimary,
+  wrap: "wrap",
+  weight: "normal",
+  tag: "p"
+};
+
+export default SmallText;

--- a/packages/styleUtils/typography/components/SuccessText.tsx
+++ b/packages/styleUtils/typography/components/SuccessText.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import Text from "./Text";
+import { BasicTextProps } from "../textTypes";
+import { themeSuccess } from "../../../design-tokens/build/js/designTokens";
+
+const SuccessText = (props: BasicTextProps) => (
+  <Text color={themeSuccess} {...props} />
+);
+
+SuccessText.defaultProps = {
+  align: "left",
+  weight: "normal",
+  size: "m",
+  wrap: "wrap",
+  tag: "p"
+};
+
+export default SuccessText;

--- a/packages/styleUtils/typography/components/Text.tsx
+++ b/packages/styleUtils/typography/components/Text.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { css, cx } from "emotion";
+import { BasicTextProps } from "../textTypes";
+import {
+  textWeight,
+  textSize,
+  tintContent,
+  textTruncate
+} from "../../../shared/styles/styleUtils";
+import { FontWeights } from "../../../shared/styles/styleUtils/typography/weight";
+import {
+  fontWeightNormal,
+  themeTextColorPrimary
+} from "../../../design-tokens/build/js/designTokens";
+
+export interface TextProps extends BasicTextProps {
+  /**
+   * The color of the text
+   */
+  color: React.CSSProperties["color"];
+  className?: string;
+}
+
+const Text = (props: TextProps) => {
+  const { align, children, tag, wrap, weight, color, size, className } = props;
+  const TextTag = tag;
+
+  return (
+    <TextTag
+      className={cx(
+        className,
+        textWeight(weight as FontWeights),
+        textSize(size),
+        tintContent(color),
+        css`
+          text-align: ${align};
+        `,
+        {
+          [textTruncate]: wrap === "truncate",
+          [css`
+            white-space: nowrap;
+          `]: wrap === "nowrap"
+        }
+      )}
+    >
+      {children}
+    </TextTag>
+  );
+};
+
+Text.defaultProps = {
+  align: "inherit",
+  tag: "p",
+  wrap: "wrap",
+  weight: fontWeightNormal,
+  color: themeTextColorPrimary,
+  size: "m"
+};
+
+export default Text;

--- a/packages/styleUtils/typography/components/WarningText.tsx
+++ b/packages/styleUtils/typography/components/WarningText.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import Text from "./Text";
+import { BasicTextProps } from "../textTypes";
+import { themeWarning } from "../../../design-tokens/build/js/designTokens";
+
+const SuccessText = (props: BasicTextProps) => (
+  <Text color={themeWarning} {...props} />
+);
+
+SuccessText.defaultProps = {
+  align: "left",
+  weight: "normal",
+  size: "m",
+  wrap: "wrap",
+  tag: "p"
+};
+
+export default SuccessText;

--- a/packages/styleUtils/typography/index.ts
+++ b/packages/styleUtils/typography/index.ts
@@ -1,0 +1,11 @@
+export { default as Text } from "./components/Text";
+export { default as CaptionText } from "./components/CaptionText";
+export { default as DangerText } from "./components/DangerText";
+export { default as HeadingText1 } from "./components/HeadingText1";
+export { default as HeadingText2 } from "./components/HeadingText2";
+export { default as HeadingText3 } from "./components/HeadingText3";
+export { default as InteractiveText } from "./components/InteractiveText";
+export { default as MonospaceText } from "./components/MonospaceText";
+export { default as SmallText } from "./components/SmallText";
+export { default as SuccessText } from "./components/SuccessText";
+export { default as WarningText } from "./components/WarningText";

--- a/packages/styleUtils/typography/stories/captionText.stories.tsx
+++ b/packages/styleUtils/typography/stories/captionText.stories.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { CaptionText } from "../index";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/CaptionText", module)
+  .addDecorator(withReadme([readme]))
+  .add("default", () => (
+    <CaptionText>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </CaptionText>
+  ));

--- a/packages/styleUtils/typography/stories/dangerText.stories.tsx
+++ b/packages/styleUtils/typography/stories/dangerText.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { DangerText } from "../index";
+import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/DangerText", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => (
+    <DangerText>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </DangerText>
+  ))
+  .add("size", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("size", sizes, "m");
+    return (
+      <DangerText size={size as FontSize}>
+        Use the knobs to change the size
+      </DangerText>
+    );
+  })
+  .add("medium weight", () => (
+    <DangerText weight="medium">
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </DangerText>
+  ));

--- a/packages/styleUtils/typography/stories/headingText1.stories.tsx
+++ b/packages/styleUtils/typography/stories/headingText1.stories.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs } from "@storybook/addon-knobs";
+import { HeadingText1 } from "../index";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/HeadingText1", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => <HeadingText1>Primary Heading</HeadingText1>)
+  .add("custom HTML tag", () => (
+    <HeadingText1 tag="h2">{`Using a <h2> tag`}</HeadingText1>
+  ));

--- a/packages/styleUtils/typography/stories/headingText2.stories.tsx
+++ b/packages/styleUtils/typography/stories/headingText2.stories.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs } from "@storybook/addon-knobs";
+import { HeadingText2 } from "../index";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/HeadingText2", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => <HeadingText2>Secondary Heading</HeadingText2>)
+  .add("custom HTML tag", () => (
+    <HeadingText2 tag="h3">{`Using a <h3> tag`}</HeadingText2>
+  ));

--- a/packages/styleUtils/typography/stories/headingText3.stories.tsx
+++ b/packages/styleUtils/typography/stories/headingText3.stories.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs } from "@storybook/addon-knobs";
+import { HeadingText3 } from "../index";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/HeadingText3", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => <HeadingText3>Tertiary Heading</HeadingText3>)
+  .add("custom HTML tag", () => (
+    <HeadingText3 tag="h4">{`Using a <h4> tag`}</HeadingText3>
+  ));

--- a/packages/styleUtils/typography/stories/interactiveText.stories.tsx
+++ b/packages/styleUtils/typography/stories/interactiveText.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { InteractiveText } from "../index";
+import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/InteractiveText", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => <InteractiveText>Click me</InteractiveText>)
+  .add("size", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("size", sizes, "m");
+    return (
+      <InteractiveText size={size as FontSize}>
+        Use the knobs to change the size
+      </InteractiveText>
+    );
+  })
+  .add("medium weight", () => (
+    <InteractiveText weight="medium">Click me</InteractiveText>
+  ));

--- a/packages/styleUtils/typography/stories/monospaceText.stories.tsx
+++ b/packages/styleUtils/typography/stories/monospaceText.stories.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { MonospaceText } from "../index";
+import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize";
+import {
+  themeTextColorDisabled,
+  themeTextColorPrimary,
+  themeTextColorSecondary,
+  blue
+} from "../../../design-tokens/build/js/designTokens";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/MonospaceText", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => (
+    <MonospaceText>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </MonospaceText>
+  ))
+  .add("size", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("size", sizes, "m");
+    return (
+      <MonospaceText size={size as FontSize}>
+        Use the knobs to change the size
+      </MonospaceText>
+    );
+  })
+  .add("color", () => {
+    const colors = {
+      themeTextColorPrimary,
+      themeTextColorSecondary,
+      themeTextColorDisabled,
+      blue
+    };
+    const color = select("color", colors, themeTextColorPrimary);
+
+    return (
+      <MonospaceText color={color}>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry.
+      </MonospaceText>
+    );
+  })
+  .add("medium weight", () => (
+    <MonospaceText weight="medium">
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </MonospaceText>
+  ));

--- a/packages/styleUtils/typography/stories/smallText.stories.tsx
+++ b/packages/styleUtils/typography/stories/smallText.stories.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { SmallText } from "../";
+import {
+  themeTextColorDisabled,
+  themeTextColorPrimary,
+  themeTextColorSecondary,
+  blue
+} from "../../../design-tokens/build/js/designTokens";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/SmallText", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => (
+    <SmallText>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </SmallText>
+  ))
+  .add("color", () => {
+    const colors = {
+      themeTextColorPrimary,
+      themeTextColorSecondary,
+      themeTextColorDisabled,
+      blue
+    };
+    const color = select("color", colors, themeTextColorPrimary);
+
+    return (
+      <SmallText color={color}>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry.
+      </SmallText>
+    );
+  })
+  .add("medium weight", () => (
+    <SmallText weight="medium">
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </SmallText>
+  ));

--- a/packages/styleUtils/typography/stories/successText.stories.tsx
+++ b/packages/styleUtils/typography/stories/successText.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { SuccessText } from "../index";
+import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/SuccessText", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => (
+    <SuccessText>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </SuccessText>
+  ))
+  .add("size", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("size", sizes, "m");
+    return (
+      <SuccessText size={size as FontSize}>
+        Use the knobs to change the size
+      </SuccessText>
+    );
+  })
+  .add("medium weight", () => (
+    <SuccessText weight="medium">
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </SuccessText>
+  ));

--- a/packages/styleUtils/typography/stories/text.stories.tsx
+++ b/packages/styleUtils/typography/stories/text.stories.tsx
@@ -1,0 +1,132 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import {
+  themeTextColorDisabled,
+  themeTextColorPrimary,
+  themeTextColorSecondary,
+  blue
+} from "../../../design-tokens/build/js/designTokens";
+import { FontSizes } from "../../../shared/styles/styleUtils/typography/textSize";
+
+import { Text } from "../";
+
+const readme = require("../README.md");
+type WrapVals = "truncate" | "nowrap" | "wrap";
+
+storiesOf("Style utilities/Typography/Text", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => (
+    <Text>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+      Lorem Ipsum has been the industry's standard dummy text ever since the
+      1500s, when an unknown printer took a galley of type and scrambled it to
+      make a type specimen book. It has survived not only five centuries, but
+      also the leap into electronic typesetting, remaining essentially
+      unchanged. It was popularised in the 1960s with the release of Letraset
+      sheets containing Lorem Ipsum passages, and more recently with desktop
+      publishing software like Aldus PageMaker including versions of Lorem
+      Ipsum.
+    </Text>
+  ))
+  .add("align", () => {
+    const textAlignments = {
+      left: "left",
+      right: "right",
+      center: "center"
+    };
+    const align = select("align", textAlignments, "center");
+
+    return (
+      <Text align={align as React.CSSProperties["textAlign"]}>
+        Lorem Ipsum is simply dummy text of the printing and typesetting
+        industry. Lorem Ipsum has been the industry's standard dummy text ever
+        since the 1500s, when an unknown printer took a galley of type and
+        scrambled it to make a type specimen book. It has survived not only five
+        centuries, but also the leap into electronic typesetting, remaining
+        essentially unchanged. It was popularised in the 1960s with the release
+        of Letraset sheets containing Lorem Ipsum passages, and more recently
+        with desktop publishing software like Aldus PageMaker including versions
+        of Lorem Ipsum.
+      </Text>
+    );
+  })
+  .add("wrap", () => {
+    const wrapVals = {
+      wrap: "wrap",
+      nowrap: "nowrap",
+      truncate: "truncate"
+    };
+    const wrap = select("wrap", wrapVals, "wrap");
+
+    return (
+      <div>
+        <p>Use the Knobs panel to change how text wraps</p>
+        <div style={{ width: "300px" }}>
+          <Text wrap={wrap as WrapVals}>
+            Lorem Ipsum is simply dummy text of the printing and typesetting
+            industry. Lorem Ipsum has been the industry's standard dummy text
+            ever since the 1500s, when an unknown printer took a galley of type
+            and scrambled it to make a type specimen book. It has survived not
+            only five centuries, but also the leap into electronic typesetting,
+            remaining essentially unchanged. It was popularised in the 1960s
+            with the release of Letraset sheets containing Lorem Ipsum passages,
+            and more recently with desktop publishing software like Aldus
+            PageMaker including versions of Lorem Ipsum.
+          </Text>
+        </div>
+      </div>
+    );
+  })
+  .add("size", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("size", sizes, "m");
+
+    return (
+      <Text size={size as FontSizes}>
+        Use the Knobs panel to change the font size
+      </Text>
+    );
+  })
+  .add("responsive size", () => {
+    return (
+      <Text
+        size={{
+          default: "s",
+          medium: "m",
+          large: "l",
+          jumbo: "xl"
+        }}
+      >
+        Change the width of your viewport to see the font size change
+      </Text>
+    );
+  })
+  .add("color", () => {
+    const colors = {
+      themeTextColorPrimary,
+      themeTextColorSecondary,
+      themeTextColorDisabled,
+      blue
+    };
+    const color = select("color", colors, themeTextColorPrimary);
+
+    return (
+      <Text color={color}>Use the Knobs panel to change the text color</Text>
+    );
+  })
+  .add("medium weight", () => (
+    <Text weight="medium">
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </Text>
+  ))
+  .add("custom HTML tag", () => (
+    <Text tag="span">{`This text is in a <span> tag`}</Text>
+  ));

--- a/packages/styleUtils/typography/stories/warningText.stories.tsx
+++ b/packages/styleUtils/typography/stories/warningText.stories.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { WarningText } from "../index";
+import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize";
+
+const readme = require("../README.md");
+
+storiesOf("Style utilities/Typography/WarningText", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
+  .add("default", () => (
+    <WarningText>
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </WarningText>
+  ))
+  .add("size", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("size", sizes, "m");
+    return (
+      <WarningText size={size as FontSize}>
+        Use the knobs to change the size
+      </WarningText>
+    );
+  })
+  .add("medium weight", () => (
+    <WarningText weight="medium">
+      Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+    </WarningText>
+  ));

--- a/packages/styleUtils/typography/style.ts
+++ b/packages/styleUtils/typography/style.ts
@@ -1,0 +1,20 @@
+import { css } from "emotion";
+import {
+  fontLineHeightS,
+  fontLineHeightM,
+  fontLineHeightDefault,
+  fontSizeM
+} from "../../design-tokens/build/js/designTokens";
+
+export const textBase = css`
+  font-size: ${fontSizeM};
+  line-height: ${fontLineHeightDefault};
+`;
+
+export const heading1 = css`
+  line-height: ${fontLineHeightS};
+`;
+
+export const heading2 = css`
+  line-height: ${fontLineHeightM};
+`;

--- a/packages/styleUtils/typography/tests/__snapshots__/typographyComponents.test.tsx.snap
+++ b/packages/styleUtils/typography/tests/__snapshots__/typographyComponents.test.tsx.snap
@@ -1,0 +1,374 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Typography CaptionText renders all props 1`] = `
+<SmallText
+  align="center"
+  color="var(--themeTextColorSecondary, #76797E)"
+  tag="span"
+  weight="normal"
+  wrap="nowrap"
+>
+  content
+</SmallText>
+`;
+
+exports[`Typography DangerText renders all props 1`] = `
+<Text
+  align="center"
+  color="var(--themeError, #EB293A)"
+  size="l"
+  tag="span"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography HeadingText renders all props all HeadingText variants 1`] = `
+<Text
+  align="center"
+  color="black"
+  size="xl"
+  tag="h1"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography HeadingText renders all props all HeadingText variants 2`] = `
+.emotion-0 {
+  line-height: 1.33;
+}
+
+<Text
+  align="center"
+  className="emotion-0"
+  color="black"
+  size="l"
+  tag="h1"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography HeadingText renders all props all HeadingText variants 3`] = `
+<Text
+  align="center"
+  color="black"
+  size="m"
+  tag="h1"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography InteractiveText renders all props 1`] = `
+.emotion-0 {
+  cursor: pointer;
+}
+
+<Text
+  align="center"
+  className="emotion-0"
+  color="var(--themeTextColorInteractive, #7D58FF)"
+  size="l"
+  tag="span"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography MonospaceText renders all props 1`] = `
+.emotion-0 {
+  font-family: monospace;
+}
+
+<Text
+  align="center"
+  className="emotion-0"
+  color="black"
+  size="l"
+  tag="span"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography SmallText renders all props 1`] = `
+<Text
+  align="center"
+  color="black"
+  size="s"
+  tag="span"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography SuccessText renders all props 1`] = `
+<Text
+  align="center"
+  color="var(--themeSuccess, #14C684)"
+  size="l"
+  tag="span"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography Text renders all props 1`] = `
+.emotion-0 {
+  font-weight: 500;
+  font-size: 12px;
+  color: black;
+  fill: black;
+  text-align: center;
+  white-space: nowrap;
+}
+
+<span
+  className="test emotion-0"
+>
+  content
+</span>
+`;
+
+exports[`Typography Text renders all wrap variants 1`] = `
+.emotion-0 {
+  font-weight: 400;
+  font-size: 14px;
+  color: black;
+  fill: black;
+  text-align: left;
+  overflow: hidden;
+  overflow: -moz-hidden-unscrollable;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<p
+  className="emotion-0"
+>
+  content
+</p>
+`;
+
+exports[`Typography Text renders all wrap variants 2`] = `
+.emotion-0 {
+  font-weight: 400;
+  font-size: 14px;
+  color: black;
+  fill: black;
+  text-align: left;
+  white-space: nowrap;
+}
+
+<p
+  className="emotion-0"
+>
+  content
+</p>
+`;
+
+exports[`Typography Text renders all wrap variants 3`] = `
+.emotion-0 {
+  font-weight: 400;
+  font-size: 14px;
+  color: black;
+  fill: black;
+  text-align: left;
+}
+
+<p
+  className="emotion-0"
+>
+  content
+</p>
+`;
+
+exports[`Typography WarningText renders all props 1`] = `
+<Text
+  align="center"
+  color="var(--themeWarning, #F9A328)"
+  size="l"
+  tag="span"
+  weight="medium"
+  wrap="nowrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 1`] = `
+.emotion-0 {
+  font-size: 14px;
+  color: var(--themeTextColorPrimary,#1B2029);
+  fill: var(--themeTextColorPrimary,#1B2029);
+  text-align: left;
+}
+
+<p
+  className="emotion-0"
+>
+  content
+</p>
+`;
+
+exports[`Typography renders all default 2`] = `
+<SmallText
+  align="left"
+  color="var(--themeTextColorSecondary, #76797E)"
+  tag="p"
+  weight="normal"
+  wrap="wrap"
+>
+  content
+</SmallText>
+`;
+
+exports[`Typography renders all default 3`] = `
+<Text
+  align="left"
+  color="var(--themeError, #EB293A)"
+  size="m"
+  tag="p"
+  weight="normal"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 4`] = `
+<Text
+  align="left"
+  color="var(--themeTextColorPrimary, #1B2029)"
+  size="xl"
+  tag="p"
+  weight="medium"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 5`] = `
+.emotion-0 {
+  line-height: 1.33;
+}
+
+<Text
+  align="left"
+  className="emotion-0"
+  color="var(--themeTextColorPrimary, #1B2029)"
+  size="l"
+  tag="p"
+  weight="medium"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 6`] = `
+<Text
+  align="left"
+  color="var(--themeTextColorPrimary, #1B2029)"
+  size="m"
+  tag="p"
+  weight="medium"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 7`] = `
+.emotion-0 {
+  cursor: pointer;
+}
+
+<Text
+  align="left"
+  className="emotion-0"
+  color="var(--themeTextColorInteractive, #7D58FF)"
+  size="m"
+  tag="p"
+  weight="normal"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 8`] = `
+.emotion-0 {
+  font-family: monospace;
+}
+
+<Text
+  align="left"
+  className="emotion-0"
+  color="var(--themeTextColorPrimary, #1B2029)"
+  size="m"
+  tag="p"
+  weight="medium"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 9`] = `
+<Text
+  align="left"
+  color="var(--themeTextColorPrimary, #1B2029)"
+  size="s"
+  tag="p"
+  weight="normal"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 10`] = `
+<Text
+  align="left"
+  color="var(--themeSuccess, #14C684)"
+  size="m"
+  tag="p"
+  weight="normal"
+  wrap="wrap"
+>
+  content
+</Text>
+`;
+
+exports[`Typography renders all default 11`] = `
+<Text
+  align="left"
+  color="var(--themeWarning, #F9A328)"
+  size="m"
+  tag="p"
+  weight="normal"
+  wrap="wrap"
+>
+  content
+</Text>
+`;

--- a/packages/styleUtils/typography/tests/typographyComponents.test.tsx
+++ b/packages/styleUtils/typography/tests/typographyComponents.test.tsx
@@ -1,0 +1,226 @@
+import React from "react";
+import { shallow } from "enzyme";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import toJson from "enzyme-to-json";
+
+import {
+  CaptionText,
+  DangerText,
+  HeadingText1,
+  HeadingText2,
+  HeadingText3,
+  InteractiveText,
+  MonospaceText,
+  SmallText,
+  SuccessText,
+  Text,
+  WarningText
+} from "../";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+const allComponents = [
+  Text,
+  CaptionText,
+  DangerText,
+  HeadingText1,
+  HeadingText2,
+  HeadingText3,
+  InteractiveText,
+  MonospaceText,
+  SmallText,
+  SuccessText,
+  WarningText
+];
+
+describe("Typography", () => {
+  it("renders all default", () => {
+    allComponents.forEach(component => {
+      const TypographyComponent = component;
+      const shallowRenderComponent = shallow(
+        <TypographyComponent tag="p" wrap="wrap" align="left">
+          content
+        </TypographyComponent>
+      );
+
+      expect(toJson(shallowRenderComponent)).toMatchSnapshot();
+    });
+  });
+
+  describe("Text", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <Text
+          align="center"
+          tag="span"
+          wrap="nowrap"
+          weight="medium"
+          color="black"
+          size="s"
+          className="test"
+        >
+          content
+        </Text>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+    it("renders all wrap variants", () => {
+      type WrapVariant = "truncate" | "nowrap" | "wrap";
+
+      ["truncate", "nowrap", "wrap"].forEach(wrapVariant => {
+        const component = shallow(
+          <Text
+            tag="p"
+            align="left"
+            size="m"
+            weight="normal"
+            color="black"
+            wrap={wrapVariant as WrapVariant}
+          >
+            content
+          </Text>
+        );
+
+        expect(toJson(component)).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe("CaptionText", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <CaptionText align="center" tag="span" wrap="nowrap">
+          content
+        </CaptionText>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+
+  describe("DangerText", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <DangerText
+          align="center"
+          tag="span"
+          wrap="nowrap"
+          weight="medium"
+          size="l"
+        >
+          content
+        </DangerText>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+
+  describe("HeadingText", () => {
+    it("renders all props all HeadingText variants", () => {
+      [HeadingText1, HeadingText2, HeadingText3].forEach(component => {
+        const HeadingComponent = component;
+        const shallowRenderComponent = shallow(
+          <HeadingComponent color="black" align="center" tag="h1" wrap="nowrap">
+            content
+          </HeadingComponent>
+        );
+
+        expect(toJson(shallowRenderComponent)).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe("InteractiveText", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <InteractiveText
+          align="center"
+          tag="span"
+          wrap="nowrap"
+          weight="medium"
+          size="l"
+        >
+          content
+        </InteractiveText>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+
+  describe("MonospaceText", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <MonospaceText
+          align="center"
+          tag="span"
+          wrap="nowrap"
+          weight="medium"
+          size="l"
+          color="black"
+        >
+          content
+        </MonospaceText>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+
+  describe("SmallText", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <SmallText
+          color="black"
+          align="center"
+          tag="span"
+          wrap="nowrap"
+          weight="medium"
+        >
+          content
+        </SmallText>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+
+  describe("SuccessText", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <SuccessText
+          align="center"
+          tag="span"
+          wrap="nowrap"
+          weight="medium"
+          size="l"
+        >
+          content
+        </SuccessText>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+
+  describe("WarningText", () => {
+    it("renders all props", () => {
+      const component = shallow(
+        <WarningText
+          align="center"
+          tag="span"
+          wrap="nowrap"
+          weight="medium"
+          size="l"
+        >
+          content
+        </WarningText>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/styleUtils/typography/textTypes.ts
+++ b/packages/styleUtils/typography/textTypes.ts
@@ -1,0 +1,36 @@
+import { FontWeights } from "../../shared/styles/styleUtils/typography/weight";
+import { FontSize } from "../../shared/styles/styleUtils/typography/textSize";
+
+export interface SharedTextProps {
+  /**
+   * How the text should be aligned
+   */
+  align: React.CSSProperties["textAlign"];
+  /**
+   * How the text should wrap in it's container
+   */
+  wrap: "truncate" | "nowrap" | "wrap";
+  /**
+   * Which HTML tag to render the text in
+   */
+  tag: keyof React.ReactHTML;
+  children: React.ReactNode;
+}
+
+export interface BasicTextProps extends SharedTextProps {
+  /**
+   * The font weight of the text
+   */
+  weight: FontWeights;
+  /**
+   * The size of the text.  Can be set for all viewport sizes, or configured to have different values at different viewport width breakpoints
+   */
+  size: FontSize;
+}
+
+export interface HeadingTextProps extends SharedTextProps {
+  /**
+   * The color of the text
+   */
+  color: React.CSSProperties["color"];
+}


### PR DESCRIPTION
These components are:
Text
HeadingText1
HeadingText2
HeadingText3
InteractiveText
SmallText
CaptionText
DangerText
WarningText
SuccessText
MonospaceText

See the READMEs in this PR for more info

Many of these stories make use of Storybook's "Knobs" panel

## Screenshots
Too many to capture. Check out the Storybook stories:
<img width="164" alt="Screen Shot 2019-07-04 at 1 34 47 AM" src="https://user-images.githubusercontent.com/2313998/60642016-5a129f00-9dfc-11e9-8fb8-a32ef7fc97ac.png">

