### PR TITLE
fix: changes the way keys are set on grouped fields (FieldList, FieldGroup)

### DIFF
--- a/packages/formStructure/components/FieldGroup.tsx
+++ b/packages/formStructure/components/FieldGroup.tsx
@@ -13,8 +13,8 @@ const FieldGroup: React.SFC<FieldGroupProps> = ({ children, direction }) => (
   <Flex gutterSize="m" direction={direction}>
     {(React.Children.toArray(children) as Array<
       React.ReactElement<{ key: React.Key }>
-    >).map(field => (
-      <FlexItem key={field.props.key}>{field}</FlexItem>
+    >).map((field, i) => (
+      <FlexItem key={field.key || i}>{field}</FlexItem>
     ))}
   </Flex>
 );

--- a/packages/formStructure/components/FieldList.tsx
+++ b/packages/formStructure/components/FieldList.tsx
@@ -29,18 +29,28 @@ const REMOVE_ICON_SIZE = iconSizeXs;
 
 interface FieldListProps {
   /** The data to populate the field values with */
-  data: Array<{ key: string | number; [key: string]: any }>;
+  data: Array<{ [key: string]: any }>;
   /** An array of the indexes of disabled rows */
   disabledRows?: number[];
   /** The callback for when the remove button is clicked */
   onRemoveItem: (affectedRowIndex: number) => () => void;
+  /**
+   * The path to an object property who's value will be unique.
+   * Typically, this will be some kind of ID. The value of this property
+   * is used to set the key for each row in the field list.
+   *
+   * This key's value cannot be the field value because it will cause
+   * problems when the field value is changed
+   */
+  pathToUniqueKey?: string;
 }
 
 const FieldList: React.SFC<FieldListProps> = ({
   children,
   data,
   disabledRows,
-  onRemoveItem
+  onRemoveItem,
+  pathToUniqueKey
 }) => {
   const columns = (React.Children.toArray(children) as Array<
     React.ReactElement<FieldListColumnProps & FieldListColumnWidthProps>
@@ -56,7 +66,7 @@ const FieldList: React.SFC<FieldListProps> = ({
         spacingSize="xxs"
         className={getFieldRowGrid(columns, REMOVE_ICON_SIZE)}
       >
-        {columns.map(col => (
+        {columns.map((col, i) => (
           <Text
             tag="div"
             weight="medium"
@@ -64,7 +74,7 @@ const FieldList: React.SFC<FieldListProps> = ({
               [invisibleColHeader]: col.type === FieldListColumnSeparator
             })}
             dataCy="fieldList-columnHeader"
-            key={col.props.key}
+            key={col.key || `columnHeader.${i}`}
           >
             {col.type === FieldListColumn && col.props.header}
             {col.type === FieldListColumnSeparator && col.props.children}
@@ -81,7 +91,14 @@ const FieldList: React.SFC<FieldListProps> = ({
     return (
       <div
         className={getFieldRowGrid(columns, REMOVE_ICON_SIZE)}
-        key={`fieldList-row.${rowData.key}`}
+        key={
+          pathToUniqueKey
+            ? `fieldList-row.${findNestedPropertyInObject(
+                rowData,
+                pathToUniqueKey
+              )}`
+            : `fieldList-row.${rowIndex}`
+        }
       >
         {columns.map((col, i) => {
           return (

--- a/packages/formStructure/stories/fieldList.stories.tsx
+++ b/packages/formStructure/stories/fieldList.stories.tsx
@@ -15,19 +15,19 @@ const mockItems = [
     name: "Brian Vaughn",
     role: "Software Engineer",
     city: "San Jose",
-    key: 0
+    id: 0
   },
   {
     name: "Jon Doe",
     role: "Product engineer",
     city: "Mountain View",
-    key: 1
+    id: 1
   },
   {
     name: "Jane Doe",
     role: "UX Designer",
     city: "San Francisco",
-    key: 2
+    id: 2
   }
 ];
 
@@ -45,7 +45,11 @@ storiesOf("Form structure/Grouped fields/FieldList", module)
     () => (
       <FieldListHelper items={mockItems}>
         {({ removeItemHander, addItemHandler, fieldUpdateHandler, items }) => (
-          <FieldList data={items} onRemoveItem={removeItemHander}>
+          <FieldList
+            data={items}
+            onRemoveItem={removeItemHander}
+            pathToUniqueKey="id"
+          >
             <FieldListColumn
               key="name"
               header="Name"
@@ -105,7 +109,11 @@ storiesOf("Form structure/Grouped fields/FieldList", module)
     }
   )
   .add("varied column widths", () => (
-    <FieldList data={mockItems} onRemoveItem={testRemoveHandler}>
+    <FieldList
+      data={mockItems}
+      onRemoveItem={testRemoveHandler}
+      pathToUniqueKey="id"
+    >
       <FieldListColumn
         key="name"
         header="Name"
@@ -145,6 +153,7 @@ storiesOf("Form structure/Grouped fields/FieldList", module)
       data={mockItems}
       onRemoveItem={testRemoveHandler}
       disabledRows={[1]}
+      pathToUniqueKey="id"
     >
       <FieldListColumn
         key="name"
@@ -194,7 +203,11 @@ storiesOf("Form structure/Grouped fields/FieldList", module)
     </FieldList>
   ))
   .add("w/ add button", () => (
-    <FieldList data={mockItems} onRemoveItem={testRemoveHandler}>
+    <FieldList
+      data={mockItems}
+      onRemoveItem={testRemoveHandler}
+      pathToUniqueKey="id"
+    >
       <FieldListColumn
         key="name"
         header="Name"
@@ -229,7 +242,11 @@ storiesOf("Form structure/Grouped fields/FieldList", module)
     </FieldList>
   ))
   .add("w/ column separators", () => (
-    <FieldList data={mockItems} onRemoveItem={testRemoveHandler}>
+    <FieldList
+      data={mockItems}
+      onRemoveItem={testRemoveHandler}
+      pathToUniqueKey="id"
+    >
       <FieldListColumn
         key="name"
         header="Name"

--- a/packages/formStructure/tests/fieldList.test.tsx
+++ b/packages/formStructure/tests/fieldList.test.tsx
@@ -15,19 +15,19 @@ const mockItems = [
     name: "Brian Vaughn",
     role: "Software Engineer",
     city: "San Jose",
-    key: 0
+    id: 0
   },
   {
     name: "Jon Doe",
     role: "Product engineer",
     city: "Mountain View",
-    key: 1
+    id: 1
   },
   {
     name: "Jane Doe",
     role: "UX Designer",
     city: "San Francisco",
-    key: 2
+    id: 2
   }
 ];
 
@@ -46,6 +46,7 @@ describe("FieldList", () => {
             data={mockItems}
             onRemoveItem={testRemoveHandler}
             disabledRows={[0]}
+            pathToUniqueKey="id"
           >
             <FieldListColumn
               header="Name"
@@ -94,7 +95,11 @@ describe("FieldList", () => {
       jest.fn();
     });
     const fieldListComponent = mount(
-      <FieldList data={mockItems} onRemoveItem={testRemoveHandler}>
+      <FieldList
+        data={mockItems}
+        onRemoveItem={testRemoveHandler}
+        pathToUniqueKey="id"
+      >
         <FieldListColumn
           key="name"
           header="Name"
@@ -139,6 +144,7 @@ describe("FieldList", () => {
         data={mockItems}
         onRemoveItem={testRemoveHandler}
         disabledRows={[0]}
+        pathToUniqueKey="id"
       >
         <FieldListColumn
           key="name"
@@ -200,7 +206,11 @@ describe("FieldList", () => {
       testFieldUpdateHandlerInner(rowIndex, pathToValue);
     });
     const fieldListComponent = mount(
-      <FieldList data={mockItems} onRemoveItem={testRemoveHandler}>
+      <FieldList
+        data={mockItems}
+        onRemoveItem={testRemoveHandler}
+        pathToUniqueKey="id"
+      >
         <FieldListColumn
           key={pathToValue}
           header="Name"


### PR DESCRIPTION
This fixes two issues:
- Keys were not being properly set on children of the FieldList 
- If the value of a FieldListColumn's child input was the value of an object property who's key was literally the string "key", the field would lose focus each time the value of the input changed

## Testing
- In each object in the `mockItems` array, change the key "name" to "key"
- In the "interactive example" story, update the first `FieldListColumn`'s `pathToValueProp` to "key"
- Open the "interactive example" story in Storybook

Ensure that the value of the input can be changed and doesn't lose focus whenever you type a new letter

## Screenshots
**Before:**
![KeyFixDemo-before](https://user-images.githubusercontent.com/2313998/71291055-74efb600-233f-11ea-9a35-c8e5cb93894c.gif)

**After:**
![KeyFixDemo-after](https://user-images.githubusercontent.com/2313998/71291064-7b7e2d80-233f-11ea-96ff-498b6be329c3.gif)
