### PR TITLE
DCOS-39095: adds browser-native tooltip to all table cells

### DIFF
--- a/packages/table/components/Cell.tsx
+++ b/packages/table/components/Cell.tsx
@@ -1,4 +1,6 @@
+import * as React from "react";
 import styled, { css } from "react-emotion";
+import getReactChildrenText from "../../utilities/getReactChildrenText";
 import { innerCellCss, cellAlignmentCss } from "../style";
 
 export type TextAlign = "left" | "right" | "center";
@@ -12,7 +14,18 @@ const alignmentStyle = (props: CellProps) => css`
   ${cellAlignmentCss(props.textAlign || "left")};
 `;
 
-export default styled("div")`
+const CellStyled = styled("div")`
   ${innerCellCss};
   ${alignmentStyle};
 `;
+
+const Cell = props => {
+  return (
+    <CellStyled
+      title={getReactChildrenText(props.children) || null}
+      {...props}
+    />
+  );
+};
+
+export default Cell;

--- a/packages/table/tests/__snapshots__/Cell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Cell.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`Cell renders correctly 1`] = `
 
 <div
   class="emotion-0"
+  title="This is content"
 >
   This is content
 </div>
@@ -33,6 +34,7 @@ exports[`HeaderCell renders correctly 1`] = `
 
 <div
   class="emotion-0"
+  title="This is content"
 >
   This is content
 </div>
@@ -53,6 +55,7 @@ exports[`TextCell renders correctly 1`] = `
 
 <div
   class="emotion-0"
+  title="This is content"
 >
   This is content
 </div>

--- a/packages/table/tests/__snapshots__/SortableHeaderCell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/SortableHeaderCell.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`SortableHeaderCell renders default 1`] = `
   role="button"
   tabIndex={0}
 >
-  <Styled(div)
+  <Styled(Cell)
     aria-label="sort by column content in ascending order"
     aria-sort="descending"
     className="emotion-0"
@@ -48,6 +48,6 @@ exports[`SortableHeaderCell renders default 1`] = `
     <span>
       column content
     </span>
-  </Styled(div)>
+  </Styled(Cell)>
 </Clickable>
 `;

--- a/packages/utilities/getReactChildrenText.ts
+++ b/packages/utilities/getReactChildrenText.ts
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+const getSubChildren = child => child && child.props && child.props.children;
+const getReactChildrenText = (children: React.ReactChildren) => {
+  return React.Children.toArray(children)
+    .reduce(
+      (flattened, child) => [
+        ...flattened,
+        React.isValidElement(child) && child.type !== "string"
+          ? getReactChildrenText(getSubChildren(child))
+          : child
+      ],
+      new Array()
+    )
+    .join(" ")
+    .replace(/ +(?= )/g, ""); // remove duplicate spaces if tags are inline like <span>Lorem</span>[SPACE]<span>ipsum</span>
+};
+
+export default getReactChildrenText;

--- a/packages/utilities/tests/getReactChildrenText.test.tsx
+++ b/packages/utilities/tests/getReactChildrenText.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { shallow } from "enzyme";
+import getReactChildrenText from "../getReactChildrenText";
+
+describe("getReactChildrenText", () => {
+  it("returns a string for a child that is a string", () => {
+    const component = shallow(<div>Lorem ipsum dolor</div>);
+    expect(getReactChildrenText(component.prop("children"))).toBe(
+      "Lorem ipsum dolor"
+    );
+  });
+  it("returns a string for a children that are React elements", () => {
+    const component = shallow(
+      <div>
+        <p>Lorem</p>
+        <span>ipsum</span>
+        <em>dolor</em>
+      </div>
+    );
+    expect(getReactChildrenText(component.prop("children"))).toBe(
+      "Lorem ipsum dolor"
+    );
+  });
+  it("returns a string for a children that are nested React elements", () => {
+    const component = shallow(
+      <div>
+        <p>
+          <span>Lorem</span>
+        </p>
+        <span>ipsum</span>
+        <em>
+          <b>dolor</b>
+        </em>
+      </div>
+    );
+    expect(getReactChildrenText(component.prop("children"))).toBe(
+      "Lorem ipsum dolor"
+    );
+  });
+  it("removes duplicate spaces from string", () => {
+    const component = shallow(
+      <div>
+        <p>Lorem </p> <span> ipsum </span> <em> dolor</em>
+      </div>
+    );
+    expect(getReactChildrenText(component.prop("children"))).toBe(
+      "Lorem ipsum dolor"
+    );
+  });
+});


### PR DESCRIPTION
We want to ensure that table cell text content is always accessible to the user, even when a cell is truncated.
This commit gives every Table cell DOM node a `title` attribute so users get a browser-native tooltip when hovering the cell.

This work was done to support [DCOS-39095](https://jira.mesosphere.com/browse/DCOS-39095) (see Jira comments for better context)

## Screenshots
![TableCellTitleTooltip](https://user-images.githubusercontent.com/2313998/62807886-99e83880-bac4-11e9-8cf2-0c655b626303.gif)

