### PR TITLE
Wrap InfoBox actions to a new line without media queries

### DIFF
--- a/packages/formStructure/tests/__snapshots__/formStructure.test.tsx.snap
+++ b/packages/formStructure/tests/__snapshots__/formStructure.test.tsx.snap
@@ -8,11 +8,13 @@ Array [
   >
     <div
       aria-live="assertive"
-      class="css-rvaq24"
+      class="css-8smtcw"
       data-cy="infoBox infoBox.warning"
       role="alert"
     >
-      <div>
+      <div
+        class="css-1xwef9y"
+      >
         Form message content
       </div>
     </div>

--- a/packages/infobox/components/InfoBox.tsx
+++ b/packages/infobox/components/InfoBox.tsx
@@ -2,15 +2,16 @@ import * as React from "react";
 import { cx } from "emotion";
 import {
   infoBox,
-  primaryActionStyle,
   infoBoxActions,
+  infoBoxContentWrap,
+  primaryActionStyle,
   dismissBtn
 } from "../style";
 import Clickable from "../../clickable/components/clickable";
 import {
+  flush,
   padding,
   textSize,
-  display,
   textWeight
 } from "../../shared/styles/styleUtils";
 import {
@@ -79,10 +80,10 @@ export class InfoBox extends React.PureComponent<InfoBoxProps, {}> {
     return (
       <div
         className={cx(
-          infoBox(appearance, hasActions),
+          infoBox(appearance),
           padding("all"),
+          flush("bottom"),
           textSize("s"),
-          display("grid"),
           textWeight("medium"),
           className
         )}
@@ -90,20 +91,26 @@ export class InfoBox extends React.PureComponent<InfoBoxProps, {}> {
         aria-live={isUrgentMessage ? "assertive" : "polite"}
         data-cy={dataCy}
       >
-        <div>{message}</div>
-        {hasActions && (
-          <div
-            className={cx(infoBoxActions, display("inline-flex"))}
-            data-cy="infoBox-actions"
-          >
-            {primaryAction && (
-              <span className={primaryActionStyle}>{primaryAction}</span>
-            )}
+        {hasActions ? (
+          <div className={infoBoxContentWrap}>
+            <div className={padding("bottom")}>{message}</div>
+            <div
+              className={cx(infoBoxActions, padding("bottom"))}
+              data-cy="infoBox-actions"
+            >
+              {primaryAction && (
+                <span className={cx(primaryActionStyle, padding("left"))}>
+                  {primaryAction}
+                </span>
+              )}
 
-            {secondaryAction && (
-              <span className={padding("right")}>{secondaryAction}</span>
-            )}
+              {secondaryAction && (
+                <span className={padding("left")}>{secondaryAction}</span>
+              )}
+            </div>
           </div>
+        ) : (
+          <div className={padding("bottom")}>{message}</div>
         )}
 
         {onDismiss && (

--- a/packages/infobox/style.ts
+++ b/packages/infobox/style.ts
@@ -1,5 +1,4 @@
 import { css } from "emotion";
-import { atMediaUp } from "../shared/styles/breakpoints";
 import {
   blueDarken4,
   blueLighten3,
@@ -8,15 +7,12 @@ import {
   greyDark,
   greyLightDarken3,
   greyLight,
-  spaceM,
   themeError,
   themeSuccess,
   themeWarning
 } from "../design-tokens/build/js/designTokens";
 import { lighten, darken } from "../shared/styles/color";
 import getCSSVarValue from "../utilities/components/getCSSVarValue";
-
-const layoutBreakpoint = "small";
 
 const infoBoxAppearances = appearance => {
   switch (appearance) {
@@ -55,30 +51,23 @@ const infoBoxAppearances = appearance => {
   }
 };
 
-export const infoBoxActions = css`
-  grid-row-start: 2;
-  grid-column: span 2;
-  justify-content: flex-end;
-
-  ${atMediaUp.small(css`
-    grid-row-start: auto;
-    grid-column: auto;
-    justify-content: flex-start;
-  `)};
+export const infoBoxContentWrap = css`
+  display: inline-flex;
+  flex-wrap: wrap;
 `;
 
-export const infoBox = (appearance, hasActions) =>
+export const infoBoxActions = css`
+  display: inline-flex;
+  margin-left: auto;
+`;
+
+export const infoBox = appearance =>
   css`
     ${infoBoxAppearances(appearance)};
-    grid-gap: ${spaceM};
-    grid-template-columns: 1fr auto;
-    align-items: center;
+    display: flex;
+    justify-content: space-between;
     overflow: auto;
     word-break: break-word;
-    ${hasActions &&
-      atMediaUp[layoutBreakpoint](css`
-        grid-template-columns: auto 1fr auto;
-      `)};
   `;
 
 export const infoBoxInline = css`

--- a/packages/infobox/tests/__snapshots__/InfoBox.test.tsx.snap
+++ b/packages/infobox/tests/__snapshots__/InfoBox.test.tsx.snap
@@ -28,37 +28,46 @@ exports[`InfoBox InfoBoxBanner renders default 1`] = `
 `;
 
 exports[`InfoBox renders default 1`] = `
-.emotion-0 {
+.emotion-1 {
   cursor: pointer;
   line-height: 0;
   opacity: 0.5;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #DADDE2;
   border-bottom-color: #828487;
   color: #1B2029;
-  grid-gap: 16px;
-  grid-template-columns: 1fr auto;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   overflow: auto;
   word-break: break-word;
   padding: 16px;
+  padding-bottom: 0;
+  margin-bottom: 0;
   font-size: 12px;
-  display: grid;
   font-weight: 500;
+}
+
+.emotion-0 {
+  padding-bottom: 16px;
 }
 
 <div
   aria-live="polite"
-  className="emotion-1"
+  className="emotion-2"
   data-cy="infoBox"
   role="log"
 >
-  <div>
+  <div
+    className="emotion-0"
+  >
     message
   </div>
   <Clickable
@@ -68,7 +77,7 @@ exports[`InfoBox renders default 1`] = `
     tabIndex={0}
   >
     <span
-      className="emotion-0"
+      className="emotion-1"
     >
       <Icon
         color="#1B2029"
@@ -81,37 +90,46 @@ exports[`InfoBox renders default 1`] = `
 `;
 
 exports[`InfoBox renders with JSX message 1`] = `
-.emotion-0 {
+.emotion-1 {
   cursor: pointer;
   line-height: 0;
   opacity: 0.5;
 }
 
-.emotion-1 {
+.emotion-2 {
   background-color: #DADDE2;
   border-bottom-color: #828487;
   color: #1B2029;
-  grid-gap: 16px;
-  grid-template-columns: 1fr auto;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   overflow: auto;
   word-break: break-word;
   padding: 16px;
+  padding-bottom: 0;
+  margin-bottom: 0;
   font-size: 12px;
-  display: grid;
   font-weight: 500;
+}
+
+.emotion-0 {
+  padding-bottom: 16px;
 }
 
 <div
   aria-live="polite"
-  className="emotion-1"
+  className="emotion-2"
   data-cy="infoBox"
   role="log"
 >
-  <div>
+  <div
+    className="emotion-0"
+  >
     <MessageComponent />
   </div>
   <Clickable
@@ -121,7 +139,7 @@ exports[`InfoBox renders with JSX message 1`] = `
     tabIndex={0}
   >
     <span
-      className="emotion-0"
+      className="emotion-1"
     >
       <Icon
         color="#1B2029"
@@ -134,93 +152,96 @@ exports[`InfoBox renders with JSX message 1`] = `
 `;
 
 exports[`InfoBox renders with actions 1`] = `
-.emotion-0 {
-  -webkit-order: 1;
-  -ms-flex-order: 1;
-  order: 1;
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
 }
 
-.emotion-3 {
+.emotion-5 {
   cursor: pointer;
   line-height: 0;
   opacity: 0.5;
 }
 
-.emotion-4 {
+.emotion-6 {
   background-color: #DADDE2;
   border-bottom-color: #828487;
   color: #1B2029;
-  grid-gap: 16px;
-  grid-template-columns: 1fr auto;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   overflow: auto;
   word-break: break-word;
   padding: 16px;
+  padding-bottom: 0;
+  margin-bottom: 0;
   font-size: 12px;
-  display: grid;
   font-weight: 500;
 }
 
-@media (min-width:600px) {
-  .emotion-4 {
-    grid-template-columns: auto 1fr auto;
-  }
+.emotion-0 {
+  padding-bottom: 16px;
 }
 
-.emotion-2 {
-  grid-row-start: 2;
-  grid-column: span 2;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
+.emotion-3 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  margin-left: auto;
+  padding-bottom: 16px;
 }
 
-@media (min-width:600px) {
-  .emotion-2 {
-    grid-row-start: auto;
-    grid-column: auto;
-    -webkit-box-pack: start;
-    -webkit-justify-content: flex-start;
-    -ms-flex-pack: start;
-    justify-content: flex-start;
-  }
+.emotion-2 {
+  padding-left: 16px;
 }
 
 .emotion-1 {
-  padding-right: 16px;
+  -webkit-order: 1;
+  -ms-flex-order: 1;
+  order: 1;
+  padding-left: 16px;
 }
 
 <div
   aria-live="polite"
-  className="emotion-4"
+  className="emotion-6"
   data-cy="infoBox"
   role="log"
 >
-  <div>
-    message
-  </div>
   <div
-    className="emotion-2"
-    data-cy="infoBox-actions"
+    className="emotion-4"
   >
-    <span
+    <div
       className="emotion-0"
     >
-      <Component />
-    </span>
-    <span
-      className="emotion-1"
+      message
+    </div>
+    <div
+      className="emotion-3"
+      data-cy="infoBox-actions"
     >
-      <Component />
-    </span>
+      <span
+        className="emotion-1"
+      >
+        <Component />
+      </span>
+      <span
+        className="emotion-2"
+      >
+        <Component />
+      </span>
+    </div>
   </div>
   <Clickable
     action={[Function]}
@@ -229,7 +250,7 @@ exports[`InfoBox renders with actions 1`] = `
     tabIndex={0}
   >
     <span
-      className="emotion-3"
+      className="emotion-5"
     >
       <Icon
         color="#1B2029"
@@ -242,31 +263,40 @@ exports[`InfoBox renders with actions 1`] = `
 `;
 
 exports[`InfoBox renders without dismiss button 1`] = `
-.emotion-0 {
+.emotion-1 {
   background-color: #DADDE2;
   border-bottom-color: #828487;
   color: #1B2029;
-  grid-gap: 16px;
-  grid-template-columns: 1fr auto;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
   overflow: auto;
   word-break: break-word;
   padding: 16px;
+  padding-bottom: 0;
+  margin-bottom: 0;
   font-size: 12px;
-  display: grid;
   font-weight: 500;
+}
+
+.emotion-0 {
+  padding-bottom: 16px;
 }
 
 <div
   aria-live="polite"
-  className="emotion-0"
+  className="emotion-1"
   data-cy="infoBox"
   role="log"
 >
-  <div>
+  <div
+    className="emotion-0"
+  >
     message
   </div>
 </div>


### PR DESCRIPTION
Sometimes we use `InfoBoxInline` or `InfoBoxBanner` in a narrow part of the screen (like a small dialog modal), so we can't depend on media queries to handle wrapping the actions to their own line.

## Screenshots
**Before:**
![Screen Shot 2019-12-17 at 7 32 38 PM](https://user-images.githubusercontent.com/2313998/71045723-0e328880-2104-11ea-9d7d-77adb3e6b13c.png)

**After:**
![Screen Shot 2019-12-17 at 7 22 27 PM](https://user-images.githubusercontent.com/2313998/71045663-c7449300-2103-11ea-93ba-a671705afb90.png)
