### PR TITLE
DCOS-56745: allow SpacingBox to set spacing per side

### DIFF
--- a/packages/shared/styles/styleUtils/modifiers/modifierUtils.ts
+++ b/packages/shared/styles/styleUtils/modifiers/modifierUtils.ts
@@ -20,8 +20,7 @@ export type BoxSides =
   | "bottom"
   | "left"
   | "horiz"
-  | "vert"
-  | undefined;
+  | "vert";
 export type SpaceSizes = "xxs" | "xs" | "s" | "m" | "l" | "xl" | "xxl" | "none";
 export type SpaceSize = BreakpointConfig<SpaceSizes>;
 

--- a/packages/styleUtils/modifiers/components/SpacingBox.tsx
+++ b/packages/styleUtils/modifiers/components/SpacingBox.tsx
@@ -16,14 +16,32 @@ interface SpacingBoxProps extends BoxProps {
    * The size of the space to apply. It can set 1 spacing size for all breakpoints, or it can be used to set different spacing values at different viewport width breakpoints
    */
   spacingSize?: SpaceSize;
+  /**
+   * Used to set different spacing values on different sides of the element
+   */
+  spacingSizePerSide?: { [Side in NonNullable<BoxSides>]?: SpaceSize };
 }
 
 const SpacingBox = (props: SpacingBoxProps) => {
-  const { side, spacingSize, className, ...other } = props;
+  const {
+    side = "all",
+    spacingSize,
+    className,
+    spacingSizePerSide,
+    ...other
+  } = props;
+  const paddingStyles = spacingSizePerSide
+    ? Object.keys(spacingSizePerSide).map(sideToSize =>
+        padding(
+          sideToSize as BoxSides,
+          spacingSizePerSide[sideToSize] as SpaceSize
+        )
+      )
+    : padding(side, spacingSize);
 
   return (
     <Box
-      className={cx(className, padding(side, spacingSize))}
+      className={cx(className, paddingStyles)}
       dataCy="spacingBox"
       {...other}
     />

--- a/packages/styleUtils/modifiers/stories/SpacingBox.stories.tsx
+++ b/packages/styleUtils/modifiers/stories/SpacingBox.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
-import { withKnobs, select } from "@storybook/addon-knobs";
+import { withKnobs, select, object } from "@storybook/addon-knobs";
 import { withReadme } from "storybook-readme";
 import SpacingBox from "../components/SpacingBox";
 import { outlineDecorator } from "./helpers/outlineDecorator";
@@ -61,6 +61,46 @@ storiesOf("Style utilities/Modifiers/SpacingBox", module)
           small: "m",
           medium: "l",
           jumbo: "xl"
+        }}
+      >
+        Resize your viewport width to see the spacing change
+      </SpacingBox>
+    );
+  })
+  .add("spacingSizePerSide", () => {
+    const defaultValue = {
+      top: "m",
+      bottom: "xs",
+      horiz: "xl"
+    };
+    const spacingSizePerSide = object(
+      "spacingSizePerSide",
+      defaultValue,
+      "spacingSizePerSide"
+    );
+
+    return (
+      <SpacingBox
+        spacingSizePerSide={
+          spacingSizePerSide as { [Side in BoxSides]?: SpaceSize }
+        }
+      >
+        Use the Knobs panel to change the sizes of the spacing per side
+      </SpacingBox>
+    );
+  })
+  .add("responsive spacingSizePerSide", () => {
+    return (
+      <SpacingBox
+        spacingSizePerSide={{
+          vert: {
+            default: "none",
+            medium: "l"
+          },
+          horiz: {
+            default: "none",
+            medium: "xl"
+          }
         }}
       >
         Resize your viewport width to see the spacing change

--- a/packages/styleUtils/modifiers/tests/SpacingBox.test.tsx
+++ b/packages/styleUtils/modifiers/tests/SpacingBox.test.tsx
@@ -36,4 +36,52 @@ describe("SpacingBox", () => {
 
     expect(toJson(component)).toMatchSnapshot();
   });
+
+  it("renders with different spacing on each side", () => {
+    const component = shallow(
+      <SpacingBox
+        tag="div"
+        spacingSizePerSide={{
+          top: "none",
+          right: "xs",
+          bottom: "s",
+          left: "m"
+        }}
+      >
+        content
+      </SpacingBox>
+    );
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders with responsive spacing on each side", () => {
+    const component = shallow(
+      <SpacingBox
+        tag="div"
+        spacingSizePerSide={{
+          top: {
+            default: "none",
+            medium: "xs"
+          },
+          right: {
+            default: "none",
+            medium: "s"
+          },
+          bottom: {
+            default: "none",
+            medium: "m"
+          },
+          left: {
+            default: "none",
+            medium: "l"
+          }
+        }}
+      >
+        content
+      </SpacingBox>
+    );
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/packages/styleUtils/modifiers/tests/__snapshots__/SpacingBox.test.tsx.snap
+++ b/packages/styleUtils/modifiers/tests/__snapshots__/SpacingBox.test.tsx.snap
@@ -42,6 +42,95 @@ exports[`SpacingBox renders with all props 1`] = `
 </Box>
 `;
 
+exports[`SpacingBox renders with different spacing on each side 1`] = `
+.emotion-0 {
+  padding-top: 0;
+  padding-right: 8px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+}
+
+<Box
+  bgImageOptions={
+    Object {
+      "position": undefined,
+      "repeat": undefined,
+      "size": undefined,
+    }
+  }
+  className="emotion-0"
+  dataCy="spacingBox"
+  tag="div"
+>
+  content
+</Box>
+`;
+
+exports[`SpacingBox renders with responsive spacing on each side 1`] = `
+@media (min-width:0) {
+  .emotion-0 {
+    padding-top: 0;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    padding-top: 8px;
+  }
+}
+
+@media (min-width:0) {
+  .emotion-0 {
+    padding-right: 0;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    padding-right: 12px;
+  }
+}
+
+@media (min-width:0) {
+  .emotion-0 {
+    padding-bottom: 0;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    padding-bottom: 16px;
+  }
+}
+
+@media (min-width:0) {
+  .emotion-0 {
+    padding-left: 0;
+  }
+}
+
+@media (min-width:900px) {
+  .emotion-0 {
+    padding-left: 24px;
+  }
+}
+
+<Box
+  bgImageOptions={
+    Object {
+      "position": undefined,
+      "repeat": undefined,
+      "size": undefined,
+    }
+  }
+  className="emotion-0"
+  dataCy="spacingBox"
+  tag="div"
+>
+  content
+</Box>
+`;
+
 exports[`SpacingBox renders with responsive spacingSize 1`] = `
 @media (min-width:0) {
   .emotion-0 {


### PR DESCRIPTION
There was a case in Kommander where I needed spacing on all sides but the bottom, and I think we'll also have situations where we want one spacing value for the left and right sides,  but a different spacing value for the top and bottom sides.

## Screenshot
![Screen Shot 2019-08-15 at 7 48 52 PM](https://user-images.githubusercontent.com/2313998/63134286-c73a5800-bf96-11e9-823f-8f04d6e52033.png)
