### PR TITLE
DCOS-60921: improves handling of long unbroken strings in infobox

### DIFF
--- a/packages/infobox/style.ts
+++ b/packages/infobox/style.ts
@@ -73,6 +73,8 @@ export const infoBox = (appearance, hasActions) =>
     grid-gap: ${spaceM};
     grid-template-columns: 1fr auto;
     align-items: center;
+    overflow: auto;
+    word-break: break-word;
     ${hasActions &&
       atMediaUp[layoutBreakpoint](css`
         grid-template-columns: auto 1fr auto;

--- a/packages/infobox/tests/__snapshots__/InfoBox.test.tsx.snap
+++ b/packages/infobox/tests/__snapshots__/InfoBox.test.tsx.snap
@@ -44,6 +44,8 @@ exports[`InfoBox renders default 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: auto;
+  word-break: break-word;
   padding: 16px;
   font-size: 12px;
   display: grid;
@@ -95,6 +97,8 @@ exports[`InfoBox renders with JSX message 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: auto;
+  word-break: break-word;
   padding: 16px;
   font-size: 12px;
   display: grid;
@@ -152,6 +156,8 @@ exports[`InfoBox renders with actions 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: auto;
+  word-break: break-word;
   padding: 16px;
   font-size: 12px;
   display: grid;
@@ -246,6 +252,8 @@ exports[`InfoBox renders without dismiss button 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  overflow: auto;
+  word-break: break-word;
   padding: 16px;
   font-size: 12px;
   display: grid;


### PR DESCRIPTION
## Testing
Try putting a very long string with no whitespace into the infobox and make sure it doesn't flow outside of the box

## Screenshot
![Screen Shot 2019-11-08 at 11 51 10 AM](https://user-images.githubusercontent.com/2313998/68496290-f4a64300-021f-11ea-933f-f578fcd254cb.png)
