### PR TITLE
Fix Typescript design-tokens distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
   "scripts": {
     "build:storybook": "build-storybook -c .storybook -o storybook_static",
     "prebuild:storybook": "npm run build:design-tokens && npm run build:svg",
-    "prebuild:design-tokens": "npm run clean:design-tokens",
     "build:design-tokens": "node ./packages/design-tokens/scripts/build.js",
     "build:svg": "node ./packages/icons/scripts/build.js",
     "clean": "rimraf dist",
-    "clean:design-tokens": "rm -rf ./dist/packages/design-tokens && rm -rf ./packages/design-tokens/dist/",
     "commitlint": "commitlint -e",
     "create:component": "./scripts/create-component",
     "deploy:storybook": "storybook-to-ghpages",


### PR DESCRIPTION
This was causing an issue with releases because the compiled Typescript would get blown away when CI ran the 'Build Storybook' step.

- `npm run dist`
    - builds the distribution where designTokens.ts gets compiled with tsc
- `npm run build:storybook`
    - removes the design-token directories via clean:design-tokens
    - rebuilds icons and design-tokens, but does not run tsc
- `npx run semantic-release`
    - publishes to npm without compiled JS design tokens