### PR TITLE
Add subtle border around Avatars

### DIFF
--- a/packages/avatar/style.ts
+++ b/packages/avatar/style.ts
@@ -1,9 +1,13 @@
 import { css } from "emotion";
 import { AvatarSizes } from "./components/Avatar";
-import { themeBgSecondary } from "../design-tokens/build/js/designTokens";
+import {
+  themeBgSecondary,
+  greyLightLighten5
+} from "../design-tokens/build/js/designTokens";
 
 export const avatarContainer = css`
   background-color: ${themeBgSecondary};
+  border: 1px solid ${greyLightLighten5};
   border-radius: 25%;
   overflow: hidden;
   vertical-align: middle;

--- a/packages/avatar/tests/__snapshots__/avatar.test.tsx.snap
+++ b/packages/avatar/tests/__snapshots__/avatar.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Avatar renders default 1`] = `
 
 .emotion-1 {
   background-color: var(--themeBgSecondary,#F7F8F9);
+  border: 1px solid #F7F8F9;
   border-radius: 25%;
   overflow: hidden;
   vertical-align: middle;
@@ -40,6 +41,7 @@ exports[`Avatar renders with a src, size, and label 1`] = `
 
 .emotion-1 {
   background-color: var(--themeBgSecondary,#F7F8F9);
+  border: 1px solid #F7F8F9;
   border-radius: 25%;
   overflow: hidden;
   vertical-align: middle;


### PR DESCRIPTION
This adds a **very** subtle light grey border around avatars in the case that the image being used has a white background.

Here's what I put in `src` to test this and take screenshots: ```data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOMAAADeCAMAAAD4tEcNAAAAA1BMVEX///+nxBvIAAAASElEQVR4nO3BMQEAAADCoPVPbQZ/oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+A8W4AAH7AbJ4AAAAAElFTkSuQmCC```

## Screenshots:
**Before:**
![Screen Shot 2019-09-25 at 5 09 34 PM](https://user-images.githubusercontent.com/2313998/65640152-b0384e00-dfb7-11e9-8db0-7aca69adc950.png)

**After:**
![Screen Shot 2019-09-25 at 5 08 46 PM](https://user-images.githubusercontent.com/2313998/65640163-ba5a4c80-dfb7-11e9-8fa5-49f7abce6667.png)
