### PR TITLE
[spike] DCOS-56720: correct which side gutterSize appears for column direction

### DIFF
--- a/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`AppChrome renders with the app chrome regions 1`] = `
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -43,6 +44,10 @@ exports[`AppChrome renders with the app chrome regions 1`] = `
   display: flex;
   min-height: 0;
   height: 100%;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {

--- a/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Sidebar SidebarItemLabel renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -28,6 +29,10 @@ exports[`Sidebar SidebarItemLabel renders 1`] = `
   min-height: 0;
   padding-top: 12px;
   padding-bottom: 12px;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -87,6 +92,7 @@ exports[`Sidebar SidebarSection renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -98,6 +104,10 @@ exports[`Sidebar SidebarSection renders 1`] = `
   font-weight: 500;
   margin-bottom: 0;
   margin-top: 0;
+}
+
+.emotion-0 > div {
+  width: auto;
 }
 
 .emotion-1 {
@@ -192,6 +202,7 @@ exports[`Sidebar SidebarSubMenuItem renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -200,6 +211,10 @@ exports[`Sidebar SidebarSubMenuItem renders 1`] = `
   min-height: 0;
   padding-top: 12px;
   padding-bottom: 12px;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {

--- a/packages/breadcrumb/tests/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/breadcrumb/tests/__snapshots__/Breadcrumb.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Breadcrumb default 1`] = `
 <nav
-  class="css-2wdnda"
+  class="css-td03f2"
 >
   <div
     class="css-1ixtlzk"

--- a/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
+++ b/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
@@ -61,6 +61,7 @@ exports[`ButtonBase renders all appearances with props 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -71,6 +72,10 @@ exports[`ButtonBase renders all appearances with props 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -174,6 +179,7 @@ exports[`ButtonBase renders all appearances with props 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -184,6 +190,10 @@ exports[`ButtonBase renders all appearances with props 2`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -334,6 +344,7 @@ exports[`ButtonBase renders all appearances with props 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -344,6 +355,10 @@ exports[`ButtonBase renders all appearances with props 3`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -502,6 +517,7 @@ exports[`ButtonBase renders all appearances with props 4`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -512,6 +528,10 @@ exports[`ButtonBase renders all appearances with props 4`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -670,6 +690,7 @@ exports[`ButtonBase renders all appearances with props 5`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -680,6 +701,10 @@ exports[`ButtonBase renders all appearances with props 5`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-0 {

--- a/packages/checkboxInput/tests/__snapshots__/CheckboxInput.test.tsx.snap
+++ b/packages/checkboxInput/tests/__snapshots__/CheckboxInput.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`CheckboxInput renders all appearances 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -39,6 +40,10 @@ exports[`CheckboxInput renders all appearances 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-4 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -149,6 +154,7 @@ exports[`CheckboxInput renders all appearances 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -159,6 +165,10 @@ exports[`CheckboxInput renders all appearances 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-4 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -271,6 +281,7 @@ exports[`CheckboxInput renders all appearances 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -281,6 +292,10 @@ exports[`CheckboxInput renders all appearances 3`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-4 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -382,6 +397,7 @@ exports[`CheckboxInput renders indeterminate 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -392,6 +408,10 @@ exports[`CheckboxInput renders indeterminate 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-6 > div {
+  width: auto;
 }
 
 .emotion-4 {
@@ -567,6 +587,7 @@ exports[`CheckboxInput renders with a hidden label 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -577,6 +598,10 @@ exports[`CheckboxInput renders with a hidden label 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-4 > div {
+  width: auto;
 }
 
 .emotion-2 {

--- a/packages/configurationmap/tests/__snapshots__/ConfigurationMap.test.tsx.snap
+++ b/packages/configurationmap/tests/__snapshots__/ConfigurationMap.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ConfigurationMap renders default 1`] = `
     data-cy="configurationMapSection"
   >
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -27,7 +27,7 @@ exports[`ConfigurationMap renders default 1`] = `
       </dd>
     </div>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -44,7 +44,7 @@ exports[`ConfigurationMap renders default 1`] = `
       </dd>
     </div>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -74,7 +74,7 @@ exports[`ConfigurationMap renders with actions 1`] = `
     data-cy="configurationMapSection"
   >
     <div
-      class="css-yae4lb"
+      class="css-1jqckuv"
       data-cy="configurationMapRow"
     >
       <dt
@@ -107,7 +107,7 @@ exports[`ConfigurationMap renders with actions 1`] = `
       </span>
     </div>
     <div
-      class="css-yae4lb"
+      class="css-1jqckuv"
       data-cy="configurationMapRow"
     >
       <dt
@@ -140,7 +140,7 @@ exports[`ConfigurationMap renders with actions 1`] = `
       </span>
     </div>
     <div
-      class="css-yae4lb"
+      class="css-1jqckuv"
       data-cy="configurationMapRow"
     >
       <dt
@@ -186,7 +186,7 @@ exports[`ConfigurationMap renders with default value 1`] = `
     data-cy="configurationMapSection"
   >
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -203,7 +203,7 @@ exports[`ConfigurationMap renders with default value 1`] = `
       </dd>
     </div>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -220,7 +220,7 @@ exports[`ConfigurationMap renders with default value 1`] = `
       </dd>
     </div>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -256,7 +256,7 @@ exports[`ConfigurationMap renders with headline 1`] = `
       Jane Doe Info
     </h1>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -273,7 +273,7 @@ exports[`ConfigurationMap renders with headline 1`] = `
       </dd>
     </div>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt
@@ -290,7 +290,7 @@ exports[`ConfigurationMap renders with headline 1`] = `
       </dd>
     </div>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt

--- a/packages/configurationmap/tests/__snapshots__/HashMap.test.tsx.snap
+++ b/packages/configurationmap/tests/__snapshots__/HashMap.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`HashMap renders array value 1`] = `
   data-cy="configurationMapSection"
 >
   <div
-    class="css-td53qz"
+    class="css-2iygaf"
     data-cy="configurationMapRow"
   >
     <dt
@@ -31,7 +31,7 @@ exports[`HashMap renders boolean value 1`] = `
   data-cy="configurationMapSection"
 >
   <div
-    class="css-td53qz"
+    class="css-2iygaf"
     data-cy="configurationMapRow"
   >
     <dt
@@ -56,7 +56,7 @@ exports[`HashMap renders default 1`] = `
   data-cy="configurationMapSection"
 >
   <div
-    class="css-td53qz"
+    class="css-2iygaf"
     data-cy="configurationMapRow"
   >
     <dt
@@ -81,7 +81,7 @@ exports[`HashMap renders empty value 1`] = `
   data-cy="configurationMapSection"
 >
   <div
-    class="css-td53qz"
+    class="css-2iygaf"
     data-cy="configurationMapRow"
   >
     <dt
@@ -112,7 +112,7 @@ exports[`HashMap renders with a headline 1`] = `
     baz
   </h1>
   <div
-    class="css-td53qz"
+    class="css-2iygaf"
     data-cy="configurationMapRow"
   >
     <dt
@@ -147,7 +147,7 @@ exports[`HashMap renders with nested object hash 1`] = `
       foo
     </h2>
     <div
-      class="css-td53qz"
+      class="css-2iygaf"
       data-cy="configurationMapRow"
     >
       <dt

--- a/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
+++ b/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Sidebar renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -49,6 +50,10 @@ exports[`Sidebar renders 1`] = `
 
 .emotion-0:focus {
   outline: 0;
+}
+
+.emotion-0 > div {
+  width: auto;
 }
 
 <Expandable

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -90,6 +90,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -100,6 +101,10 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-12 > div {
+  width: auto;
 }
 
 .emotion-9 {
@@ -139,6 +144,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -146,6 +152,10 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   display: flex;
   min-height: 0;
   padding: 24px;
+}
+
+.emotion-5 > div {
+  width: auto;
 }
 
 .emotion-1 {
@@ -568,6 +578,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -578,6 +589,10 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-14 > div {
+  width: auto;
 }
 
 .emotion-10 {
@@ -617,6 +632,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -624,6 +640,10 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   display: flex;
   min-height: 0;
   padding: 24px;
+}
+
+.emotion-5 > div {
+  width: auto;
 }
 
 .emotion-1 {
@@ -1380,6 +1400,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1398,6 +1419,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: initial;
+}
+
+.emotion-8 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -1551,7 +1576,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                       data-cy="dialogModal-header"
                     >
                       <div
-                        class="css-1udp9vv"
+                        class="css-mrra2t"
                       >
                         <div
                           class="css-16jj0m8"
@@ -1599,7 +1624,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                       data-cy="dialogModal-footer"
                     >
                       <div
-                        class="css-kqhhpv"
+                        class="css-1yp2uay"
                       >
                         <div
                           class="css-48ylac"
@@ -1726,6 +1751,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -1736,6 +1762,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-14 > div {
+  width: auto;
 }
 
 .emotion-10 {
@@ -1775,6 +1805,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1782,6 +1813,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   display: flex;
   min-height: 0;
   padding: 24px;
+}
+
+.emotion-5 > div {
+  width: auto;
 }
 
 .emotion-1 {
@@ -2290,6 +2325,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -2308,6 +2344,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   width: initial;
+}
+
+.emotion-10 > div {
+  width: auto;
 }
 
 .emotion-3 {

--- a/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`PageHeader default 1`] = `
 <div
-  class="css-4sqa7y"
+  class="css-ya955p"
   data-cy="pageHeader"
 >
   <div
     class="css-qi8t7c"
   >
     <nav
-      class="css-2wdnda"
+      class="css-td03f2"
     >
       <div
         class="css-1ixtlzk"
@@ -52,7 +52,7 @@ exports[`PageHeader default 1`] = `
     class="css-48ylac"
   >
     <ul
-      class="css-1s6ufm8"
+      class="css-cdxrln"
       data-cy="pageHeader-actions"
     >
       <li

--- a/packages/styleUtils/layout/flexbox/components/Flex.tsx
+++ b/packages/styleUtils/layout/flexbox/components/Flex.tsx
@@ -4,9 +4,9 @@ import { FlexItemProps } from "./FlexItem";
 import { SpaceSize } from "../../../../shared/styles/styleUtils/modifiers/modifierUtils";
 import {
   FlexboxProperties,
-  flex
+  flex,
+  applyFlexItemGutters
 } from "../../../../shared/styles/styleUtils/layout/flexbox";
-import { getResponsiveSpacingStyle } from "../../../../shared/styles/styleUtils";
 
 interface FlexProps extends FlexboxProperties {
   /**
@@ -25,10 +25,7 @@ const Flex = (props: FlexProps) => {
     <div
       className={css`
         ${flex({ ...flexboxProperties })};
-
-        > *:not(:first-child) {
-          ${getResponsiveSpacingStyle("padding-left", gutterSize)};
-        }
+        ${applyFlexItemGutters(flexboxProperties.direction, gutterSize)};
       `}
       data-cy="flex"
     >
@@ -41,7 +38,8 @@ Flex.defaultProps = {
   align: "flex-start",
   direction: "row",
   wrap: "nowrap",
-  justify: "flex-start"
+  justify: "flex-start",
+  gutterSize: "none"
 };
 
 export default Flex;

--- a/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
+++ b/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
@@ -29,12 +29,22 @@ storiesOf("Style utilities/Layout/Flex", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (
-    <Flex>
-      <FlexItem>1</FlexItem>
-      <FlexItem>2</FlexItem>
-      <FlexItem>3</FlexItem>
-      <FlexItem>4</FlexItem>
-    </Flex>
+    <SampleContainer>
+      <Flex>
+        <FlexItem>
+          <DemoChild>1</DemoChild>
+        </FlexItem>
+        <FlexItem>
+          <DemoChild>2</DemoChild>
+        </FlexItem>
+        <FlexItem>
+          <DemoChild>3</DemoChild>
+        </FlexItem>
+        <FlexItem>
+          <DemoChild>4</DemoChild>
+        </FlexItem>
+      </Flex>
+    </SampleContainer>
   ))
   .add("align", () => {
     const alignments = {
@@ -215,6 +225,36 @@ storiesOf("Style utilities/Layout/Flex", module)
       </div>
     );
   })
+  .add("responsive directions and gutterSize", () => (
+    <div>
+      <p>
+        Reduce the width of your viewport to see the boxes lay out as a column
+        and see the gutter size change
+      </p>
+      <Flex
+        direction={{
+          default: "column",
+          medium: "row",
+          large: "row"
+        }}
+        gutterSize={{ default: "xs", medium: "l", large: "xxl" }}
+      >
+        <FlexItem>
+          <DemoChild>1</DemoChild>
+        </FlexItem>
+        <FlexItem>
+          <DemoChild>2</DemoChild>
+        </FlexItem>
+        <FlexItem>
+          <DemoChild>3</DemoChild>
+        </FlexItem>
+        <FlexItem>
+          <DemoChild>4</DemoChild>
+        </FlexItem>
+        {null}
+      </Flex>
+    </div>
+  ))
   .add("justify", () => {
     const justifications = {
       flexStart: "flex-start",

--- a/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
+++ b/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Flex renders default 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -24,8 +25,13 @@ exports[`Flex renders default 1`] = `
   min-height: 0;
 }
 
+.emotion-0 > div {
+  width: auto;
+}
+
 .emotion-0 > *:not(:first-child) {
   padding-left: 0;
+  padding-top: 0;
 }
 
 <div
@@ -75,7 +81,8 @@ exports[`Flex renders with all props 1`] = `
 }
 
 .emotion-0 > *:not(:first-child) {
-  padding-left: 24px;
+  padding-left: 0;
+  padding-top: 24px;
 }
 
 <div
@@ -199,13 +206,25 @@ exports[`Flex renders with responsive props 1`] = `
 
 @media (min-width:0) {
   .emotion-0 > *:not(:first-child) {
-    padding-left: 12px;
+    padding-left: 0;
   }
 }
 
 @media (min-width:900px) {
   .emotion-0 > *:not(:first-child) {
     padding-left: 16px;
+  }
+}
+
+@media (min-width:0) {
+  .emotion-0 > *:not(:first-child) {
+    padding-top: 12px;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 > *:not(:first-child) {
+    padding-top: 0;
   }
 }
 

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -91,6 +91,7 @@ Array [
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -107,6 +108,10 @@ Array [
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-9 > div {
+  width: auto;
 }
 
 .emotion-7 {
@@ -170,6 +175,7 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -180,6 +186,10 @@ Array [
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-4 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -765,6 +775,7 @@ Array [
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -781,6 +792,10 @@ Array [
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-11 > div {
+  width: auto;
 }
 
 .emotion-9 {
@@ -844,6 +859,7 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -854,6 +870,10 @@ Array [
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-6 > div {
+  width: auto;
 }
 
 .emotion-4 {
@@ -1535,6 +1555,7 @@ Array [
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1551,6 +1572,10 @@ Array [
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-9 > div {
+  width: auto;
 }
 
 .emotion-7 {
@@ -1614,6 +1639,7 @@ Array [
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1624,6 +1650,10 @@ Array [
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-4 > div {
+  width: auto;
 }
 
 .emotion-2 {

--- a/packages/table/tests/__snapshots__/Table.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Table.test.tsx.snap
@@ -86,6 +86,7 @@ Array [
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -102,6 +103,10 @@ Array [
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-5 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -798,6 +803,7 @@ Array [
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -814,6 +820,10 @@ Array [
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -1192,6 +1202,7 @@ Array [
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1208,6 +1219,10 @@ Array [
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {

--- a/packages/textInput/tests/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInput.test.tsx.snap
@@ -14,12 +14,17 @@ exports[`TextInput should display icon with tooltip if tooltipText is set 1`] = 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-1 {
@@ -72,12 +77,17 @@ exports[`TextInput should display validation message if set & appearance == Erro
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -136,12 +146,17 @@ exports[`TextInput should hide label if \`showInputLabel\` set to false 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -177,12 +192,17 @@ exports[`TextInput should not display validation message if set & appearance == 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -226,6 +246,7 @@ exports[`TextInput should render all appearances focus 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -234,11 +255,16 @@ exports[`TextInput should render all appearances focus 1`] = `
   min-height: 0;
 }
 
+.emotion-1 > div {
+  width: auto;
+}
+
 .emotion-3 {
   -webkit-align-items: flex;
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -255,6 +281,10 @@ exports[`TextInput should render all appearances focus 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -396,12 +426,17 @@ exports[`TextInput should render all appearances focus 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -419,6 +454,7 @@ exports[`TextInput should render all appearances focus 2`] = `
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -435,6 +471,10 @@ exports[`TextInput should render all appearances focus 2`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -579,6 +619,7 @@ exports[`TextInput should render all appearances focus 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -587,11 +628,16 @@ exports[`TextInput should render all appearances focus 3`] = `
   min-height: 0;
 }
 
+.emotion-1 > div {
+  width: auto;
+}
+
 .emotion-3 {
   -webkit-align-items: flex;
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -608,6 +654,10 @@ exports[`TextInput should render all appearances focus 3`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -752,12 +802,17 @@ exports[`TextInput should render all appearances with props 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -788,12 +843,17 @@ exports[`TextInput should render all appearances with props 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -842,12 +902,17 @@ exports[`TextInput should render all appearances with props 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -886,12 +951,17 @@ exports[`TextInput should render node as inputLabel 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -932,12 +1002,17 @@ exports[`TextInput should render string inputLabel 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div

--- a/packages/textInput/tests/__snapshots__/TextInputWithIcon.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithIcon.test.tsx.snap
@@ -14,12 +14,17 @@ exports[`TextInputWithIcon should render all appearances with iconEnd 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -50,12 +55,17 @@ exports[`TextInputWithIcon should render all appearances with iconEnd 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -104,12 +114,17 @@ exports[`TextInputWithIcon should render all appearances with iconEnd 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -148,12 +163,17 @@ exports[`TextInputWithIcon should render all appearances with iconStart 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -184,12 +204,17 @@ exports[`TextInputWithIcon should render all appearances with iconStart 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -238,12 +263,17 @@ exports[`TextInputWithIcon should render all appearances with iconStart 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -282,12 +312,17 @@ exports[`TextInputWithIcon should render all appearances with twoIcons 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div
@@ -318,12 +353,17 @@ exports[`TextInputWithIcon should render all appearances with twoIcons 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -372,12 +412,17 @@ exports[`TextInputWithIcon should render all appearances with twoIcons 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 <div

--- a/packages/toggleInput/tests/__snapshots__/ToggleInput.test.tsx.snap
+++ b/packages/toggleInput/tests/__snapshots__/ToggleInput.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`ToggleInput renders all appearances 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -16,6 +17,10 @@ exports[`ToggleInput renders all appearances 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -80,6 +85,7 @@ exports[`ToggleInput renders all appearances 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -90,6 +96,10 @@ exports[`ToggleInput renders all appearances 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {
@@ -156,6 +166,7 @@ exports[`ToggleInput renders all appearances 3`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -166,6 +177,10 @@ exports[`ToggleInput renders all appearances 3`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-2 > div {
+  width: auto;
 }
 
 .emotion-0 {

--- a/packages/toggleInputList/tests/__snapshots__/ToggleInputList.test.tsx.snap
+++ b/packages/toggleInputList/tests/__snapshots__/ToggleInputList.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`ToggleInputList renders default 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -62,6 +63,10 @@ exports[`ToggleInputList renders default 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-5 > div {
+  width: auto;
 }
 
 .emotion-3 {
@@ -368,6 +373,7 @@ exports[`ToggleInputList renders with errors 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -378,6 +384,10 @@ exports[`ToggleInputList renders with errors 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-5 > div {
+  width: auto;
 }
 
 .emotion-3 {
@@ -723,6 +733,7 @@ exports[`ToggleInputList renders with hidden label 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -733,6 +744,10 @@ exports[`ToggleInputList renders with hidden label 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-5 > div {
+  width: auto;
 }
 
 .emotion-3 {
@@ -1053,6 +1068,7 @@ exports[`ToggleInputList renders with selected items 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -1063,6 +1079,10 @@ exports[`ToggleInputList renders with selected items 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+
+.emotion-7 > div {
+  width: auto;
 }
 
 .emotion-5 {

--- a/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
+++ b/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Typeahead renders 1`] = `
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -22,6 +23,10 @@ exports[`Typeahead renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-23 {
@@ -56,12 +61,17 @@ exports[`Typeahead renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -183,6 +193,7 @@ exports[`Typeahead renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -201,8 +212,13 @@ exports[`Typeahead renders 1`] = `
   min-height: 0;
 }
 
+.emotion-7 > div {
+  width: auto;
+}
+
 .emotion-7 > *:not(:first-child) {
   padding-left: 8px;
+  padding-top: 0;
 }
 
 .emotion-4 {
@@ -505,6 +521,7 @@ exports[`Typeahead renders 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -523,8 +540,13 @@ exports[`Typeahead renders 1`] = `
   min-height: 0;
 }
 
+.emotion-3 > div {
+  width: auto;
+}
+
 .emotion-3 > *:not(:first-child) {
   padding-left: 8px;
+  padding-top: 0;
 }
 
 .emotion-0 {
@@ -1055,6 +1077,7 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   -webkit-box-align: flex;
   -ms-flex-align: flex;
   align-items: flex;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1071,6 +1094,10 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-3 > div {
+  width: auto;
 }
 
 .emotion-23 {
@@ -1105,12 +1132,17 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
 }
 
 .emotion-2 {
@@ -1232,6 +1264,7 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1250,8 +1283,13 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   min-height: 0;
 }
 
+.emotion-7 > div {
+  width: auto;
+}
+
 .emotion-7 > *:not(:first-child) {
   padding-left: 8px;
+  padding-top: 0;
 }
 
 .emotion-4 {
@@ -1662,6 +1700,7 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  height: auto;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -1680,8 +1719,13 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   min-height: 0;
 }
 
+.emotion-3 > div {
+  width: auto;
+}
+
 .emotion-3 > *:not(:first-child) {
   padding-left: 8px;
+  padding-top: 0;
 }
 
 .emotion-0 {


### PR DESCRIPTION
When setting a `gutterSize` and setting a `direction` prop to "column" or "column-reverse", the padding on the FlexItem remained on the left instead of moving to the top.

## Screenshots:
Before:
![Screen Shot 2019-07-18 at 7 17 20 PM](https://user-images.githubusercontent.com/2313998/61498423-33726d80-a991-11e9-8bab-b6d30b0c1284.png)

After:
![Screen Shot 2019-07-18 at 7 18 23 PM](https://user-images.githubusercontent.com/2313998/61498431-38372180-a991-11e9-8c34-40c80915acd5.png)
