### PR TITLE
Fix for text inputs losing focus when table w/ resizable column unmounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21659,24 +21659,12 @@
       }
     },
     "react-draggable": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.2.1.tgz",
-      "integrity": "sha512-r+3Bs9InID2lyIEbR8UIRVtpn4jgu1ArFEZgIy8vibJjijLSdNLX7rH9U68BBVD4RD9v44RXbaK4EHLyKXzNQw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-3.3.2.tgz",
+      "integrity": "sha512-oaz8a6enjbPtx5qb0oDWxtDNuybOylvto1QLydsXgKmwT7e3GXC2eMVDwEMIUYJIFqVG72XpOv673UuuAq6LhA==",
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.0"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        }
       }
     },
     "react-element-to-jsx-string": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-chartist": "^0.13.3",
     "react-click-outside": "3.0.1",
     "react-delegate-component": "1.0.0",
-    "react-draggable": "3.2.1",
+    "react-draggable": "3.3.2",
     "react-emotion": "9.2.12",
     "react-focus-lock": "2.0.5",
     "react-tabs": "^3.0.0",

--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -469,6 +469,9 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
                     this.getContainerWidth() * (1 - COL_RESIZE_MAX_WIDTH),
                   bottom: 0
                 }}
+                // Needed for an issue where text inputs lose focus when a Draggable unmounts
+                // Github issue: https://github.com/mzabriskie/react-draggable/issues/315
+                enableUserSelectHack={false}
               >
                 <div>
                   <div


### PR DESCRIPTION
When react-draggable's Draggable component unmounts, it causes text inputs to lose focus. These changes add a workaround for this problem: https://github.com/mzabriskie/react-draggable/issues/315

This bug was discovered while working on Kommander. Internal D2iQ Slack thread here: https://mesosphere.slack.com/archives/CMAAP82G6/p1572061677078800