### PR TITLE
DCOS-56497: themable SidebarItem hover background color

### DIFF
--- a/packages/appChrome/components/SidebarItem.tsx
+++ b/packages/appChrome/components/SidebarItem.tsx
@@ -19,7 +19,8 @@ class SidebarItemComponent extends React.PureComponent<SidebarItemProps, {}> {
         return css`
           ${sidebarNavItem(
             Boolean(isActive),
-            props.theme.sidebarBackgroundColor
+            props.theme.sidebarBackgroundColor,
+            props.theme.itemHoverBackgroundColor
           )};
           padding-left: ${props.theme.sidebarItemPaddingHor
             ? spaceSizes[props.theme.sidebarItemPaddingHor]

--- a/packages/appChrome/components/SidebarSubMenu.tsx
+++ b/packages/appChrome/components/SidebarSubMenu.tsx
@@ -69,7 +69,11 @@ export class SidebarSubMenuComponent extends React.PureComponent<
         <Expandable
           labelClassName={cx(
             appChromeInsetContent,
-            sidebarNavItem(false, sidebarBgColor),
+            sidebarNavItem(
+              false,
+              sidebarBgColor,
+              theme && theme.itemHoverBackgroundColor
+            ),
             tintContent(
               pickReadableTextColor(
                 sidebarBgColor,

--- a/packages/appChrome/components/SidebarSubMenuItem.tsx
+++ b/packages/appChrome/components/SidebarSubMenuItem.tsx
@@ -47,7 +47,11 @@ class SidebarSubMenuItem extends React.PureComponent<
           getCSSVarValue(themeTextColorSecondaryInverted)
         )
       ),
-      sidebarNavItem(Boolean(isActive), sidebarBgColor),
+      sidebarNavItem(
+        Boolean(isActive),
+        sidebarBgColor,
+        theme && theme.itemHoverBackgroundColor
+      ),
       textSize("s"),
       flex({ align: "center" }),
       {

--- a/packages/appChrome/stories/AppChrome.stories.tsx
+++ b/packages/appChrome/stories/AppChrome.stories.tsx
@@ -21,6 +21,7 @@ import {
   cyan,
   greyLight,
   greyDark,
+  greyDarkLighten2,
   red,
   yellow,
   green,
@@ -498,7 +499,19 @@ storiesOf("AppChrome", module)
       step: 1
     });
 
+    const colors = {
+      greyDarkLighten2,
+      black,
+      cyan,
+      red,
+      green,
+      blue,
+      purple
+    };
+    const color = select("Hover background color", colors, greyDarkLighten2);
+
     const CustomTheme = {
+      itemHoverBackgroundColor: color,
       sidebarItemPaddingHor: paddingHorSize,
       sidebarItemPaddingVert: paddingVertSize,
       iconWidth
@@ -535,7 +548,19 @@ storiesOf("AppChrome", module)
       step: 1
     });
 
+    const colors = {
+      greyDarkLighten2,
+      black,
+      cyan,
+      red,
+      green,
+      blue,
+      purple
+    };
+    const color = select("Hover background color", colors, greyDarkLighten2);
+
     const CustomTheme = {
+      itemHoverBackgroundColor: color,
       iconWidth
     };
 

--- a/packages/appChrome/style.ts
+++ b/packages/appChrome/style.ts
@@ -61,31 +61,33 @@ export const sidebarSectionList = css`
   margin: 0;
 `;
 
-export const sidebarNavItem = (isActive: boolean, sidebarBgColor: string) => {
-  return css`
-    background-color: ${isActive ? themeBgSelected : "transparent"};
-    color: ${isActive
-      ? pickReadableTextColor(
-          sidebarBgColor,
-          themeTextColorPrimary,
-          themeTextColorPrimaryInverted
-        )
-      : null};
-    cursor: pointer;
-    text-transform: capitalize;
+export const sidebarNavItem = (
+  isActive: boolean,
+  sidebarBgColor: string,
+  themedHoverColor?: string
+) => css`
+  background-color: ${isActive ? themeBgSelected : "transparent"};
+  color: ${isActive
+    ? pickReadableTextColor(
+        sidebarBgColor,
+        themeTextColorPrimary,
+        themeTextColorPrimaryInverted
+      )
+    : null};
+  cursor: pointer;
+  text-transform: capitalize;
 
-    &:hover,
-    &:focus {
-      background-color: ${isActive
-        ? themeBgSelected
-        : pickHoverBg(
-            sidebarBgColor,
-            getCSSVarValue(themeBgHover),
-            getCSSVarValue(themeBgHoverInverted)
-          )};
-    }
-  `;
-};
+  &:hover,
+  &:focus {
+    background-color: ${isActive
+      ? themeBgSelected
+      : pickHoverBg(
+          sidebarBgColor,
+          themedHoverColor || getCSSVarValue(themeBgHover),
+          themedHoverColor || getCSSVarValue(themeBgHoverInverted)
+        )};
+  }
+`;
 
 export const sidebarNavItemIconWrap = css`
   line-height: 0;

--- a/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
@@ -143,7 +143,7 @@ exports[`Sidebar SidebarSubMenu renders 1`] = `
         </SidebarItemLabel>
       </div>
     }
-    labelClassName="css-193h9wh"
+    labelClassName="css-pd13g3"
   >
     <ul
       className="emotion-0"

--- a/packages/appChrome/types/appChromeTheme.ts
+++ b/packages/appChrome/types/appChromeTheme.ts
@@ -14,6 +14,7 @@ export interface AppChromeTheme extends Theme {
   headerPaddingHor?: PaddingHoriz;
   headerPaddingVert?: PaddingVert;
   iconWidth?: ElWidth;
+  itemHoverBackgroundColor?: BgColor;
   sidebarBackgroundColor?: BgColor;
   sidebarHeaderPaddingHor?: PaddingHoriz;
   sidebarHeaderPaddingVert?: PaddingVert;


### PR DESCRIPTION
This issue surface while I was implementing the latest designs for the Konvoy/Kommander AppChrome when the designers asked me to try a light grey background.

## Screenshots
Note: the light grey sidebar background isn't showing in the GIF color space, but I think this still demonstrates the changes :)

**Before:**
![InvisibleSidebarItemHover-before](https://user-images.githubusercontent.com/2313998/61245859-77f4d380-a71b-11e9-94ed-44ab1b828761.gif)

**After (with a themed hover bg color):**
![InvisibleSidebarItemHover-after](https://user-images.githubusercontent.com/2313998/61245886-8c38d080-a71b-11e9-8d34-29f37d973d2e.gif)
