### PR TITLE
DCOS-56894: Fix Sidebar open/close toggle bugs

### DIFF
--- a/packages/appChrome/stories/AppChrome.stories.tsx
+++ b/packages/appChrome/stories/AppChrome.stories.tsx
@@ -3,7 +3,14 @@ import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { withReadme } from "storybook-readme";
 import { ThemeProvider } from "emotion-theming";
-import { number, select, text, withKnobs } from "@storybook/addon-knobs";
+import {
+  number,
+  select,
+  text,
+  object,
+  boolean,
+  withKnobs
+} from "@storybook/addon-knobs";
 import { SidebarBareContent } from "./helpers/StorybookSidebarHelpers";
 import DCOSAppChrome from "./helpers/DCOSAppChrome";
 import AppChrome from "../components/AppChrome";
@@ -443,17 +450,56 @@ storiesOf("AppChrome", module)
       step: 1
     });
 
+    const sidebarIsOpen = boolean("isOpen", true);
+
     const CustomTheme = {
       sidebarBackgroundColor: color,
       sidebarHeaderPaddingHor: paddingHorSize,
       sidebarHeaderPaddingVert: paddingVertSize,
-      sidebarWidth: sidebarWidth + "px"
+      sidebarWidth: `${sidebarWidth}px`
     };
 
     return (
       <ThemeProvider theme={CustomTheme}>
-        <Sidebar isOpen={true}>
+        <Sidebar isOpen={sidebarIsOpen}>
           <SidebarSection label={sectionHeader}>
+            <SidebarItem isActive={true} onClick={action("clicked a nav item")}>
+              <SidebarItemLabel>Lorem Ipsum</SidebarItemLabel>
+            </SidebarItem>
+            <SidebarItem onClick={action("clicked a nav item")}>
+              <SidebarItemLabel>Dolor Sit</SidebarItemLabel>
+            </SidebarItem>
+            <SidebarItem onClick={action("clicked a nav item")}>
+              <SidebarItemLabel>Amet Consecutor</SidebarItemLabel>
+            </SidebarItem>
+            <SidebarItem onClick={action("clicked a nav item")}>
+              <SidebarItemLabel>Adipiscing Edit</SidebarItemLabel>
+            </SidebarItem>
+            <SidebarItem onClick={action("clicked a nav item")}>
+              <SidebarItemLabel>Praesent Massa</SidebarItemLabel>
+            </SidebarItem>
+          </SidebarSection>
+        </Sidebar>
+      </ThemeProvider>
+    );
+  })
+
+  .add("Sidebar Responsive Width w/ Knobs", () => {
+    const responsiveWidthsValue = object(
+      "Responsive widths",
+      { default: "200px", large: "300px" },
+      "responsiveWidths"
+    );
+    const sidebarIsOpen = boolean("isOpen", true);
+
+    const CustomTheme = {
+      sidebarWidth: responsiveWidthsValue
+    };
+
+    return (
+      <ThemeProvider theme={CustomTheme}>
+        <Sidebar isOpen={sidebarIsOpen}>
+          <SidebarSection label="Section header">
             <SidebarItem isActive={true} onClick={action("clicked a nav item")}>
               <SidebarItemLabel>Lorem Ipsum</SidebarItemLabel>
             </SidebarItem>

--- a/packages/appChrome/style.ts
+++ b/packages/appChrome/style.ts
@@ -46,7 +46,7 @@ export const sidebar = css`
 export const sidebarAnimator = css`
   height: 100%;
   overflow: hidden;
-  transition: width 150ms ease-in-out;
+  transition: width 150ms ease-in-out, transform 150ms ease-in-out;
 `;
 
 export const sidebarItemHeight = css`

--- a/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
@@ -250,22 +250,16 @@ exports[`Sidebar SidebarSubMenuItem renders 1`] = `
 `;
 
 exports[`Sidebar renders 1`] = `
+.emotion-0 {
+  height: 100%;
+}
+
 .emotion-1 {
   height: 100%;
   overflow: hidden;
-  -webkit-transition: width 150ms ease-in-out;
-  transition: width 150ms ease-in-out;
-}
-
-.emotion-0 {
-  height: 100%;
-  width: 240px;
-}
-
-@media (min-width:1200px) {
-  .emotion-0 {
-    width: 280px;
-  }
+  -webkit-transition: width 150ms ease-in-out,-webkit-transform 150ms ease-in-out;
+  -webkit-transition: width 150ms ease-in-out,transform 150ms ease-in-out;
+  transition: width 150ms ease-in-out,transform 150ms ease-in-out;
 }
 
 <ThemeProvider

--- a/packages/appChrome/types/appChromeTheme.ts
+++ b/packages/appChrome/types/appChromeTheme.ts
@@ -1,4 +1,5 @@
 import { Theme } from "../../themes/types/appTheme";
+import { BreakpointConfig } from "../../shared/styles/breakpoints";
 
 type BgColor = React.CSSProperties["backgroundColor"];
 type PaddingHoriz =
@@ -19,7 +20,7 @@ export interface AppChromeTheme extends Theme {
   sidebarBackgroundColor?: BgColor;
   sidebarHeaderPaddingHor?: PaddingHoriz;
   sidebarHeaderPaddingVert?: PaddingVert;
-  sidebarWidth?: ElWidth;
+  sidebarWidth?: BreakpointConfig<ElWidth>;
   sidebarItemPaddingHor?: PaddingHoriz;
   sidebarItemPaddingVert?: PaddingVert;
 }


### PR DESCRIPTION
Bugs fixed:
- The Sidebar would not toggle closed when `sidebarWidth` was set in the AppChrome theme
- The Sidebar open/close animation was broken
- `styled` was being called in the render method, which hurts React performance

## Testing:
1. Go to the story called "Sidebar Customizable w/ Knobs"
2. Uncheck the "isOpen" checkbox
3. Confirm the Sidebar opens and closes, and animates when it does

## Screenshots:
**Before - toggle bug:**
![sidebarWidthThemeBug_before](https://user-images.githubusercontent.com/2313998/62324483-a2fb5900-b477-11e9-9a11-9f6478f5d45e.gif)

**After - toggle bug:**
![sidebarWidthThemeBug_after](https://user-images.githubusercontent.com/2313998/62324378-5f085400-b477-11e9-8004-49660478ab50.gif)

**Before - animation bug:**
![sidebarAnimationBug_before](https://user-images.githubusercontent.com/2313998/62324360-54e65580-b477-11e9-922f-f86912f01b66.gif)

**After - animation bug:**
![sidebarAnimationBug_after](https://user-images.githubusercontent.com/2313998/62324369-5a43a000-b477-11e9-8356-72604cb80fd4.gif)
