### PR TITLE
DCOS-57982: component for rendering badges in a text input

### DIFF
--- a/packages/badge/components/badge.tsx
+++ b/packages/badge/components/badge.tsx
@@ -1,14 +1,16 @@
 import * as React from "react";
 import { badge } from "../style";
 
+export type BadgeAppearance =
+  | "default"
+  | "success"
+  | "primary"
+  | "warning"
+  | "danger"
+  | "outline";
+
 export interface BadgeProps {
-  appearance?:
-    | "default"
-    | "success"
-    | "primary"
-    | "warning"
-    | "danger"
-    | "outline";
+  appearance?: BadgeAppearance;
   children: JSX.Element | string;
 }
 

--- a/packages/badge/style.ts
+++ b/packages/badge/style.ts
@@ -16,6 +16,7 @@ import getCSSVarValue from "../utilities/components/getCSSVarValue";
 
 const badgeAppearanceStyle = (color, isOutlined?: boolean) => {
   const bgColor = isOutlined ? getCSSVarValue(themeBgPrimary) : color;
+
   return css`
     background-color: ${bgColor};
     border-color: ${color};

--- a/packages/selectInput/components/SelectInput.tsx
+++ b/packages/selectInput/components/SelectInput.tsx
@@ -4,7 +4,8 @@ import { select, selectIcon, selectContainer } from "../style";
 import {
   inputContainer,
   getInputAppearanceStyle,
-  getLabelStyle
+  getLabelStyle,
+  getIconAppearanceStyle
 } from "../../shared/styles/formStyles";
 import {
   inputReset,
@@ -158,7 +159,13 @@ class SelectInput extends React.PureComponent<
                   /* tslint:enable */
                 ))}
               </select>
-              <span className={cx(selectIcon, padding("horiz", "m"))}>
+              <span
+                className={cx(
+                  selectIcon,
+                  padding("horiz", "m"),
+                  getIconAppearanceStyle(this.getInputAppearance())
+                )}
+              >
                 <Icon
                   shape={SystemIcons.TriangleDown}
                   size={iconSizeXs}

--- a/packages/shared/styles/formStyles.ts
+++ b/packages/shared/styles/formStyles.ts
@@ -25,6 +25,7 @@ const getFocusFieldBg = color => hexToRgbA(color, 0.05);
 
 const toggleInputHeight = 16;
 const toggleInputBorderWidth = 1;
+export const textInputHeight = 36;
 
 export const toggleInput = css`
   border-color: ${themeBorder};
@@ -70,23 +71,67 @@ export const toggleInputApperances = {
   `
 };
 
+export const getIconAppearanceStyle = appearance => {
+  switch (appearance) {
+    case "standard":
+      return css`
+        svg {
+          fill: ${themeTextColorPrimary};
+        }
+      `;
+    case "disabled":
+      return css`
+        svg {
+          fill: ${themeTextColorDisabled};
+        }
+      `;
+    case "error":
+      return css`
+        svg {
+          fill: ${themeError};
+        }
+      `;
+    case "success":
+      return css`
+        svg {
+          fill: ${themeSuccess};
+        }
+      `;
+    case "standard-focus":
+      return css`
+        svg {
+          fill: ${themeBrandPrimary};
+        }
+      `;
+    case "error-focus":
+      return css`
+        svg {
+          fill: ${themeError};
+        }
+      `;
+    case "success-focus":
+      return css`
+        svg {
+          fill: ${themeSuccess};
+        }
+      `;
+    default:
+      return "";
+  }
+};
+
 export const getInputAppearanceStyle = appearance => {
   switch (appearance) {
     case "standard":
       return css`
         background-color: ${themeBgPrimary};
         border-color: ${themeBorder};
-        svg {
-          fill: ${themeTextColorPrimary};
-        }
+
         &:focus {
           background-color: ${getFocusFieldBg(
             getCSSVarValue(themeBrandPrimary)
           )};
           border-color: ${themeBrandPrimary};
-          svg {
-            fill: ${themeBrandPrimary};
-          }
         }
       `;
     case "disabled":
@@ -94,12 +139,11 @@ export const getInputAppearanceStyle = appearance => {
         background-color: ${themeBgDisabled};
         border-color: ${themeBgDisabled};
         color: ${themeTextColorDisabled};
-        svg {
-          fill: ${themeTextColorDisabled};
-        }
+
         &::placeholder {
           color: ${themeTextColorDisabled};
         }
+
         input {
           color: ${themeTextColorDisabled};
           ::placeholder {
@@ -111,9 +155,7 @@ export const getInputAppearanceStyle = appearance => {
       return css`
         background-color: ${themeBgPrimary};
         border-color: ${themeError};
-        svg {
-          fill: ${themeError};
-        }
+
         &:focus {
           background-color: ${getFocusFieldBg(getCSSVarValue(themeError))};
         }
@@ -122,9 +164,7 @@ export const getInputAppearanceStyle = appearance => {
       return css`
         background-color: ${themeBgPrimary};
         border-color: ${themeSuccess};
-        svg {
-          fill: ${themeSuccess};
-        }
+
         &:focus {
           background-color: ${getFocusFieldBg(getCSSVarValue(themeSuccess))};
         }
@@ -133,25 +173,16 @@ export const getInputAppearanceStyle = appearance => {
       return css`
         background-color: ${getFocusFieldBg(getCSSVarValue(themeBrandPrimary))};
         border-color: ${themeBrandPrimary};
-        svg {
-          fill: ${themeBrandPrimary};
-        }
       `;
     case "error-focus":
       return css`
         background-color: ${getFocusFieldBg(getCSSVarValue(themeError))};
         border-color: ${themeError};
-        svg {
-          fill: ${themeError};
-        }
       `;
     case "success-focus":
       return css`
         background-color: ${getFocusFieldBg(getCSSVarValue(themeSuccess))};
         border-color: ${themeSuccess};
-        svg {
-          fill: ${themeSuccess};
-        }
       `;
     default:
       return "";
@@ -162,7 +193,7 @@ export const inputContainer = css`
   border: 1px solid;
   border-radius: ${borderRadiusSmall};
   color: inherit;
-  height: 36px;
+  height: ${textInputHeight}px;
   font-size: inherit;
   ${padding("horiz", "m")};
   &::placeholder {

--- a/packages/textInput/README.md
+++ b/packages/textInput/README.md
@@ -29,3 +29,6 @@ If the `tooltipContent` prop is set, an icon tooltip with the given text will be
 
 ## TextInputWithIcon
 `TextInputWithIcon` extends the `TextInput` component but adds two additional props, `iconStart` & `iconEnd`. These props can be provided a `ReactNode` to be rendered either at the start or end of the `TextInput` or both.
+
+## TextInputWithBadges
+`TextInputWithBadges` extends the `TextInputWithIcon` component. More info coming soon...

--- a/packages/textInput/components/TextInputWithBadges.tsx
+++ b/packages/textInput/components/TextInputWithBadges.tsx
@@ -1,0 +1,201 @@
+import * as React from "react";
+import { cx } from "emotion";
+import FormFieldWrapper from "../../shared/components/FormFieldWrapper";
+import {
+  getInputAppearanceStyle,
+  inputContainer
+} from "../../shared/styles/formStyles";
+import { Badge } from "../../badge";
+import { flex, textTruncate } from "../../shared/styles/styleUtils";
+import {
+  badgeInput,
+  badgeInputContainer,
+  badgeInputContents,
+  badgeText
+} from "../style";
+import { Flex, FlexItem } from "../../styleUtils/layout";
+import { SystemIcons } from "../../icons/dist/system-icons-enum";
+import { iconSizeXxs } from "../../design-tokens/build/js/designTokens";
+import { Icon } from "../../icon";
+import Clickable from "../../clickable/components/clickable";
+import { TextInputWithIconProps } from "./TextInputWithIcon";
+import { TextInputWithIcon } from "..";
+import { BadgeAppearance } from "../../badge/components/badge";
+import { StateChangeOptions } from "downshift";
+
+export interface BadgeDatum {
+  value: string;
+  label: React.ReactNode;
+}
+
+interface TextInputWithBadgesProps extends TextInputWithIconProps {
+  badges?: BadgeDatum[];
+  onBadgeChange?: (
+    currentBadges: BadgeDatum[],
+    affectedBadge?: BadgeDatum // the badge to add or delete
+  ) => void;
+  downshiftReset?: (
+    otherStateToSet?: Partial<StateChangeOptions<string>>,
+    cb?: () => void
+  ) => void;
+  badgeAppearance?: BadgeAppearance;
+}
+
+export const getStringAsBadgeDatum = (
+  badgeLabelString: string
+): BadgeDatum => ({
+  label: badgeLabelString,
+  value: badgeLabelString
+});
+
+export class TextInputWithBadges extends TextInputWithIcon<
+  TextInputWithBadgesProps,
+  {}
+> {
+  private inputRef = React.createRef<HTMLInputElement>();
+
+  constructor(props) {
+    super(props);
+
+    this.handleKeyUp = this.handleKeyUp.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.handleTagAdd = this.handleTagAdd.bind(this);
+    this.handleTagDelete = this.handleTagDelete.bind(this);
+  }
+
+  protected getInputElementProps() {
+    let baseProps = super.getInputElementProps();
+    const {
+      badges,
+      onBadgeChange,
+      downshiftReset,
+      ...inputProps
+    } = baseProps as TextInputWithBadgesProps;
+    inputProps.onKeyDown = this.handleKeyDown;
+    inputProps.onKeyUp = this.handleKeyUp;
+    inputProps.type = "text";
+    inputProps.ref = this.inputRef;
+    return inputProps;
+  }
+
+  protected getInputContent() {
+    const inputAppearance = this.getInputAppearance();
+    const { badgeAppearance = "primary" } = this.props;
+    return (
+      <FormFieldWrapper
+        id={this.props.id}
+        errors={this.props.errors}
+        hintContent={this.props.hintContent}
+      >
+        {({ getValidationErrors, getHintContent, isValid, describedByIds }) => (
+          <React.Fragment>
+            <div
+              className={cx(
+                flex({ wrap: "wrap" }),
+                inputContainer,
+                badgeInputContainer,
+                getInputAppearanceStyle(inputAppearance)
+              )}
+            >
+              {this.props.badges &&
+                this.props.badges.map(badge => (
+                  <span
+                    className={badgeInputContents}
+                    key={`${badge.value}-badgeWrapper`}
+                  >
+                    <Badge appearance={badgeAppearance}>
+                      <Flex align="center" gutterSize="xxs">
+                        <FlexItem>
+                          <div className={cx(textTruncate, badgeText)}>
+                            {typeof badge.label === "string"
+                              ? badge.label.replace(/\s/g, "\u00a0")
+                              : badge.label}
+                          </div>
+                        </FlexItem>
+                        <FlexItem flex="shrink">
+                          <Clickable
+                            action={this.onBadgeClose.bind(this, badge)}
+                          >
+                            <span>
+                              <Icon
+                                shape={SystemIcons.Close}
+                                size={iconSizeXxs}
+                              />
+                            </span>
+                          </Clickable>
+                        </FlexItem>
+                      </Flex>
+                    </Badge>
+                  </span>
+                ))}
+              {this.getInputElement(
+                [badgeInput, badgeInputContents],
+                isValid,
+                describedByIds
+              )}
+            </div>
+            {getHintContent}
+            {getValidationErrors}
+          </React.Fragment>
+        )}
+      </FormFieldWrapper>
+    );
+  }
+
+  private handleTagDelete(tagToDelete: BadgeDatum) {
+    const { onBadgeChange, badges = [] } = this.props;
+
+    if (onBadgeChange) {
+      onBadgeChange(
+        badges.filter(badge => badge.value !== tagToDelete.value),
+        tagToDelete
+      );
+    }
+  }
+
+  private handleTagAdd(tagToAdd: BadgeDatum) {
+    const { onBadgeChange, badges = [] } = this.props;
+    const badgeValues = badges.map(badge => badge.value);
+
+    if (this.props.downshiftReset) {
+      this.props.downshiftReset();
+    }
+
+    if (
+      onBadgeChange &&
+      tagToAdd.value.replace(/\s/g, "").length &&
+      !badgeValues.includes(tagToAdd.value)
+    ) {
+      onBadgeChange([...badges, tagToAdd], tagToAdd);
+      if (this.inputRef && this.inputRef.current) {
+        this.inputRef.current.value = "";
+      }
+    }
+  }
+
+  private handleKeyDown(e) {
+    if (!e.target.value && e.key === "Backspace" && this.props.badges) {
+      this.handleTagDelete(this.props.badges[this.props.badges.length - 1]);
+    }
+
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(e);
+    }
+  }
+
+  private handleKeyUp(e) {
+    if (e.key === "Enter") {
+      this.handleTagAdd(getStringAsBadgeDatum(e.target.value));
+    }
+
+    if (this.props.onKeyUp) {
+      this.props.onKeyUp(e);
+    }
+  }
+
+  private onBadgeClose(clickedTag) {
+    this.handleTagDelete(clickedTag);
+  }
+}
+
+export default TextInputWithBadges;

--- a/packages/textInput/components/TextInputWithIcon.tsx
+++ b/packages/textInput/components/TextInputWithIcon.tsx
@@ -5,7 +5,8 @@ import { TextInput, TextInputProps } from "./TextInput";
 
 import {
   getInputAppearanceStyle,
-  inputContainer
+  inputContainer,
+  getIconAppearanceStyle
 } from "../../shared/styles/formStyles";
 import { flex, flexItem, flush, padding } from "../../shared/styles/styleUtils";
 import FormFieldWrapper from "../../shared/components/FormFieldWrapper";
@@ -23,13 +24,13 @@ export interface TextInputWithIconProps extends TextInputProps {
 }
 
 export interface TextInputWithIconState {
-  hasFocus: boolean;
+  hasFocus?: boolean;
 }
 
-export class TextInputWithIcon extends TextInput<
-  TextInputWithIconProps,
-  TextInputWithIconState
-> {
+export class TextInputWithIcon<
+  P extends TextInputWithIconProps,
+  S extends TextInputWithIconState
+> extends TextInput<P, S> {
   public static defaultProps: Partial<TextInputWithIconProps> = {
     type: "text",
     appearance: InputAppearance.Standard,
@@ -41,6 +42,9 @@ export class TextInputWithIcon extends TextInput<
     this.inputOnFocus = this.inputOnFocus.bind(this);
     this.inputOnBlur = this.inputOnBlur.bind(this);
 
+    // I can't find a workaround for this issue:
+    // https://stackoverflow.com/questions/51074355/cannot-assign-to-state-because-it-is-a-constant-or-a-read-only-property
+    // @ts-ignore
     this.state = {
       hasFocus: false
     };
@@ -77,7 +81,8 @@ export class TextInputWithIcon extends TextInput<
         className={cx(
           padding("right", "xs"),
           flex({ align: "center", justify: "center" }),
-          flexItem("shrink")
+          flexItem("shrink"),
+          getIconAppearanceStyle(this.getInputAppearance())
         )}
       >
         {this.props.iconStart}
@@ -94,7 +99,8 @@ export class TextInputWithIcon extends TextInput<
         className={cx(
           flex({ align: "center", justify: "center" }),
           flexItem("shrink"),
-          flush("left")
+          flush("left"),
+          getIconAppearanceStyle(this.getInputAppearance())
         )}
       >
         {this.props.iconEnd}

--- a/packages/textInput/index.ts
+++ b/packages/textInput/index.ts
@@ -1,2 +1,5 @@
 export { default as TextInput } from "./components/TextInput";
 export { default as TextInputWithIcon } from "./components/TextInputWithIcon";
+export {
+  default as TextInputWithBadges
+} from "./components/TextInputWithBadges";

--- a/packages/textInput/stories/TextInputWithBadges.stories.tsx
+++ b/packages/textInput/stories/TextInputWithBadges.stories.tsx
@@ -1,0 +1,144 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import { TextInputWithBadges } from "../index";
+import { inputStoryWrapper } from "../../../decorators/inputStoryWrapper";
+import TextInputWithBadgesStoryHelper from "./helpers/TextInputWithBadgesStoryHelper";
+import { Typeahead } from "../../typeahead";
+import TextInputWithBadgesTypeaheadStoryHelper from "./helpers/TextInputWithBadgesTypeaheadStoryHelper";
+
+const readme = require("../README.md");
+
+const typeaheadItems = [
+  { value: "exosphere", label: "Exosphere" },
+  { value: "thermosphere", label: "Thermosphere" },
+  { value: "mesosphere", label: "Mesosphere" },
+  { value: "stratosphere", label: "Stratosphere" },
+  { value: "ozone-layer", label: "Ozone Layer" },
+  { value: "troposphere", label: "Troposphere" }
+];
+
+const defaultBadges = [
+  {
+    label: "Badge one",
+    value: "badge-one"
+  },
+  {
+    label: "Badge two",
+    value: "badge-two"
+  },
+  {
+    label: "Badge three",
+    value: "badge-three"
+  }
+];
+
+storiesOf("Forms/TextInputWithBadges", module)
+  .addDecorator(withReadme([readme]))
+  .addDecorator(inputStoryWrapper)
+  .add("default", () => (
+    <TextInputWithBadgesStoryHelper>
+      {({ badges, badgeChangeHandler }) => (
+        <TextInputWithBadges
+          id="default"
+          inputLabel="Default"
+          onBadgeChange={badgeChangeHandler}
+          badges={badges}
+        />
+      )}
+    </TextInputWithBadgesStoryHelper>
+  ))
+  .add("pre-filled w/ badges", () => (
+    <TextInputWithBadgesStoryHelper badges={defaultBadges}>
+      {({ badges, badgeChangeHandler }) => (
+        <TextInputWithBadges
+          id="prefilled"
+          inputLabel="Pre-filled"
+          badges={badges}
+          onBadgeChange={badgeChangeHandler}
+        />
+      )}
+    </TextInputWithBadgesStoryHelper>
+  ))
+  .add("custom badge appearance", () => (
+    <TextInputWithBadgesStoryHelper badges={defaultBadges}>
+      {({ badges, badgeChangeHandler }) => (
+        <TextInputWithBadges
+          id="appearance"
+          inputLabel="Success badges"
+          badges={badges}
+          onBadgeChange={badgeChangeHandler}
+          badgeAppearance="success"
+        />
+      )}
+    </TextInputWithBadgesStoryHelper>
+  ))
+  .add("used w/ a Typeahead", () => (
+    <TextInputWithBadgesTypeaheadStoryHelper items={typeaheadItems}>
+      {({
+        items,
+        selectHandler,
+        selectedItems,
+        badgeChangeHandler,
+        badges
+      }) => {
+        return (
+          <Typeahead
+            // removes items from the Typeahead that already exist in the badge input
+            items={items.filter(
+              item => !badges.map(badge => badge.value).includes(item.value)
+            )}
+            selectedItems={selectedItems}
+            keepOpenOnSelect={false}
+            resetInputOnSelect={true}
+            textField={
+              <TextInputWithBadges
+                id="typeahead.default"
+                inputLabel="Typeahead"
+                placeholder={badges.length ? "" : "Placeholder"}
+                badges={badges}
+                onBadgeChange={badgeChangeHandler}
+              />
+            }
+            onSelect={selectHandler}
+          />
+        );
+      }}
+    </TextInputWithBadgesTypeaheadStoryHelper>
+  ))
+  .add("used w/ a Typeahead + prefilled w/ badges", () => (
+    <TextInputWithBadgesTypeaheadStoryHelper
+      items={typeaheadItems}
+      badges={[typeaheadItems[0], typeaheadItems[1], typeaheadItems[2]]}
+    >
+      {({
+        items,
+        selectHandler,
+        selectedItems,
+        badgeChangeHandler,
+        badges
+      }) => {
+        return (
+          <Typeahead
+            // removes items from the Typeahead that already exist in the badge input
+            items={items.filter(
+              item => !badges.map(badge => badge.value).includes(item.value)
+            )}
+            selectedItems={selectedItems}
+            keepOpenOnSelect={false}
+            resetInputOnSelect={true}
+            textField={
+              <TextInputWithBadges
+                id="typeahead.prefilled"
+                inputLabel="Pre-filled Typeahead"
+                placeholder={badges.length ? "" : "Placeholder"}
+                badges={badges}
+                onBadgeChange={badgeChangeHandler}
+              />
+            }
+            onSelect={selectHandler}
+          />
+        );
+      }}
+    </TextInputWithBadgesTypeaheadStoryHelper>
+  ));

--- a/packages/textInput/stories/helpers/TextInputWithBadgesStoryHelper.tsx
+++ b/packages/textInput/stories/helpers/TextInputWithBadgesStoryHelper.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { BadgeDatum } from "../../components/TextInputWithBadges";
+
+interface RenderProps {
+  badges: BadgeDatum[];
+  badgeChangeHandler: (badges: BadgeDatum[]) => void;
+}
+
+interface TextInputWithBadgesStoryHelperProps {
+  badges?: BadgeDatum[];
+  children: (renderProps: RenderProps) => React.ReactNode;
+}
+
+interface TextInputWithBadgesStoryHelperState {
+  badges: BadgeDatum[];
+}
+
+class TextInputWithBadgesStoryHelper extends React.PureComponent<
+  TextInputWithBadgesStoryHelperProps,
+  TextInputWithBadgesStoryHelperState
+> {
+  constructor(props) {
+    super(props);
+
+    this.badgeChangeHandler = this.badgeChangeHandler.bind(this);
+
+    this.state = {
+      badges: props.badges || []
+    };
+  }
+
+  badgeChangeHandler(badges) {
+    this.setState({ badges });
+  }
+
+  render() {
+    return this.props.children({
+      badges: this.state.badges,
+      badgeChangeHandler: this.badgeChangeHandler
+    });
+  }
+}
+
+export default TextInputWithBadgesStoryHelper;

--- a/packages/textInput/stories/helpers/TextInputWithBadgesTypeaheadStoryHelper.tsx
+++ b/packages/textInput/stories/helpers/TextInputWithBadgesTypeaheadStoryHelper.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import { Item } from "../../../typeahead/components/Typeahead";
+import { BadgeDatum } from "../../components/TextInputWithBadges";
+import { items } from "../../../typeahead/stories/helpers/itemMocks";
+
+interface RenderProps {
+  selectedItems: string[];
+  selectHandler: (selectedItems: string[], lastSelectedItem?: string) => void;
+  badges: BadgeDatum[];
+  badgeChangeHandler: (
+    badges: BadgeDatum[],
+    lastAddedBadge: BadgeDatum
+  ) => void;
+  items: Item[];
+}
+
+interface Props {
+  badges?: BadgeDatum[];
+  children: (renderProps: RenderProps) => React.ReactNode;
+  items: Item[];
+}
+
+interface State {
+  selectedItems: string[];
+  badges: BadgeDatum[];
+  items: Item[];
+}
+
+class TextInputWithBadgesTypeaheadStoryHelper extends React.PureComponent<
+  Props,
+  State
+> {
+  constructor(props) {
+    super(props);
+
+    this.badgeChangeHandler = this.badgeChangeHandler.bind(this);
+    this.selectHandler = this.selectHandler.bind(this);
+
+    this.state = {
+      selectedItems: props.selectedItems || [],
+      badges: props.badges || [],
+      items: props.items || []
+    };
+  }
+
+  selectHandler(selectedItems, lastSelectedItem) {
+    const itemDataFromItemsArray = () => {
+      if (!this.state.badges.some(badge => badge.value === lastSelectedItem)) {
+        return this.props.items.filter(item => item.value === lastSelectedItem);
+      }
+      return [];
+    };
+
+    this.setState({
+      selectedItems,
+      badges: [
+        ...this.state.badges.filter(item => item.value !== lastSelectedItem),
+        ...itemDataFromItemsArray()
+      ]
+    });
+  }
+
+  badgeChangeHandler(badges) {
+    this.setState({
+      badges,
+      selectedItems: badges.map(badge => badge.value)
+    });
+  }
+
+  getItems(value, checked) {
+    const selectedItems = this.state.items || [];
+
+    if (checked) {
+      return [...items, value];
+    }
+
+    return selectedItems.filter(selectedItem => selectedItem !== value);
+  }
+
+  render() {
+    const { children } = this.props;
+    const { selectedItems, badges, items } = this.state;
+
+    return children({
+      selectHandler: this.selectHandler,
+      badgeChangeHandler: this.badgeChangeHandler,
+      badges,
+      selectedItems,
+      items
+    });
+  }
+}
+
+export default TextInputWithBadgesTypeaheadStoryHelper;

--- a/packages/textInput/style.ts
+++ b/packages/textInput/style.ts
@@ -1,0 +1,35 @@
+import { css } from "emotion";
+import { spaceXs } from "../design-tokens/build/js/designTokens";
+import { textInputHeight } from "../shared/styles/formStyles";
+
+const badgeGapSize = spaceXs;
+
+export const badgeInputContainer = css`
+  height: auto;
+  min-height: ${textInputHeight}px;
+  padding-bottom: ${parseInt(badgeGapSize, 10) / 2}px;
+  padding-top: ${parseInt(badgeGapSize, 10) / 2}px;
+`;
+
+export const badgeText = css`
+  white-space: nowrap;
+`;
+
+export const badgeInputContents = css`
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-bottom: ${parseInt(badgeGapSize, 10) / 2}px;
+  padding-top: ${parseInt(badgeGapSize, 10) / 2}px;
+  padding-right: ${badgeGapSize};
+
+  &,
+  * {
+    max-width: 100%;
+  }
+`;
+
+export const badgeInput = css`
+  flex-grow: 1;
+  min-width: 50px;
+`;

--- a/packages/textInput/tests/TextInputWithBadges.test.tsx
+++ b/packages/textInput/tests/TextInputWithBadges.test.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import * as emotion from "emotion";
+import { createSerializer } from "jest-emotion";
+import { mount } from "enzyme";
+import toJson from "enzyme-to-json";
+
+import TextInputWithBadges, {
+  getStringAsBadgeDatum
+} from "../components/TextInputWithBadges";
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+const defaultBadges = [
+  {
+    label: "Badge one",
+    value: "badge-one"
+  },
+  {
+    label: "Badge two",
+    value: "badge-two"
+  },
+  {
+    label: "Badge three",
+    value: "badge-three"
+  }
+];
+
+describe("TextInputWithBadges", () => {
+  it("renders empty", () => {
+    const component = mount(
+      <TextInputWithBadges id="empty" inputLabel="empty" />
+    );
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders with badges", () => {
+    const component = mount(
+      <TextInputWithBadges
+        id="withBadges"
+        inputLabel="With badges"
+        badges={defaultBadges}
+      />
+    );
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("renders badges with custom BadgeAppearance", () => {
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        badges={defaultBadges}
+      />
+    );
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
+
+  it("calls onBadgeChange with the badge data and input value when keying enter", () => {
+    const badgeChangeHandler = jest.fn();
+    const inputValue = "some value";
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        value={inputValue}
+        onBadgeChange={badgeChangeHandler}
+      />
+    );
+
+    expect(badgeChangeHandler).not.toHaveBeenCalled();
+    component.find("input").simulate("focus");
+    component.find("input").simulate("keyUp", {
+      key: "Enter"
+    });
+
+    // TODO: change this if I decide not to "sanitize" the `value` string
+    expect(badgeChangeHandler).toHaveBeenCalledWith(
+      [getStringAsBadgeDatum(inputValue)],
+      getStringAsBadgeDatum(inputValue)
+    );
+  });
+
+  it("does not call onBadgeChange when keying enter if the input value is undefined", () => {
+    const badgeChangeHandler = jest.fn();
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        onBadgeChange={badgeChangeHandler}
+      />
+    );
+
+    expect(badgeChangeHandler).not.toHaveBeenCalled();
+    component.find("input").simulate("focus");
+    component.find("input").simulate("keyDown", {
+      key: "Enter"
+    });
+    expect(badgeChangeHandler).not.toHaveBeenCalled();
+  });
+
+  it("does not call onBadgeChange when keying enter if the input value is whitespace chars", () => {
+    const badgeChangeHandler = jest.fn();
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        value=" "
+        onBadgeChange={badgeChangeHandler}
+      />
+    );
+
+    expect(badgeChangeHandler).not.toHaveBeenCalled();
+    component.find("input").simulate("focus");
+    component.find("input").simulate("keyDown", {
+      key: "Enter"
+    });
+    expect(badgeChangeHandler).not.toHaveBeenCalled();
+  });
+
+  it("calls onBadgeChange with the badge data when clicking the close icon", () => {
+    const firstBadge = { value: "firstbadge", label: "First badge" };
+    const badgeChangeHandler = jest.fn();
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        badges={[firstBadge, ...defaultBadges]}
+        onBadgeChange={badgeChangeHandler}
+      />
+    );
+
+    expect(badgeChangeHandler).not.toHaveBeenCalled();
+    component
+      .find('[data-cy="badge"]')
+      .first()
+      .find('[aria-label="system-close icon"]')
+      .simulate("click");
+    expect(badgeChangeHandler).toHaveBeenCalledWith(defaultBadges, firstBadge);
+  });
+
+  it("calls onBadgeChange with the last badge's data when keying backspace", () => {
+    const lastBadge = { value: "lastbadge", label: "Last badge" };
+    const badgeChangeHandler = jest.fn();
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        badges={[...defaultBadges, lastBadge]}
+        onBadgeChange={badgeChangeHandler}
+      />
+    );
+
+    expect(badgeChangeHandler).not.toHaveBeenCalled();
+    component.find("input").simulate("focus");
+    component.find("input").simulate("keyDown", {
+      key: "Backspace"
+    });
+    expect(badgeChangeHandler).toHaveBeenCalledWith(defaultBadges, lastBadge);
+  });
+
+  it("calls the input's onKeyDown prop", () => {
+    const onKeyDownFn = jest.fn();
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        onKeyDown={onKeyDownFn}
+      />
+    );
+
+    expect(onKeyDownFn).not.toHaveBeenCalled();
+    component.find("input").simulate("keyDown", {
+      key: "Space"
+    });
+    expect(onKeyDownFn).toHaveBeenCalled();
+  });
+
+  it("calls the input's onKeyUp prop", () => {
+    const onKeyUpFn = jest.fn();
+    const component = mount(
+      <TextInputWithBadges
+        id="appearance"
+        inputLabel="Appearance"
+        onKeyUp={onKeyUpFn}
+      />
+    );
+
+    expect(onKeyUpFn).not.toHaveBeenCalled();
+    component.find("input").simulate("keyUp", {
+      key: "Space"
+    });
+    expect(onKeyUpFn).toHaveBeenCalled();
+  });
+});

--- a/packages/textInput/tests/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInput.test.tsx.snap
@@ -364,17 +364,9 @@ exports[`TextInput should render all appearances focus 1`] = `
   opacity: 0.4;
 }
 
-.emotion-2 svg {
-  fill: var(--themeTextColorPrimary,#1B2029);
-}
-
 .emotion-2:focus {
   background-color: rgba(125,88,255,0.05);
   border-color: var(--themeBrandPrimary,#7D58FF);
-}
-
-.emotion-2:focus svg {
-  fill: var(--themeBrandPrimary,#7D58FF);
 }
 
 <TextInput
@@ -554,10 +546,6 @@ exports[`TextInput should render all appearances focus 2`] = `
   opacity: 0.4;
 }
 
-.emotion-2 svg {
-  fill: var(--themeError,#EB293A);
-}
-
 .emotion-2:focus {
   background-color: rgba(235,41,58,0.05);
 }
@@ -735,10 +723,6 @@ exports[`TextInput should render all appearances focus 3`] = `
 .emotion-2 input::placeholder {
   color: var(--themeTextColorPrimary,#1B2029);
   opacity: 0.4;
-}
-
-.emotion-2 svg {
-  fill: var(--themeSuccess,#14C684);
 }
 
 .emotion-2:focus {

--- a/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
@@ -1,0 +1,1362 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
+.emotion-5 {
+  cursor: pointer;
+}
+
+.emotion-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  padding-right: 8px;
+}
+
+.emotion-9,
+.emotion-9 * {
+  max-width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  padding-top: 0;
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
+}
+
+.emotion-27 {
+  height: auto;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  color: inherit;
+  height: 36px;
+  font-size: inherit;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: auto;
+  min-height: 36px;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  background-color: var(--themeBgPrimary,#FFFFFF);
+  border-color: var(--themeBorder,#DADDE2);
+}
+
+.emotion-27 > div {
+  width: auto;
+}
+
+.emotion-27::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27::-moz-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27::placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input {
+  font-size: inherit;
+  color: inherit;
+}
+
+.emotion-27 input::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input::-moz-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input::placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27:focus {
+  background-color: rgba(125,88,255,0.05);
+  border-color: var(--themeBrandPrimary,#7D58FF);
+}
+
+.emotion-26 {
+  background: none;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  padding-right: 8px;
+}
+
+.emotion-26:focus {
+  outline: 0;
+}
+
+.emotion-26,
+.emotion-26 * {
+  max-width: 100%;
+}
+
+.emotion-2 {
+  overflow: hidden;
+  overflow: -moz-hidden-unscrollable;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  white-space: nowrap;
+}
+
+.emotion-8 {
+  background-color: #7D58FF;
+  border-color: #7D58FF;
+  color: #FFFFFF;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: solid;
+  padding: 0 8px 0;
+  font-size: 80%;
+  line-height: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-rendering: optimizeLegibility;
+  border-radius: 4px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+}
+
+.emotion-7 > div {
+  width: auto;
+}
+
+.emotion-7 > *:not(:first-child) {
+  padding-left: 4px;
+  padding-top: 0;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: initial;
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: currentColor;
+}
+
+.emotion-4 use {
+  pointer-events: none;
+}
+
+<TextInputWithBadges
+  appearance="standard"
+  badges={
+    Array [
+      Object {
+        "label": "Badge one",
+        "value": "badge-one",
+      },
+      Object {
+        "label": "Badge two",
+        "value": "badge-two",
+      },
+      Object {
+        "label": "Badge three",
+        "value": "badge-three",
+      },
+    ]
+  }
+  id="appearance"
+  inputLabel="Appearance"
+  showInputLabel={true}
+  type="text"
+>
+  <div
+    data-cy="textInput"
+  >
+    <div
+      className="emotion-1"
+      data-cy="textInput-label"
+    >
+      <label
+        className="emotion-0"
+        htmlFor="appearance"
+      >
+        Appearance
+      </label>
+    </div>
+    <FormFieldWrapper
+      id="appearance"
+    >
+      <div
+        className="emotion-27"
+      >
+        <span
+          className="emotion-9"
+          key="badge-one-badgeWrapper"
+        >
+          <Badge
+            appearance="primary"
+          >
+            <span
+              className="emotion-8"
+              data-cy="badge"
+            >
+              <Flex
+                align="center"
+                direction="row"
+                gutterSize="xxs"
+                justify="flex-start"
+                wrap="nowrap"
+              >
+                <div
+                  className="emotion-7"
+                  data-cy="flex"
+                >
+                  <FlexItem
+                    flex="grow"
+                  >
+                    <div
+                      className="emotion-3"
+                      data-cy="flexItem"
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        Badge one
+                      </div>
+                    </div>
+                  </FlexItem>
+                  <FlexItem
+                    flex="shrink"
+                  >
+                    <div
+                      className="emotion-6"
+                      data-cy="flexItem"
+                    >
+                      <Clickable
+                        action={[Function]}
+                        disableFocusOutline={false}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <span
+                          className="emotion-5"
+                          onClick={[Function]}
+                          onKeyPress={[Function]}
+                          role="button"
+                          tabIndex={-1}
+                        >
+                          <Icon
+                            shape="system-close"
+                            size="12px"
+                          >
+                            <svg
+                              aria-label="system-close icon"
+                              className="emotion-4"
+                              data-cy="icon"
+                              height={12}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 12 12"
+                              width={12}
+                            >
+                              <use
+                                xlinkHref="#system-close"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </Clickable>
+                    </div>
+                  </FlexItem>
+                </div>
+              </Flex>
+            </span>
+          </Badge>
+        </span>
+        <span
+          className="emotion-9"
+          key="badge-two-badgeWrapper"
+        >
+          <Badge
+            appearance="primary"
+          >
+            <span
+              className="emotion-8"
+              data-cy="badge"
+            >
+              <Flex
+                align="center"
+                direction="row"
+                gutterSize="xxs"
+                justify="flex-start"
+                wrap="nowrap"
+              >
+                <div
+                  className="emotion-7"
+                  data-cy="flex"
+                >
+                  <FlexItem
+                    flex="grow"
+                  >
+                    <div
+                      className="emotion-3"
+                      data-cy="flexItem"
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        Badge two
+                      </div>
+                    </div>
+                  </FlexItem>
+                  <FlexItem
+                    flex="shrink"
+                  >
+                    <div
+                      className="emotion-6"
+                      data-cy="flexItem"
+                    >
+                      <Clickable
+                        action={[Function]}
+                        disableFocusOutline={false}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <span
+                          className="emotion-5"
+                          onClick={[Function]}
+                          onKeyPress={[Function]}
+                          role="button"
+                          tabIndex={-1}
+                        >
+                          <Icon
+                            shape="system-close"
+                            size="12px"
+                          >
+                            <svg
+                              aria-label="system-close icon"
+                              className="emotion-4"
+                              data-cy="icon"
+                              height={12}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 12 12"
+                              width={12}
+                            >
+                              <use
+                                xlinkHref="#system-close"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </Clickable>
+                    </div>
+                  </FlexItem>
+                </div>
+              </Flex>
+            </span>
+          </Badge>
+        </span>
+        <span
+          className="emotion-9"
+          key="badge-three-badgeWrapper"
+        >
+          <Badge
+            appearance="primary"
+          >
+            <span
+              className="emotion-8"
+              data-cy="badge"
+            >
+              <Flex
+                align="center"
+                direction="row"
+                gutterSize="xxs"
+                justify="flex-start"
+                wrap="nowrap"
+              >
+                <div
+                  className="emotion-7"
+                  data-cy="flex"
+                >
+                  <FlexItem
+                    flex="grow"
+                  >
+                    <div
+                      className="emotion-3"
+                      data-cy="flexItem"
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        Badge three
+                      </div>
+                    </div>
+                  </FlexItem>
+                  <FlexItem
+                    flex="shrink"
+                  >
+                    <div
+                      className="emotion-6"
+                      data-cy="flexItem"
+                    >
+                      <Clickable
+                        action={[Function]}
+                        disableFocusOutline={false}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <span
+                          className="emotion-5"
+                          onClick={[Function]}
+                          onKeyPress={[Function]}
+                          role="button"
+                          tabIndex={-1}
+                        >
+                          <Icon
+                            shape="system-close"
+                            size="12px"
+                          >
+                            <svg
+                              aria-label="system-close icon"
+                              className="emotion-4"
+                              data-cy="icon"
+                              height={12}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 12 12"
+                              width={12}
+                            >
+                              <use
+                                xlinkHref="#system-close"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </Clickable>
+                    </div>
+                  </FlexItem>
+                </div>
+              </Flex>
+            </span>
+          </Badge>
+        </span>
+        <input
+          aria-describedby=""
+          aria-invalid={false}
+          className="emotion-26"
+          data-cy="textInput-input"
+          id="appearance"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          type="text"
+        />
+      </div>
+    </FormFieldWrapper>
+  </div>
+</TextInputWithBadges>
+`;
+
+exports[`TextInputWithBadges renders empty 1`] = `
+.emotion-0 {
+  display: block;
+  padding-top: 0;
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
+}
+
+.emotion-3 {
+  height: auto;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  color: inherit;
+  height: 36px;
+  font-size: inherit;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: auto;
+  min-height: 36px;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  background-color: var(--themeBgPrimary,#FFFFFF);
+  border-color: var(--themeBorder,#DADDE2);
+}
+
+.emotion-3 > div {
+  width: auto;
+}
+
+.emotion-3::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3::-moz-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3::placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3 input {
+  font-size: inherit;
+  color: inherit;
+}
+
+.emotion-3 input::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3 input::-moz-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3 input:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3 input::placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-3:focus {
+  background-color: rgba(125,88,255,0.05);
+  border-color: var(--themeBrandPrimary,#7D58FF);
+}
+
+.emotion-2 {
+  background: none;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  padding-right: 8px;
+}
+
+.emotion-2:focus {
+  outline: 0;
+}
+
+.emotion-2,
+.emotion-2 * {
+  max-width: 100%;
+}
+
+<TextInputWithBadges
+  appearance="standard"
+  id="empty"
+  inputLabel="empty"
+  showInputLabel={true}
+  type="text"
+>
+  <div
+    data-cy="textInput"
+  >
+    <div
+      className="emotion-1"
+      data-cy="textInput-label"
+    >
+      <label
+        className="emotion-0"
+        htmlFor="empty"
+      >
+        empty
+      </label>
+    </div>
+    <FormFieldWrapper
+      id="empty"
+    >
+      <div
+        className="emotion-3"
+      >
+        <input
+          aria-describedby=""
+          aria-invalid={false}
+          className="emotion-2"
+          data-cy="textInput-input"
+          id="empty"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          type="text"
+        />
+      </div>
+    </FormFieldWrapper>
+  </div>
+</TextInputWithBadges>
+`;
+
+exports[`TextInputWithBadges renders with badges 1`] = `
+.emotion-5 {
+  cursor: pointer;
+}
+
+.emotion-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  padding-right: 8px;
+}
+
+.emotion-9,
+.emotion-9 * {
+  max-width: 100%;
+}
+
+.emotion-0 {
+  display: block;
+  padding-top: 0;
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+}
+
+.emotion-1 > div {
+  width: auto;
+}
+
+.emotion-27 {
+  height: auto;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  border: 1px solid;
+  border-radius: 4px;
+  color: inherit;
+  height: 36px;
+  font-size: inherit;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: auto;
+  min-height: 36px;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  background-color: var(--themeBgPrimary,#FFFFFF);
+  border-color: var(--themeBorder,#DADDE2);
+}
+
+.emotion-27 > div {
+  width: auto;
+}
+
+.emotion-27::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27::-moz-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27::placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input {
+  font-size: inherit;
+  color: inherit;
+}
+
+.emotion-27 input::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input::-moz-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27 input::placeholder {
+  color: var(--themeTextColorPrimary,#1B2029);
+  opacity: 0.4;
+}
+
+.emotion-27:focus {
+  background-color: rgba(125,88,255,0.05);
+  border-color: var(--themeBrandPrimary,#7D58FF);
+}
+
+.emotion-26 {
+  background: none;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 50px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-bottom: 4px;
+  padding-top: 4px;
+  padding-right: 8px;
+}
+
+.emotion-26:focus {
+  outline: 0;
+}
+
+.emotion-26,
+.emotion-26 * {
+  max-width: 100%;
+}
+
+.emotion-2 {
+  overflow: hidden;
+  overflow: -moz-hidden-unscrollable;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  white-space: nowrap;
+}
+
+.emotion-8 {
+  background-color: #7D58FF;
+  border-color: #7D58FF;
+  color: #FFFFFF;
+  box-sizing: border-box;
+  border-width: 1px;
+  border-style: solid;
+  padding: 0 8px 0;
+  font-size: 80%;
+  line-height: inherit;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-rendering: optimizeLegibility;
+  border-radius: 4px;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+}
+
+.emotion-7 > div {
+  width: auto;
+}
+
+.emotion-7 > *:not(:first-child) {
+  padding-left: 4px;
+  padding-top: 0;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+}
+
+.emotion-6 {
+  box-sizing: border-box;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: initial;
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: currentColor;
+}
+
+.emotion-4 use {
+  pointer-events: none;
+}
+
+<TextInputWithBadges
+  appearance="standard"
+  badges={
+    Array [
+      Object {
+        "label": "Badge one",
+        "value": "badge-one",
+      },
+      Object {
+        "label": "Badge two",
+        "value": "badge-two",
+      },
+      Object {
+        "label": "Badge three",
+        "value": "badge-three",
+      },
+    ]
+  }
+  id="withBadges"
+  inputLabel="With badges"
+  showInputLabel={true}
+  type="text"
+>
+  <div
+    data-cy="textInput"
+  >
+    <div
+      className="emotion-1"
+      data-cy="textInput-label"
+    >
+      <label
+        className="emotion-0"
+        htmlFor="withBadges"
+      >
+        With badges
+      </label>
+    </div>
+    <FormFieldWrapper
+      id="withBadges"
+    >
+      <div
+        className="emotion-27"
+      >
+        <span
+          className="emotion-9"
+          key="badge-one-badgeWrapper"
+        >
+          <Badge
+            appearance="primary"
+          >
+            <span
+              className="emotion-8"
+              data-cy="badge"
+            >
+              <Flex
+                align="center"
+                direction="row"
+                gutterSize="xxs"
+                justify="flex-start"
+                wrap="nowrap"
+              >
+                <div
+                  className="emotion-7"
+                  data-cy="flex"
+                >
+                  <FlexItem
+                    flex="grow"
+                  >
+                    <div
+                      className="emotion-3"
+                      data-cy="flexItem"
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        Badge one
+                      </div>
+                    </div>
+                  </FlexItem>
+                  <FlexItem
+                    flex="shrink"
+                  >
+                    <div
+                      className="emotion-6"
+                      data-cy="flexItem"
+                    >
+                      <Clickable
+                        action={[Function]}
+                        disableFocusOutline={false}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <span
+                          className="emotion-5"
+                          onClick={[Function]}
+                          onKeyPress={[Function]}
+                          role="button"
+                          tabIndex={-1}
+                        >
+                          <Icon
+                            shape="system-close"
+                            size="12px"
+                          >
+                            <svg
+                              aria-label="system-close icon"
+                              className="emotion-4"
+                              data-cy="icon"
+                              height={12}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 12 12"
+                              width={12}
+                            >
+                              <use
+                                xlinkHref="#system-close"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </Clickable>
+                    </div>
+                  </FlexItem>
+                </div>
+              </Flex>
+            </span>
+          </Badge>
+        </span>
+        <span
+          className="emotion-9"
+          key="badge-two-badgeWrapper"
+        >
+          <Badge
+            appearance="primary"
+          >
+            <span
+              className="emotion-8"
+              data-cy="badge"
+            >
+              <Flex
+                align="center"
+                direction="row"
+                gutterSize="xxs"
+                justify="flex-start"
+                wrap="nowrap"
+              >
+                <div
+                  className="emotion-7"
+                  data-cy="flex"
+                >
+                  <FlexItem
+                    flex="grow"
+                  >
+                    <div
+                      className="emotion-3"
+                      data-cy="flexItem"
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        Badge two
+                      </div>
+                    </div>
+                  </FlexItem>
+                  <FlexItem
+                    flex="shrink"
+                  >
+                    <div
+                      className="emotion-6"
+                      data-cy="flexItem"
+                    >
+                      <Clickable
+                        action={[Function]}
+                        disableFocusOutline={false}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <span
+                          className="emotion-5"
+                          onClick={[Function]}
+                          onKeyPress={[Function]}
+                          role="button"
+                          tabIndex={-1}
+                        >
+                          <Icon
+                            shape="system-close"
+                            size="12px"
+                          >
+                            <svg
+                              aria-label="system-close icon"
+                              className="emotion-4"
+                              data-cy="icon"
+                              height={12}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 12 12"
+                              width={12}
+                            >
+                              <use
+                                xlinkHref="#system-close"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </Clickable>
+                    </div>
+                  </FlexItem>
+                </div>
+              </Flex>
+            </span>
+          </Badge>
+        </span>
+        <span
+          className="emotion-9"
+          key="badge-three-badgeWrapper"
+        >
+          <Badge
+            appearance="primary"
+          >
+            <span
+              className="emotion-8"
+              data-cy="badge"
+            >
+              <Flex
+                align="center"
+                direction="row"
+                gutterSize="xxs"
+                justify="flex-start"
+                wrap="nowrap"
+              >
+                <div
+                  className="emotion-7"
+                  data-cy="flex"
+                >
+                  <FlexItem
+                    flex="grow"
+                  >
+                    <div
+                      className="emotion-3"
+                      data-cy="flexItem"
+                    >
+                      <div
+                        className="emotion-2"
+                      >
+                        Badge three
+                      </div>
+                    </div>
+                  </FlexItem>
+                  <FlexItem
+                    flex="shrink"
+                  >
+                    <div
+                      className="emotion-6"
+                      data-cy="flexItem"
+                    >
+                      <Clickable
+                        action={[Function]}
+                        disableFocusOutline={false}
+                        role="button"
+                        tabIndex={-1}
+                      >
+                        <span
+                          className="emotion-5"
+                          onClick={[Function]}
+                          onKeyPress={[Function]}
+                          role="button"
+                          tabIndex={-1}
+                        >
+                          <Icon
+                            shape="system-close"
+                            size="12px"
+                          >
+                            <svg
+                              aria-label="system-close icon"
+                              className="emotion-4"
+                              data-cy="icon"
+                              height={12}
+                              preserveAspectRatio="xMinYMin meet"
+                              role="img"
+                              viewBox="0 0 12 12"
+                              width={12}
+                            >
+                              <use
+                                xlinkHref="#system-close"
+                              />
+                            </svg>
+                          </Icon>
+                        </span>
+                      </Clickable>
+                    </div>
+                  </FlexItem>
+                </div>
+              </Flex>
+            </span>
+          </Badge>
+        </span>
+        <input
+          aria-describedby=""
+          aria-invalid={false}
+          className="emotion-26"
+          data-cy="textInput-input"
+          id="withBadges"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          type="text"
+        />
+      </div>
+    </FormFieldWrapper>
+  </div>
+</TextInputWithBadges>
+`;

--- a/packages/typeahead/components/Typeahead.tsx
+++ b/packages/typeahead/components/Typeahead.tsx
@@ -35,7 +35,7 @@ export interface TypeaheadProps {
   /**
    * callback for when an item is selected
    */
-  onSelect?: (selectedItems: string[]) => void;
+  onSelect?: (selectedItems: string[], lastSelectedItem?: string) => void;
   /**
    * which DOM node the dropdown menu will attach to
    */
@@ -44,6 +44,14 @@ export interface TypeaheadProps {
    * an array of item values that are selected
    */
   selectedItems?: string[];
+  /**
+   * whether the menu stays open on select
+   */
+  keepOpenOnSelect?: boolean;
+  /**
+   * whether the selected item's value is set as the input's value
+   */
+  resetInputOnSelect?: boolean;
 }
 
 interface TypeaheadState {
@@ -98,7 +106,8 @@ class Typeahead extends React.PureComponent<TypeaheadProps, TypeaheadState> {
             highlightedIndex,
             openMenu,
             selectedItem,
-            inputValue
+            inputValue,
+            ...other
           }) => {
             return (
               <div>
@@ -159,6 +168,7 @@ class Typeahead extends React.PureComponent<TypeaheadProps, TypeaheadState> {
                         );
                       },
                       value: value === undefined ? inputValue : value,
+                      downshiftReset: other.reset,
                       ...textFieldProps
                     })
                   )}
@@ -216,7 +226,8 @@ class Typeahead extends React.PureComponent<TypeaheadProps, TypeaheadState> {
 
     if (this.props.onSelect) {
       this.props.onSelect(
-        this.getSelectedItems(selectedItem.value, !isItemSelected)
+        this.getSelectedItems(selectedItem.value, !isItemSelected),
+        selectedItem.value
       );
     }
   }
@@ -230,8 +241,12 @@ class Typeahead extends React.PureComponent<TypeaheadProps, TypeaheadState> {
         return {
           ...changes,
           selectedItem: [changes.selectedItem.value],
-          isOpen: this.props.multiSelect,
-          inputValue: this.props.multiSelect ? "" : changes.inputValue
+          isOpen:
+            this.props.multiSelect && !(this.props.keepOpenOnSelect === false),
+          inputValue:
+            this.props.multiSelect || this.props.resetInputOnSelect
+              ? ""
+              : changes.inputValue
         };
 
       case Downshift.stateChangeTypes.changeInput:

--- a/packages/typeahead/tests/Typeahead.test.tsx
+++ b/packages/typeahead/tests/Typeahead.test.tsx
@@ -168,7 +168,7 @@ describe("Typeahead", () => {
     input.simulate("keyDown", {
       key: "Enter"
     });
-    expect(onSelectFn).toHaveBeenCalledWith([items[0].value]);
+    expect(onSelectFn).toHaveBeenCalledWith([items[0].value], items[0].value);
   });
 
   it("sets the input value to the selected item's value on change", () => {
@@ -227,11 +227,70 @@ describe("Typeahead", () => {
     expect(component.find(DropdownContents).prop("open")).toBe(true);
   });
 
+  it("hides the dropdown when selecting an item if keepOpenOnSelect is false", () => {
+    const onSelectFn = jest.fn();
+    const component = mount(
+      <Typeahead
+        multiSelect={true}
+        keepOpenOnSelect={false}
+        items={items}
+        onSelect={onSelectFn}
+        textField={
+          <TextInput
+            id="standard.input"
+            inputLabel="Standard"
+            placeholder="Placeholder"
+          />
+        }
+      />
+    );
+
+    expect(component.find(DropdownContents).prop("open")).toBe(false);
+    component.find("input").simulate("focus");
+    expect(onSelectFn).not.toHaveBeenCalled();
+    component.find("input").simulate("keyDown", {
+      key: "ArrowDown"
+    });
+    component.find("input").simulate("keyDown", {
+      key: "Enter"
+    });
+    expect(component.find(DropdownContents).prop("open")).toBe(false);
+  });
+
   it("does not set the input value if multiSelect is true", () => {
     const onSelectFn = jest.fn();
     const component = mount(
       <Typeahead
         multiSelect={true}
+        items={items}
+        onSelect={onSelectFn}
+        textField={
+          <TextInput
+            id="standard.input"
+            inputLabel="Standard"
+            placeholder="Placeholder"
+          />
+        }
+      />
+    );
+
+    expect(component.find("input").prop("value")).toBe("");
+    component.find("input").simulate("focus");
+    expect(onSelectFn).not.toHaveBeenCalled();
+    component.find("input").simulate("keyDown", {
+      key: "ArrowDown"
+    });
+    component.find("input").simulate("keyDown", {
+      key: "Enter"
+    });
+    expect(component.find("input").prop("value")).toBe("");
+  });
+
+  it("does not set the input value if resetInputOnSelect is true", () => {
+    const onSelectFn = jest.fn();
+    const component = mount(
+      <Typeahead
+        resetInputOnSelect={true}
         items={items}
         onSelect={onSelectFn}
         textField={

--- a/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
+++ b/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
@@ -151,17 +151,9 @@ exports[`Typeahead renders 1`] = `
   opacity: 0.4;
 }
 
-.emotion-2 svg {
-  fill: var(--themeTextColorPrimary,#1B2029);
-}
-
 .emotion-2:focus {
   background-color: rgba(125,88,255,0.05);
   border-color: var(--themeBrandPrimary,#7D58FF);
-}
-
-.emotion-2:focus svg {
-  fill: var(--themeBrandPrimary,#7D58FF);
 }
 
 .emotion-19 {
@@ -412,6 +404,7 @@ exports[`Typeahead renders 1`] = `
                   aria-controls={null}
                   aria-labelledby="downshift-0-label"
                   autoComplete="off"
+                  downshiftReset={[Function]}
                   id="standard.input"
                   inputLabel="Standard"
                   onBlur={[Function]}
@@ -455,6 +448,7 @@ exports[`Typeahead renders 1`] = `
                             autoComplete="off"
                             className="emotion-2"
                             data-cy="textInput-input"
+                            downshiftReset={[Function]}
                             id="standard.input"
                             onBlur={[Function]}
                             onChange={[Function]}
@@ -1222,17 +1216,9 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   opacity: 0.4;
 }
 
-.emotion-2 svg {
-  fill: var(--themeTextColorPrimary,#1B2029);
-}
-
 .emotion-2:focus {
   background-color: rgba(125,88,255,0.05);
   border-color: var(--themeBrandPrimary,#7D58FF);
-}
-
-.emotion-2:focus svg {
-  fill: var(--themeBrandPrimary,#7D58FF);
 }
 
 .emotion-19 {
@@ -1483,6 +1469,7 @@ exports[`Typeahead renders a menu with a max height 1`] = `
                   aria-controls={null}
                   aria-labelledby="downshift-1-label"
                   autoComplete="off"
+                  downshiftReset={[Function]}
                   id="standard.input"
                   inputLabel="Standard"
                   onBlur={[Function]}
@@ -1526,6 +1513,7 @@ exports[`Typeahead renders a menu with a max height 1`] = `
                             autoComplete="off"
                             className="emotion-2"
                             data-cy="textInput-input"
+                            downshiftReset={[Function]}
                             id="standard.input"
                             onBlur={[Function]}
                             onChange={[Function]}


### PR DESCRIPTION
## Testing
You should be able to add badges by hitting "Enter" after you type some value into the input
You should be able to add badges using the Typeahead variants
You can't add duplicates

## Screenshots
**Default:**
![badgeDemo_default](https://user-images.githubusercontent.com/2313998/64739096-12c12280-d4bf-11e9-9669-8e0f892a425e.gif)

**Pre-filled:**
![Screen Shot 2019-09-11 at 6 02 04 PM](https://user-images.githubusercontent.com/2313998/64739079-0f2d9b80-d4bf-11e9-9d59-fbd83cc10e8a.png)

**w/ a Typeahead:**
![badgeDemo_typeahead](https://user-images.githubusercontent.com/2313998/64739101-1654a980-d4bf-11e9-9936-168ab344ad0b.gif)

---

Some small things I'd like to address before merging, but probably aren't blockers:
- [ ] The vertical centering of the text in the badges is a little off when the `<input>` isn't on the same line as the badges
- [ ] I'd like to add some handler for when a user tries to add a duplicate badge
- [x] I want to reconsider "sanitizing" the string that goes into the `value` property of the badge data