### PR TITLE
Small tweaks to style utility components

### DIFF
--- a/packages/shared/styles/styleUtils/layout/flexbox.ts
+++ b/packages/shared/styles/styleUtils/layout/flexbox.ts
@@ -49,14 +49,17 @@ export const flex = (
 ) => {
   const { direction } = flexProps;
   const isColumn = direction === "column" || direction === "column-reverse";
-  const getResponsiveColumnStyles = valueForColumnDirection => {
+  const getResponsiveColumnStyles = (
+    valueForColumnDirection,
+    valueForOtherDirections = "auto"
+  ) => {
     if (isColumn) {
       return valueForColumnDirection;
     } else if (typeof direction === "object") {
       return Object.entries(direction).reduce((acc, [breakpoint, config]) => {
-        if (config.includes("column")) {
-          acc[breakpoint] = valueForColumnDirection;
-        }
+        acc[breakpoint] = config.includes("column")
+          ? valueForColumnDirection
+          : valueForOtherDirections;
 
         return acc;
       }, {});

--- a/packages/styleUtils/layout/flexbox/components/Flex.tsx
+++ b/packages/styleUtils/layout/flexbox/components/Flex.tsx
@@ -14,7 +14,7 @@ interface FlexProps extends FlexboxProperties {
    */
   gutterSize?: SpaceSize;
   children:
-    | Array<React.ReactElement<FlexItemProps>>
+    | Array<React.ReactElement<FlexItemProps> | null>
     | React.ReactElement<FlexItemProps>;
 }
 

--- a/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
+++ b/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
@@ -150,6 +150,7 @@ storiesOf("Style utilities/Layout/Flex", module)
         <FlexItem>
           <DemoChild>4</DemoChild>
         </FlexItem>
+        {null}
       </Flex>
     </div>
   ))

--- a/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
+++ b/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
@@ -125,6 +125,12 @@ exports[`Flex renders with responsive props 1`] = `
   }
 }
 
+@media (min-width:900px) {
+  .emotion-0 {
+    height: auto;
+  }
+}
+
 @media (min-width:0) {
   .emotion-0 {
     -webkit-flex-direction: column;
@@ -181,9 +187,21 @@ exports[`Flex renders with responsive props 1`] = `
   }
 }
 
+@media (min-width:900px) {
+  .emotion-0 {
+    min-height: auto;
+  }
+}
+
 @media (min-width:0) {
   .emotion-0 > div {
     width: 100%;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 > div {
+    width: auto;
   }
 }
 

--- a/packages/styleUtils/modifiers/components/Box.tsx
+++ b/packages/styleUtils/modifiers/components/Box.tsx
@@ -78,7 +78,7 @@ const Box = (props: BoxProps) => {
 
   const boxStyles = css`
     background-color: ${bgColor};
-    background-image: url(${bgImageUrl});
+    background-image: ${bgImageUrl ? `url(${bgImageUrl})` : null};
     background-position: ${getBgImageOptionVal("position")};
     background-repeat: ${getBgImageOptionVal("repeat") || "no-repeat"};
     background-size: ${getBgImageOptionVal("size")};

--- a/packages/styleUtils/modifiers/tests/__snapshots__/Box.test.tsx.snap
+++ b/packages/styleUtils/modifiers/tests/__snapshots__/Box.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Box renders default 1`] = `
 .emotion-0 {
-  background-image: url();
   background-repeat: no-repeat;
 }
 

--- a/packages/styleUtils/typography/components/CaptionText.tsx
+++ b/packages/styleUtils/typography/components/CaptionText.tsx
@@ -8,7 +8,7 @@ const CaptionText = (props: SharedTextProps) => (
 );
 
 CaptionText.defaultProps = {
-  align: "left",
+  align: "inherit",
   tag: "p"
 };
 

--- a/packages/styleUtils/typography/components/DangerText.tsx
+++ b/packages/styleUtils/typography/components/DangerText.tsx
@@ -8,7 +8,7 @@ const DangerText = (props: BasicTextProps) => (
 );
 
 DangerText.defaultProps = {
-  align: "left",
+  align: "inherit",
   weight: "normal",
   size: "m",
   wrap: "wrap",

--- a/packages/styleUtils/typography/components/HeadingText1.tsx
+++ b/packages/styleUtils/typography/components/HeadingText1.tsx
@@ -8,7 +8,7 @@ const HeadingText1 = (props: HeadingTextProps) => (
 );
 
 HeadingText1.defaultProps = {
-  align: "left",
+  align: "inherit",
   color: themeTextColorPrimary,
   wrap: "wrap",
   tag: "h3"

--- a/packages/styleUtils/typography/components/HeadingText2.tsx
+++ b/packages/styleUtils/typography/components/HeadingText2.tsx
@@ -9,7 +9,7 @@ const HeadingText2 = (props: HeadingTextProps) => (
 );
 
 HeadingText2.defaultProps = {
-  align: "left",
+  align: "inherit",
   color: themeTextColorPrimary,
   wrap: "wrap",
   tag: "h2"

--- a/packages/styleUtils/typography/components/HeadingText3.tsx
+++ b/packages/styleUtils/typography/components/HeadingText3.tsx
@@ -8,7 +8,7 @@ const HeadingText3 = (props: HeadingTextProps) => (
 );
 
 HeadingText3.defaultProps = {
-  align: "left",
+  align: "inherit",
   color: themeTextColorPrimary,
   wrap: "wrap",
   tag: "h3"

--- a/packages/styleUtils/typography/components/InteractiveText.tsx
+++ b/packages/styleUtils/typography/components/InteractiveText.tsx
@@ -15,7 +15,7 @@ const InteractiveText = (props: BasicTextProps) => (
 );
 
 InteractiveText.defaultProps = {
-  align: "left",
+  align: "inherit",
   weight: "normal",
   size: "m",
   wrap: "wrap",

--- a/packages/styleUtils/typography/components/MonospaceText.tsx
+++ b/packages/styleUtils/typography/components/MonospaceText.tsx
@@ -25,7 +25,7 @@ MonospaceText.defaultProps = {
   tag: "code",
   size: "m",
   weight: "medium",
-  align: "left",
+  align: "inherit",
   wrap: "wrap"
 };
 

--- a/packages/styleUtils/typography/components/SmallText.tsx
+++ b/packages/styleUtils/typography/components/SmallText.tsx
@@ -22,7 +22,7 @@ export interface SmallTextProps extends SharedTextProps {
 const SmallText = (props: SmallTextProps) => <Text size="s" {...props} />;
 
 SmallText.defaultProps = {
-  align: "left",
+  align: "inherit",
   color: themeTextColorPrimary,
   wrap: "wrap",
   weight: "normal",

--- a/packages/styleUtils/typography/components/SuccessText.tsx
+++ b/packages/styleUtils/typography/components/SuccessText.tsx
@@ -8,7 +8,7 @@ const SuccessText = (props: BasicTextProps) => (
 );
 
 SuccessText.defaultProps = {
-  align: "left",
+  align: "inherit",
   weight: "normal",
   size: "m",
   wrap: "wrap",

--- a/packages/styleUtils/typography/components/Text.tsx
+++ b/packages/styleUtils/typography/components/Text.tsx
@@ -33,6 +33,7 @@ const Text = (props: TextProps) => {
         textSize(size),
         tintContent(color),
         css`
+          margin: 0;
           text-align: ${align};
         `,
         {

--- a/packages/styleUtils/typography/components/WarningText.tsx
+++ b/packages/styleUtils/typography/components/WarningText.tsx
@@ -8,7 +8,7 @@ const SuccessText = (props: BasicTextProps) => (
 );
 
 SuccessText.defaultProps = {
-  align: "left",
+  align: "inherit",
   weight: "normal",
   size: "m",
   wrap: "wrap",

--- a/packages/styleUtils/typography/tests/__snapshots__/typographyComponents.test.tsx.snap
+++ b/packages/styleUtils/typography/tests/__snapshots__/typographyComponents.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`Typography Text renders all props 1`] = `
   font-size: 12px;
   color: black;
   fill: black;
+  margin: 0;
   text-align: center;
   white-space: nowrap;
 }
@@ -154,6 +155,7 @@ exports[`Typography Text renders all wrap variants 1`] = `
   font-size: 14px;
   color: black;
   fill: black;
+  margin: 0;
   text-align: left;
   overflow: hidden;
   overflow: -moz-hidden-unscrollable;
@@ -174,6 +176,7 @@ exports[`Typography Text renders all wrap variants 2`] = `
   font-size: 14px;
   color: black;
   fill: black;
+  margin: 0;
   text-align: left;
   white-space: nowrap;
 }
@@ -191,6 +194,7 @@ exports[`Typography Text renders all wrap variants 3`] = `
   font-size: 14px;
   color: black;
   fill: black;
+  margin: 0;
   text-align: left;
 }
 
@@ -219,6 +223,7 @@ exports[`Typography renders all default 1`] = `
   font-size: 14px;
   color: var(--themeTextColorPrimary,#1B2029);
   fill: var(--themeTextColorPrimary,#1B2029);
+  margin: 0;
   text-align: left;
 }
 


### PR DESCRIPTION
While using the style utility components in Kommander, I noticed a few small things that could be improved. This PR:
- kills browser default margins on typography components
- typography elements' text alignment defaults to inherit
- Flex component can accept children that are null
- fixed an issue with responsive flex-direction styles
- doesn't set empty background-image rule for Box