### PR TITLE
fix: prevent gridlist cell content from overflowing

### DIFF
--- a/packages/styleUtils/layout/gridList/style.ts
+++ b/packages/styleUtils/layout/gridList/style.ts
@@ -7,7 +7,9 @@ export const gridColumnTemplate = columnCount => {
           acc[breakpoint] = `repeat(${columnCount[breakpoint]}, 1fr)`;
           return acc;
         }, {})
-      : `repeat(${columnCount}, 1fr)`;
+      : `repeat(${columnCount}, minmax(0, 1fr))`;
+  // 👆explicitly setting the min to 0 so content doesn't overflow the grid cell
+  // see: https://github.com/rachelandrew/cssgrid-ama/issues/25
 
   return getResponsiveStyle("grid-template-columns", gridTemplateColumns);
 };

--- a/packages/styleUtils/layout/gridList/tests/__snapshots__/GridList.test.tsx.snap
+++ b/packages/styleUtils/layout/gridList/tests/__snapshots__/GridList.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`GridList renders default 1`] = `
 .emotion-0 {
   display: grid;
   grid-gap: 16px;
-  grid-template-columns: repeat(2,1fr);
+  grid-template-columns: repeat(2,minmax(0,1fr));
   list-style: none;
   margin-left: 0;
   margin-top: 0;
@@ -29,7 +29,7 @@ exports[`GridList renders with all props 1`] = `
 .emotion-0 {
   display: grid;
   grid-gap: 24px;
-  grid-template-columns: repeat(2,1fr);
+  grid-template-columns: repeat(2,minmax(0,1fr));
   list-style: none;
   margin-left: 0;
   margin-top: 0;


### PR DESCRIPTION
## Screenshots

Before:
<img width="626" alt="Screen Shot 2019-08-29 at 5 28 34 PM" src="https://user-images.githubusercontent.com/2313998/63982641-40ef3d00-ca91-11e9-95ed-307c0bdd1584.png">

After:
<img width="627" alt="Screen Shot 2019-08-29 at 5 28 12 PM" src="https://user-images.githubusercontent.com/2313998/63982650-451b5a80-ca91-11e9-928d-ae50bb2979c3.png">
