### PR TITLE
fix: broaden version of react peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "shortid": "2.2.14"
   },
   "peerDependencies": {
-    "react": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0",
-    "react-dom": ">=16.2.0 <16.9.0 || 16.7.0-alpha.0",
+    "react": ">=16.2.0",
+    "react-dom": ">=16.2.0",
     "react-gemini-scrollbar": "^2.1.5 || ^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
npm frequently complains about the peerDependencies of ui-kit not being fulfilled as we (dcos-ui) use react `16.12.0`. is there any particular reason to have the restriction to `<16.9.0`?