### PR TITLE
Fix Table cell capitalization

### DIFF
--- a/packages/table/components/Cell.tsx
+++ b/packages/table/components/Cell.tsx
@@ -6,7 +6,7 @@ import { innerCellCss, cellAlignmentCss, textCapitalize } from "../style";
 export type TextAlign = "left" | "right" | "center";
 export interface CellProps {
   textAlign?: TextAlign;
-  lowerCase?: boolean;
+  capitalize?: boolean;
   children: React.ReactElement<HTMLElement> | string;
   className?: string;
   role?: string;
@@ -47,7 +47,7 @@ class Cell extends React.PureComponent<CellProps, CellState> {
   }
 
   render() {
-    const { children, className, textAlign, lowerCase, ...other } = this.props;
+    const { children, className, textAlign, capitalize, ...other } = this.props;
 
     return (
       <div
@@ -55,7 +55,7 @@ class Cell extends React.PureComponent<CellProps, CellState> {
         className={cx(
           innerCellCss,
           cellAlignmentCss(textAlign || "left"),
-          lowerCase ? null : textCapitalize,
+          !capitalize ? null : textCapitalize,
           className
         )}
         {...other}

--- a/packages/table/components/HeaderCell.tsx
+++ b/packages/table/components/HeaderCell.tsx
@@ -1,9 +1,17 @@
-import { default as Cell } from "./Cell";
+import React from "react";
+
+import Cell, { CellProps } from "./Cell";
 import styled from "react-emotion";
 import { headerCellCss } from "../style";
 import { textTruncate } from "../../shared/styles/styleUtils";
 
-export default styled(Cell)`
+// Make capitalize false only if it is explicitly passed as false.
+// If it is undefned, make it true.
+const HeaderCell = (props: CellProps) => (
+  <Cell capitalize={props.capitalize === false ? false : true} {...props} />
+);
+
+export default styled(HeaderCell)`
   ${headerCellCss};
   ${textTruncate};
 `;

--- a/packages/table/components/SortableHeaderCell.tsx
+++ b/packages/table/components/SortableHeaderCell.tsx
@@ -11,7 +11,7 @@ export interface SortableHeaderCellProps {
   sortDirection: SortDirection;
   columnContent: React.ReactNode;
   textAlign?: TextAlign;
-  lowerCase?: boolean;
+  capitalize?: boolean;
 }
 interface SortableHeaderCellState {
   hovered: boolean;
@@ -45,7 +45,7 @@ export class SortableHeaderCell extends React.Component<
       sortDirection,
       columnContent,
       textAlign,
-      lowerCase
+      capitalize
     } = this.props;
 
     const displaySortDirection =
@@ -74,7 +74,7 @@ export class SortableHeaderCell extends React.Component<
             ariaSortString === "descending" ? "ascending" : "descending"
           } order`}
           textAlign={textAlign}
-          lowerCase={lowerCase}
+          capitalize={capitalize}
         >
           <span>{columnContent}</span>
         </HeaderCell>

--- a/packages/table/tests/__snapshots__/Cell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/Cell.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`Cell renders correctly 1`] = `
   padding: 7px;
   z-index: 1;
   text-align: left;
-  text-transform: capitalize;
 }
 
 <div
@@ -46,7 +45,6 @@ exports[`TextCell renders correctly 1`] = `
   padding: 7px;
   z-index: 1;
   text-align: left;
-  text-transform: capitalize;
   overflow: hidden;
   overflow: -moz-hidden-unscrollable;
   text-overflow: ellipsis;

--- a/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/CheckboxTable.test.tsx.snap
@@ -254,7 +254,6 @@ Array [
   padding: 7px;
   z-index: 1;
   text-align: left;
-  text-transform: capitalize;
 }
 
 <div
@@ -939,7 +938,6 @@ Array [
   padding: 7px;
   z-index: 1;
   text-align: left;
-  text-transform: capitalize;
 }
 
 .emotion-3 {
@@ -1720,7 +1718,6 @@ Array [
   padding: 7px;
   z-index: 1;
   text-align: left;
-  text-transform: capitalize;
 }
 
 .emotion-33 {

--- a/packages/table/tests/__snapshots__/SortableHeaderCell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/SortableHeaderCell.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`SortableHeaderCell renders default 1`] = `
   role="button"
   tabIndex={0}
 >
-  <Styled(Cell)
+  <Styled(HeaderCell)
     aria-label="sort by column content in ascending order"
     aria-sort="descending"
     className="emotion-0"
@@ -48,6 +48,6 @@ exports[`SortableHeaderCell renders default 1`] = `
     <span>
       column content
     </span>
-  </Styled(Cell)>
+  </Styled(HeaderCell)>
 </Clickable>
 `;


### PR DESCRIPTION
## Testing
Go to `packages/table/stories/helpers/mocks.ts` and change items to something like
```
export const items = [
  {
    name: "brian Vaughn",
    role: "software Engineer",
    city: "san Jose",
    state: "cA",
    zipcode: 95125
  },
  {
    name: "jon Doe",
    role: "Product engineer",
    city: "Mountain View",
    state: "CA",
    zipcode: 95125
  },
  {
    name: "jane Doe",
    role: "UX Designer",
    city: "San Francisco",
    state: "CA",
    zipcode: 95125
  }
];
```

Open any table, for example [default checkbox table](http://localhost:6006/?path=/story/table-checkboxtable--default) and verify that the table cells are not capitalized.

![Screenshot from 2019-11-08 10-53-40](https://user-images.githubusercontent.com/40791275/68462973-5cf02700-0216-11ea-9e4a-000cf620259a.png)
