### PR TITLE
fix: arrow direction / asc & desc

### DIFF
--- a/packages/table/style.ts
+++ b/packages/table/style.ts
@@ -139,13 +139,13 @@ export const styleArrowDirection = displaySortDirection => {
     case "DESC":
       return css`
         &:after {
-          ${pseudoElTriangle("bottom", pointerSize, "currentColor")};
+          ${pseudoElTriangle("top", pointerSize, "currentColor")};
         }
       `;
     case "ASC":
       return css`
         &:after {
-          ${pseudoElTriangle("top", pointerSize, "currentColor")};
+          ${pseudoElTriangle("bottom", pointerSize, "currentColor")};
         }
       `;
     default:

--- a/packages/table/tests/__snapshots__/SortableHeaderCell.test.tsx.snap
+++ b/packages/table/tests/__snapshots__/SortableHeaderCell.test.tsx.snap
@@ -23,10 +23,10 @@ exports[`SortableHeaderCell renders default 1`] = `
   content: "";
   height: 0;
   width: 0;
-  border-bottom: 4px solid currentColor;
+  border-top: 4px solid currentColor;
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
-  border-top: none;
+  border-bottom: none;
 }
 
 <Clickable


### PR DESCRIPTION
When sort direction is "ascending" the arrow should point up

Here is the fixed version:

![Nov-21-2019 23-02-12](https://user-images.githubusercontent.com/174332/69402057-f8bc7100-0cb3-11ea-8b14-5b1057bbb3de.gif)
