### PR TITLE
Color selected Sidebar item text based on selected bg color

### DIFF
--- a/packages/appChrome/stories/AppChrome.stories.tsx
+++ b/packages/appChrome/stories/AppChrome.stories.tsx
@@ -451,7 +451,7 @@ storiesOf("AppChrome", module)
       <ThemeProvider theme={CustomTheme}>
         <Sidebar isOpen={true}>
           <SidebarSection label={sectionHeader}>
-            <SidebarItem onClick={action("clicked a nav item")}>
+            <SidebarItem isActive={true} onClick={action("clicked a nav item")}>
               <SidebarItemLabel>Lorem Ipsum</SidebarItemLabel>
             </SidebarItem>
             <SidebarItem onClick={action("clicked a nav item")}>

--- a/packages/appChrome/style.ts
+++ b/packages/appChrome/style.ts
@@ -6,10 +6,12 @@ import {
   spaceXl,
   themeBgSelected,
   themeBgHover,
-  themeBgHoverInverted
+  themeBgHoverInverted,
+  themeTextColorPrimary,
+  themeTextColorPrimaryInverted
 } from "../design-tokens/build/js/designTokens";
 import { padding } from "../shared/styles/styleUtils";
-import { pickHoverBg } from "../shared/styles/color";
+import { pickHoverBg, pickReadableTextColor } from "../shared/styles/color";
 import getCSSVarValue from "../utilities/components/getCSSVarValue";
 
 const iconSize = "24px";
@@ -62,6 +64,13 @@ export const sidebarSectionList = css`
 export const sidebarNavItem = (isActive: boolean, sidebarBgColor: string) => {
   return css`
     background-color: ${isActive ? themeBgSelected : "transparent"};
+    color: ${isActive
+      ? pickReadableTextColor(
+          sidebarBgColor,
+          themeTextColorPrimary,
+          themeTextColorPrimaryInverted
+        )
+      : null};
     cursor: pointer;
     text-transform: capitalize;
 

--- a/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`Sidebar SidebarSubMenu renders 1`] = `
         </SidebarItemLabel>
       </div>
     }
-    labelClassName="css-1beii4s"
+    labelClassName="css-193h9wh"
   >
     <ul
       className="emotion-0"


### PR DESCRIPTION
I found this issue when using a white background color for the Kommander sidebar.

You can test this by using the Knobs panel in the ["Sidebar Customizable w/ Knobs" story](http://localhost:6006/?path=/story/appchrome--sidebar-customizable-w-knobs) to change the Sidebar background color to white.

## Screenshots
**Before:**
<img width="1375" alt="Screen Shot 2019-07-12 at 11 30 19 AM" src="https://user-images.githubusercontent.com/2313998/61140617-bc713c80-a499-11e9-983c-e46955e7f036.png">

**After:**
<img width="1367" alt="Screen Shot 2019-07-12 at 11 28 02 AM" src="https://user-images.githubusercontent.com/2313998/61140631-c2ffb400-a499-11e9-991b-262c6289e775.png">