### PR TITLE
Make it easier to select loading indicator elements with Cypress

### DIFF
--- a/packages/icon/components/Icon.tsx
+++ b/packages/icon/components/Icon.tsx
@@ -33,10 +33,12 @@ export interface IconProps {
   shape: SystemIcons | ProductIcons;
   /** The width and height of the icon */
   size?: IconSizes;
+  /** human-readable selector used for writing tests */
+  dataCy?: string;
 }
 
 const Icon = (props: IconProps) => {
-  const { color, size, shape, ariaLabel } = props;
+  const { color, size, shape, ariaLabel, dataCy } = props;
   const svgColor = color || "currentColor";
   const iconSize = size || iconSizeS;
 
@@ -49,7 +51,7 @@ const Icon = (props: IconProps) => {
       role="img"
       aria-label={ariaLabel || `${shape} icon`}
       className={cx(icon, tintSVG(svgColor))}
-      data-cy="icon"
+      data-cy={["icon", dataCy].filter(Boolean).join(" ")}
     >
       <use xlinkHref={`#${shape}`} />
     </svg>

--- a/packages/loadingIndicator/components/InlineLoadingIndicator.tsx
+++ b/packages/loadingIndicator/components/InlineLoadingIndicator.tsx
@@ -4,7 +4,11 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { iconSizeXs } from "../../design-tokens/build/js/designTokens";
 
 const InlineLoadingIndicator: React.SFC = () => (
-  <Icon shape={SystemIcons.Spinner} size={iconSizeXs} />
+  <Icon
+    shape={SystemIcons.Spinner}
+    size={iconSizeXs}
+    dataCy="inlineLoadingIndicator"
+  />
 );
 
 export default InlineLoadingIndicator;

--- a/packages/loadingIndicator/components/SectionLoadingIndicator.tsx
+++ b/packages/loadingIndicator/components/SectionLoadingIndicator.tsx
@@ -3,7 +3,10 @@ import { sectionLoadingWrapper, sectionLoadingIndicator } from "../style";
 
 const SectionLoadingIndicator: React.SFC = () => (
   <div className={sectionLoadingWrapper}>
-    <div className={sectionLoadingIndicator} />
+    <div
+      className={sectionLoadingIndicator}
+      data-cy="sectionLoadingIndicator"
+    />
   </div>
 );
 

--- a/packages/loadingIndicator/tests/__snapshots__/loadingIndicator.test.tsx.snap
+++ b/packages/loadingIndicator/tests/__snapshots__/loadingIndicator.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Loading indicators renders InlineLoadingIndicator 1`] = `
 >
   <div
     class="css-15gzp3f"
+    data-cy="sectionLoadingIndicator"
   />
 </div>
 `;
@@ -14,7 +15,7 @@ exports[`Loading indicators renders SectionLoadingIndicator 1`] = `
 <svg
   aria-label="system-spinner icon"
   class="css-zgvqkl"
-  data-cy="icon"
+  data-cy="icon inlineLoadingIndicator"
   height="16"
   preserveAspectRatio="xMinYMin meet"
   role="img"


### PR DESCRIPTION
Forgot to add `data-cy` attributes