### PR TITLE
Make it easier to render a Table in a tab panel

### DIFF
--- a/packages/pageheader/components/PageHeader.tsx
+++ b/packages/pageheader/components/PageHeader.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../shared/styles/styleUtils";
 import { SpaceSizes } from "../../shared/styles/styleUtils/modifiers/modifierUtils";
 import PageHeaderTabs from "../components/PageHeaderTabs";
+import { fillHeight } from "../style";
 
 export interface PageHeaderProps {
   breadcrumbElements: React.ReactNodeArray;
@@ -29,7 +30,7 @@ class PageHeader extends React.PureComponent<PageHeaderProps, {}> {
 
     return (
       <div
-        className={cx(padding("all", pageHeaderPaddingSize), {
+        className={cx(padding("all", pageHeaderPaddingSize), fillHeight, {
           [border("bottom")]: !hasTabsChild
         })}
       >

--- a/packages/pageheader/components/PageHeaderTabs.tsx
+++ b/packages/pageheader/components/PageHeaderTabs.tsx
@@ -7,6 +7,7 @@ const PageHeaderTabs = ({ children }) => {
   return (
     <div
       className={css`
+        flex-grow: 1;
         margin-left: -${spaceSizes[pageHeaderPaddingSize]};
         margin-right: -${spaceSizes[pageHeaderPaddingSize]};
       `}

--- a/packages/pageheader/style.ts
+++ b/packages/pageheader/style.ts
@@ -1,0 +1,11 @@
+import { css } from "emotion";
+
+export const fillHeight = css`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  > * {
+    flex-shrink: 0;
+  }
+`;

--- a/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/pageheader/tests/__snapshots__/PageHeader.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PageHeader default 1`] = `
 <div
-  class="css-1ik9ay"
+  class="css-18vxolt"
 >
   <div
     class="css-1s0dtwu"

--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Tabs as ReactTabs, TabList, TabPanel } from "react-tabs";
-import { injectGlobal } from "emotion";
+import { injectGlobal, css, cx } from "emotion";
 
 import { TabItemProps } from "./TabItem";
 import { TabTitle } from "..";
@@ -69,6 +69,7 @@ injectGlobal`
 
 .react-tabs__tab-panel {
   display: none;
+  flex-grow: 1;
   ${margin("horiz", "l")}
   ${margin("vert", "xl")}
 }
@@ -78,6 +79,12 @@ injectGlobal`
 }
 `;
 /* tslint:enable */
+
+const fullHeightTabs = css`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
 
 export type TabSelected = string;
 export interface TabsProps {
@@ -120,15 +127,19 @@ class Tabs extends React.PureComponent<TabsProps, {}> {
             tabs: [...tabs, title],
             tabsContent: [
               ...tabsContent,
-              <TabPanel key={key}>{tabChildren}</TabPanel>
+              ...(tabChildren.length
+                ? [<TabPanel key={key}>{tabChildren}</TabPanel>]
+                : [])
             ]
           };
         },
         { tabs: [], tabsContent: [] }
       );
-
     return (
       <ReactTabs
+        className={cx("react-tabs", {
+          [fullHeightTabs]: Boolean(tabsContent.length)
+        })}
         selectedIndex={selectedIndex}
         onSelect={onSelect}
         data-cy="tabs"

--- a/packages/tabs/tests/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/tabs/tests/__snapshots__/Tabs.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tabs default 1`] = `
 <div
-  class="react-tabs"
+  class="react-tabs css-flq1iw"
   data-cy="tabs"
   data-tabs="true"
 >


### PR DESCRIPTION
This issue came up during Kommander beta development

Tables grow to the height of their parent. This is a problem when you have a Table that's inside of Tabs because the tab panels get the height of their children.