### PR TITLE
Add aspectRatio prop to Card

### DIFF
--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -1,3 +1,5 @@
-# Card Name
+# Card
+Cards are used to visually group related content. Cards can be used to make it easier for users to scan a view.
 
-Card documentation
+## Aspect ratio
+Sometimes we want a card's size to obey a specific aspect ratio. When an aspect ratio is defined, the card's width and height will always follow that proportion unless the content is too high: in which case the card's height will increase.

--- a/packages/card/components/Card.tsx
+++ b/packages/card/components/Card.tsx
@@ -1,15 +1,28 @@
 import * as React from "react";
 import { style } from "../style";
+import { cx } from "emotion";
+import { preserveAspectRatio, padding } from "../../shared/styles/styleUtils";
 
 export interface CardProps {
+  /**
+   * `[width, height]` Keeps the card's width and height at a specific proportion. e.g.: 2:1 would be [2, 1]
+   */
+  aspectRatio?: [number, number];
   children?: React.ReactNode | string;
 }
 
 class Card extends React.PureComponent<CardProps, {}> {
   public render() {
-    const { children } = this.props;
+    const { children, aspectRatio } = this.props;
+    const aspectRatioStyle = aspectRatio
+      ? preserveAspectRatio(aspectRatio[0], aspectRatio[1])
+      : null;
 
-    return <div className={style}>{children}</div>;
+    return (
+      <div className={cx(style, aspectRatioStyle)}>
+        <div className={padding("all")}>{children}</div>
+      </div>
+    );
   }
 }
 

--- a/packages/card/stories/Card.stories.tsx
+++ b/packages/card/stories/Card.stories.tsx
@@ -7,4 +7,11 @@ const readme = require("../README.md");
 
 storiesOf("Card", module)
   .addDecorator(withReadme([readme]))
-  .add("default", () => <Card>default</Card>);
+  .add("default", () => <Card>default</Card>)
+  .add("2:1 aspect ratio", () => {
+    return (
+      <div style={{ maxWidth: "400px" }}>
+        <Card aspectRatio={[2, 1]}>I stay at a 2:1 aspect ratio</Card>
+      </div>
+    );
+  });

--- a/packages/card/style.ts
+++ b/packages/card/style.ts
@@ -1,14 +1,9 @@
 import { css } from "emotion";
-import {
-  border,
-  borderRadius,
-  padding
-} from "../shared/styles/styleUtils/index";
+import { border, borderRadius } from "../shared/styles/styleUtils/index";
 import { themeBgPrimary } from "../design-tokens/build/js/designTokens";
 
 export const style = css`
   background-color: ${themeBgPrimary};
   ${border("all")};
   ${borderRadius("default")};
-  ${padding("all")};
 `;

--- a/packages/card/tests/Card.test.tsx
+++ b/packages/card/tests/Card.test.tsx
@@ -8,4 +8,9 @@ describe("Card", () => {
   it("default", () => {
     expect(toJSON(render(<Card>Example Content</Card>))).toMatchSnapshot();
   });
+  it("with aspectRatio set", () => {
+    expect(
+      toJSON(render(<Card aspectRatio={[2, 1]}>Example Content</Card>))
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/card/tests/__snapshots__/Card.test.tsx.snap
+++ b/packages/card/tests/__snapshots__/Card.test.tsx.snap
@@ -2,8 +2,24 @@
 
 exports[`Card default 1`] = `
 <div
-  class="css-qsaa8e"
+  class="css-1rmvfmi"
 >
-  Example Content
+  <div
+    class="css-2yjhih"
+  >
+    Example Content
+  </div>
+</div>
+`;
+
+exports[`Card with aspectRatio set 1`] = `
+<div
+  class="css-88gmn3"
+>
+  <div
+    class="css-2yjhih"
+  >
+    Example Content
+  </div>
 </div>
 `;

--- a/packages/shared/styles/styleUtils/index.ts
+++ b/packages/shared/styles/styleUtils/index.ts
@@ -1,3 +1,4 @@
+export { preserveAspectRatio } from "./modifiers/preserveAspectRatio";
 export { flex, flexItem } from "./layout/flexbox";
 export { flush } from "./modifiers/flush";
 export { textTruncate } from "./typography/textTruncate";

--- a/packages/shared/styles/styleUtils/modifiers/preserveAspectRatio.ts
+++ b/packages/shared/styles/styleUtils/modifiers/preserveAspectRatio.ts
@@ -1,0 +1,18 @@
+import { css } from "emotion";
+
+export const preserveAspectRatio = (width, height) => css`
+  &::before {
+    content: "";
+    height: 0;
+    float: left;
+    margin-left: -1px;
+    padding-top: ${(height / width) * 100}%;
+    width: 1px;
+  }
+
+  &::after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+`;


### PR DESCRIPTION
These cards in Konvoy and Kommander are limited by a 4:5 aspect ratio, and I think we may end up using this again.
<img width="768" alt="Screen Shot 2019-07-11 at 7 40 50 PM" src="https://user-images.githubusercontent.com/2313998/61092642-17ad1b80-a415-11e9-8914-d299d6107d51.png">


## Screenshot:
<img width="346" alt="Screen Shot 2019-07-11 at 7 41 01 PM" src="https://user-images.githubusercontent.com/2313998/61092635-11b73a80-a415-11e9-9a7f-97248ad399b1.png">
