### PR TITLE
DCOS-56473: Update DonutChart styles

### DIFF
--- a/packages/donutChart/components/DonutChart.tsx
+++ b/packages/donutChart/components/DonutChart.tsx
@@ -4,6 +4,8 @@ import {
   themeBrandPrimary
 } from "../../design-tokens/build/js/designTokens";
 import { tintContentSecondary } from "../../shared/styles/styleUtils/typography/color";
+import { hexToRgbA } from "../../shared/styles/color";
+import getCSSVarValue from "../../utilities/components/getCSSVarValue";
 
 interface DonutChartDatum {
   percentage: number;
@@ -28,7 +30,7 @@ export interface DonutChartProps {
 class DonutChart extends React.PureComponent<DonutChartProps, {}> {
   public render() {
     const { data, label, text } = this.props;
-    const strokeWidth = 2;
+    const strokeWidth = 1.5;
     const radius = 100 / (Math.PI * 2);
     const diameter = radius * 2 + strokeWidth;
     const circleCenter = diameter / 2;
@@ -41,7 +43,7 @@ class DonutChart extends React.PureComponent<DonutChartProps, {}> {
           r={radius}
           fill="transparent"
           stroke-width={strokeWidth}
-          style={{ stroke: themeBorder }}
+          style={{ stroke: hexToRgbA(getCSSVarValue(themeBorder), 0.65) }}
         />
         {data.map((datum, i) => {
           const { percentage, color } = datum;

--- a/packages/donutChart/tests/__snapshots__/DonutChart.test.tsx.snap
+++ b/packages/donutChart/tests/__snapshots__/DonutChart.test.tsx.snap
@@ -2,29 +2,29 @@
 
 exports[`DonutChart renders default 1`] = `
 <svg
-  viewBox="0 0 33.83098861837907 33.83098861837907"
+  viewBox="0 0 33.33098861837907 33.33098861837907"
 >
   <circle
-    cx={16.915494309189533}
-    cy={16.915494309189533}
+    cx={16.665494309189533}
+    cy={16.665494309189533}
     fill="transparent"
     r={15.915494309189533}
-    stroke-width={2}
+    stroke-width={1.5}
     style={
       Object {
-        "stroke": "var(--themeBorder, #DADDE2)",
+        "stroke": "rgba(218,221,226,0.65)",
       }
     }
   />
   <circle
-    cx={16.915494309189533}
-    cy={16.915494309189533}
+    cx={16.665494309189533}
+    cy={16.665494309189533}
     fill="none"
     key="0"
     r={15.915494309189533}
     stroke-dasharray="10 90"
     stroke-dashoffset={125}
-    stroke-width={2}
+    stroke-width={1.5}
     style={
       Object {
         "stroke": "#F00",
@@ -37,8 +37,8 @@ exports[`DonutChart renders default 1`] = `
         "textAnchor": "middle",
       }
     }
-    x={16.915494309189533}
-    y={16.915494309189533}
+    x={16.665494309189533}
+    y={16.665494309189533}
   >
     <tspan
       dominantBaseline="central"
@@ -61,29 +61,29 @@ exports[`DonutChart renders with text and label 1`] = `
 }
 
 <svg
-  viewBox="0 0 33.83098861837907 33.83098861837907"
+  viewBox="0 0 33.33098861837907 33.33098861837907"
 >
   <circle
-    cx={16.915494309189533}
-    cy={16.915494309189533}
+    cx={16.665494309189533}
+    cy={16.665494309189533}
     fill="transparent"
     r={15.915494309189533}
-    stroke-width={2}
+    stroke-width={1.5}
     style={
       Object {
-        "stroke": "var(--themeBorder, #DADDE2)",
+        "stroke": "rgba(218,221,226,0.65)",
       }
     }
   />
   <circle
-    cx={16.915494309189533}
-    cy={16.915494309189533}
+    cx={16.665494309189533}
+    cy={16.665494309189533}
     fill="none"
     key="0"
     r={15.915494309189533}
     stroke-dasharray="10 90"
     stroke-dashoffset={125}
-    stroke-width={2}
+    stroke-width={1.5}
     style={
       Object {
         "stroke": "#F00",
@@ -96,8 +96,8 @@ exports[`DonutChart renders with text and label 1`] = `
         "textAnchor": "middle",
       }
     }
-    x={16.915494309189533}
-    y={16.915494309189533}
+    x={16.665494309189533}
+    y={16.665494309189533}
   >
     <tspan
       dominantBaseline="unset"
@@ -108,8 +108,8 @@ exports[`DonutChart renders with text and label 1`] = `
     <tspan
       className="emotion-0"
       fontSize={3}
-      x={16.915494309189533}
-      y={21.115494309189533}
+      x={16.665494309189533}
+      y={20.865494309189533}
     >
       1 of 10
     </tspan>


### PR DESCRIPTION
In a recent review of Kommander work, the design team requested two minor changes to the donut chart:
- A thinner stroke weight for the donut chart
- A lighter grey for the un-filled part of the chart

## Screenshots
**Before:**
<img width="385" alt="Screen Shot 2019-07-15 at 12 56 10 PM" src="https://user-images.githubusercontent.com/2313998/61234680-b7aec180-a701-11e9-801f-063959c751ac.png">

**After:**
<img width="393" alt="Screen Shot 2019-07-15 at 12 55 51 PM" src="https://user-images.githubusercontent.com/2313998/61234683-bbdadf00-a701-11e9-96ed-8ec2deb01290.png">
