### PR TITLE
[DEMO/DISCUSSION] possible way of solving double-scrollbar in kommander

### DIFF
--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -69,6 +69,7 @@ export interface TableProps {
    * Set the row height
    */
   rowHeight?: number;
+  style?: any;
 }
 
 export interface TableState {
@@ -268,7 +269,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
 
   public render() {
     return (
-      <React.Fragment>
+      <div style={...this.props.style}>
         <AutoSizer
           __dataThatTriggersARerenderWhenChanged={this.props.data} // passed to notify react-virtualized about updates
           className={tableCss}
@@ -285,7 +286,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
           accurately calculate column widths
         */}
         <div className={scrollbarMeas} ref={this.scrollMeasRef} />
-      </React.Fragment>
+      </div>
     );
   }
 

--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -126,46 +126,57 @@ storiesOf("Table", module)
     </div>
   ))
   .add("column width fill remaining", () => (
-    <div
-      style={{
-        height: "175px",
-        width: "100%",
-        fontSize: "14px"
-      }}
-    >
-      <Table data={items}>
-        <Column
-          header={<HeaderCell>name</HeaderCell>}
-          cellRenderer={nameCellRenderer}
-          growToFill={true}
-          minWidth={100}
-          maxWidth={150}
-        />
-        <Column
-          header={<HeaderCell>role</HeaderCell>}
-          cellRenderer={roleCellRenderer}
-          growToFill={true}
-        />
-        <Column
-          header={<HeaderCell>state</HeaderCell>}
-          cellRenderer={stateCellRenderer}
-          growToFill={true}
-          minWidth={100}
-          maxWidth={150}
-        />
-        <Column
-          header={<HeaderCell>Very Long</HeaderCell>}
-          cellRenderer={veryLongRenderer}
-          growToFill={true}
-        />
-        <Column
-          header={<HeaderCell textAlign="right">zip code</HeaderCell>}
-          cellRenderer={zipcodeCellRenderer}
-          growToFill={true}
-          minWidth={100}
-          maxWidth={150}
-        />
-      </Table>
+    <div style={{ height: "300px", fontSize: "14px" }}>
+      <div
+        style={{
+          display: "flex",
+          height: "100%",
+          flexDirection: "column",
+          border: "1px solid red"
+        }}
+      >
+        <div>Lorem ipsum hassenichgesehn</div>
+        <div>Lorem ipsum hassenichgesehn</div>
+        <div>Lorem ipsum hassenichgesehn</div>
+        <div>Lorem ipsum hassenichgesehn</div>
+        <div>Lorem ipsum hassenichgesehn</div>
+        <div>Lorem ipsum hassenichgesehn</div>
+        <div>Lorem ipsum hassenichgesehn</div>
+
+        <Table data={items} style={{ flexGrow: 1 }}>
+          <Column
+            header={<HeaderCell>name</HeaderCell>}
+            cellRenderer={nameCellRenderer}
+            growToFill={true}
+            minWidth={100}
+            maxWidth={150}
+          />
+          <Column
+            header={<HeaderCell>role</HeaderCell>}
+            cellRenderer={roleCellRenderer}
+            growToFill={true}
+          />
+          <Column
+            header={<HeaderCell>state</HeaderCell>}
+            cellRenderer={stateCellRenderer}
+            growToFill={true}
+            minWidth={100}
+            maxWidth={150}
+          />
+          <Column
+            header={<HeaderCell>Very Long</HeaderCell>}
+            cellRenderer={veryLongRenderer}
+            growToFill={true}
+          />
+          <Column
+            header={<HeaderCell textAlign="right">zip code</HeaderCell>}
+            cellRenderer={zipcodeCellRenderer}
+            growToFill={true}
+            minWidth={100}
+            maxWidth={150}
+          />
+        </Table>
+      </div>
     </div>
   ))
   .add("width-aware render", () => {


### PR DESCRIPTION
allow style-attr to be passed in order to let consumers decide on how/where to embed a table.

i abused a story to reproduce the kommander-issue and demo it. those changed would need to be removed again of course.

i have no idea on how to do idiomatic ui-kit-stuff, so please excuse this potentially very unsophisticated approach.

⚠️ this might be totally opposing the philosophy of ui-kit and everyone should use the flex-helpers to solve problems like we currently have in kommander? 🤔 

# before 

<img width="1603" alt="Table - column width fill remaining ⋅ Storybook 2019-10-17 12-27-39" src="https://user-images.githubusercontent.com/300861/67001366-d5613d80-f0d9-11e9-8359-b50a12d5dfde.png">

# after

<img width="1642" alt="Table - column width fill remaining ⋅ Storybook 2019-10-17 12-24-48" src="https://user-images.githubusercontent.com/300861/67001113-5409ab00-f0d9-11e9-91fa-322e2eb5921a.png">
