### PR TITLE
fix: hides tooltip when mouse leaves disabled button

### DIFF
--- a/packages/button/style.ts
+++ b/packages/button/style.ts
@@ -65,6 +65,7 @@ export const filledButton = (
 const mutedButton = css`
   ${tintContent(themeTextColorDisabled)};
   cursor: default;
+  pointer-events: none;
 
   &:hover,
   &:focus,

--- a/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
+++ b/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`ButtonBase renders all appearances with props 1`] = `
   color: var(--themeTextColorDisabled,#AEB0B4);
   fill: var(--themeTextColorDisabled,#AEB0B4);
   cursor: default;
+  pointer-events: none;
   background-color: var(--themeBgDisabled,#E8EAED);
 }
 
@@ -252,6 +253,7 @@ exports[`ButtonBase renders all appearances with props 2`] = `
   color: var(--themeTextColorDisabled,#AEB0B4);
   fill: var(--themeTextColorDisabled,#AEB0B4);
   cursor: default;
+  pointer-events: none;
 }
 
 .emotion-4::-moz-focus-inner {
@@ -410,6 +412,7 @@ exports[`ButtonBase renders all appearances with props 3`] = `
   color: var(--themeTextColorDisabled,#AEB0B4);
   fill: var(--themeTextColorDisabled,#AEB0B4);
   cursor: default;
+  pointer-events: none;
   background-color: var(--themeBgDisabled,#E8EAED);
 }
 
@@ -573,6 +576,7 @@ exports[`ButtonBase renders all appearances with props 4`] = `
   color: var(--themeTextColorDisabled,#AEB0B4);
   fill: var(--themeTextColorDisabled,#AEB0B4);
   cursor: default;
+  pointer-events: none;
   background-color: var(--themeBgDisabled,#E8EAED);
 }
 
@@ -736,6 +740,7 @@ exports[`ButtonBase renders all appearances with props 5`] = `
   color: var(--themeTextColorDisabled,#AEB0B4);
   fill: var(--themeTextColorDisabled,#AEB0B4);
   cursor: default;
+  pointer-events: none;
   background-color: var(--themeBgDisabled,#E8EAED);
 }
 

--- a/packages/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/tooltip/stories/Tooltip.stories.tsx
@@ -5,17 +5,23 @@ import { select } from "@storybook/addon-knobs";
 
 import { Tooltip } from "../../index";
 import { Direction } from "../../dropdownable/components/Dropdownable";
+import { Box } from "../../styleUtils/modifiers";
 
 const readme = require("../README.md");
 
+const tooltipStoryDecorator = storyFn => (
+  <div style={{ textAlign: "center" }}>
+    <Box display="inline-block">{storyFn()}</Box>
+  </div>
+);
+
 storiesOf("Tooltip", module)
   .addDecorator(withReadme([readme]))
+  .addDecorator(tooltipStoryDecorator)
   .add("default", () => (
-    <div style={{ textAlign: "center" }}>
-      <Tooltip trigger="hover me" id="default">
-        content
-      </Tooltip>
-    </div>
+    <Tooltip trigger="hover me" id="default">
+      content
+    </Tooltip>
   ))
   .add("with custom direction", () => {
     const options = {
@@ -36,40 +42,34 @@ storiesOf("Tooltip", module)
     }
 
     return (
-      <div style={{ textAlign: "center" }}>
-        <Tooltip
-          trigger="hover me"
-          id="customDir"
-          preferredDirections={[Direction[getKeyByValue(knobDirection)]]}
-        >
-          Use the knobs to change tooltip alignment
-        </Tooltip>
-      </div>
+      <Tooltip
+        trigger="hover me"
+        id="customDir"
+        preferredDirections={[Direction[getKeyByValue(knobDirection)]]}
+      >
+        Use the knobs to change tooltip alignment
+      </Tooltip>
     );
   })
   .add("min or max width", () => (
-    <div>
-      <div style={{ textAlign: "center", marginBottom: "1em" }}>
+    <React.Fragment>
+      <div style={{ marginBottom: "1em" }}>
         <Tooltip trigger="maxWidth 100px" id="maxWidth" maxWidth={100}>
           content that is greater than 100px
         </Tooltip>
       </div>
-      <div style={{ textAlign: "center" }}>
-        <Tooltip
-          trigger="minWidth 200px"
-          id="minWidth"
-          minWidth={200}
-          preferredDirections={[Direction.BottomCenter]}
-        >
-          content
-        </Tooltip>
-      </div>
-    </div>
+      <Tooltip
+        trigger="minWidth 200px"
+        id="minWidth"
+        minWidth={200}
+        preferredDirections={[Direction.BottomCenter]}
+      >
+        content
+      </Tooltip>
+    </React.Fragment>
   ))
   .add("suppress toggle", () => (
-    <div style={{ textAlign: "center" }}>
-      <Tooltip trigger="hover me" id="suppress" open={true} suppress={true}>
-        I won't toggle open and closed
-      </Tooltip>
-    </div>
+    <Tooltip trigger="hover me" id="suppress" open={true} suppress={true}>
+      I won't toggle open and closed
+    </Tooltip>
   ));


### PR DESCRIPTION
## Testing
1. In the "default" Tooltip story, replace the `trigger` prop with:
```
trigger={<PrimaryButton disabled={true}>Hover me</PrimaryButton>}
```
2. Hover over the button and then off the button

The tooltip should disappear when your cursor leaves the button

## Screenshots
**Before:**
![disabledButtonTooltipBug_before](https://user-images.githubusercontent.com/2313998/62329624-78fc6380-b484-11e9-8c3f-de3f9ac920bd.gif)

**After:**
![disabledButtonTooltipBug_after](https://user-images.githubusercontent.com/2313998/62329667-8e718d80-b484-11e9-998d-dfd69c4d9ca5.gif)

