### PR TITLE
fix: tweaks to card and appchrome layout

### DIFF
--- a/packages/appChrome/components/AppChrome.tsx
+++ b/packages/appChrome/components/AppChrome.tsx
@@ -37,7 +37,7 @@ class AppChrome extends React.PureComponent<AppChromeProps, {}> {
           <div className="headerBar">{headerBar}</div>
           <div className={cx(flex(), appWrapper)}>
             <div className={flexItem("shrink")}>{sidebar}</div>
-            <main className={cx(flexItem("grow"), flush("left"))}>
+            <main className={cx(flexItem("grow"), flush("left"), appWrapper)}>
               {mainContent}
             </main>
           </div>

--- a/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/AppChrome.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`AppChrome renders with the app chrome regions 1`] = `
   width: auto;
   padding-left: 0;
   margin-left: 0;
+  height: 100%;
 }
 
 <ThemeProvider

--- a/packages/card/style.ts
+++ b/packages/card/style.ts
@@ -6,4 +6,8 @@ export const style = css`
   background-color: ${themeBgPrimary};
   ${border("all")};
   ${borderRadius("default")};
+
+  > div {
+    height: 100%;
+  }
 `;

--- a/packages/card/tests/__snapshots__/Card.test.tsx.snap
+++ b/packages/card/tests/__snapshots__/Card.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Card default 1`] = `
 <div
-  class="css-1rmvfmi"
+  class="css-1txfjje"
 >
   <div
     class="css-2yjhih"
@@ -14,7 +14,7 @@ exports[`Card default 1`] = `
 
 exports[`Card with aspectRatio set 1`] = `
 <div
-  class="css-88gmn3"
+  class="css-1jys0p8"
 >
   <div
     class="css-2yjhih"
@@ -26,7 +26,7 @@ exports[`Card with aspectRatio set 1`] = `
 
 exports[`Card with paddingSize set 1`] = `
 <div
-  class="css-1rmvfmi"
+  class="css-1txfjje"
 >
   <div
     class="css-jl90x"


### PR DESCRIPTION
card: inner div is set to 100% to match the card's height
appchrome: make the wrapper for the main content area 100% to avoid strange bug where bottom of the main content is cut off when the sidebar and main content area scroll together