### PR TITLE
Set button type attribute to "button" by default

### DIFF
--- a/packages/button/components/ButtonBase.tsx
+++ b/packages/button/components/ButtonBase.tsx
@@ -102,6 +102,7 @@ class ButtonBase extends React.PureComponent<ButtonBaseProps, {}> {
       isProcessing,
       isFullWidth,
       onClick,
+      type = "button",
       url,
       ...other
     } = this.props;
@@ -156,6 +157,7 @@ class ButtonBase extends React.PureComponent<ButtonBaseProps, {}> {
           disabled={disabled || isProcessing}
           onClick={this.onClick}
           tabIndex={0}
+          type={type}
           {...other}
         >
           {this.getButtonContent()}

--- a/packages/button/components/ResetButton.tsx
+++ b/packages/button/components/ResetButton.tsx
@@ -4,13 +4,13 @@ import { buttonReset } from "../../shared/styles/styleUtils";
 import { keyboardFocus, pointerCursor } from "../style";
 
 const ResetButton = (props: React.HTMLProps<HTMLButtonElement>) => {
-  const { children, className, disabled, ...other } = props;
+  const { children, className, disabled, type = "button", ...other } = props;
   const classNames = cx(buttonReset, className, keyboardFocus, {
     [pointerCursor]: !disabled
   });
 
   return (
-    <button disabled={disabled} className={classNames} {...other}>
+    <button disabled={disabled} className={classNames} type={type} {...other}>
       <div tabIndex={-1}>{children}</div>
     </button>
   );

--- a/packages/configurationmap/tests/__snapshots__/ConfigurationMap.test.tsx.snap
+++ b/packages/configurationmap/tests/__snapshots__/ConfigurationMap.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`ConfigurationMap renders with actions 1`] = `
           class="css-67j5fi"
           data-cy="secondaryButton"
           tabindex="0"
+          type="button"
         >
           <span
             class=""
@@ -130,6 +131,7 @@ exports[`ConfigurationMap renders with actions 1`] = `
           class="css-67j5fi"
           data-cy="secondaryButton"
           tabindex="0"
+          type="button"
         >
           <span
             class=""
@@ -163,6 +165,7 @@ exports[`ConfigurationMap renders with actions 1`] = `
           class="css-67j5fi"
           data-cy="secondaryButton"
           tabindex="0"
+          type="button"
         >
           <span
             class=""

--- a/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
+++ b/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
@@ -85,6 +85,7 @@ exports[`Dropdownable is visible after opening 1`] = `
                 data-cy="primaryButton"
                 onClick={[Function]}
                 tabIndex={0}
+                type="button"
               >
                 <span
                   className=""
@@ -255,6 +256,7 @@ exports[`Dropdownable is visible after opening 2`] = `
                 data-cy="primaryButton"
                 onClick={[Function]}
                 tabIndex={0}
+                type="button"
               >
                 <span
                   className=""

--- a/packages/emptyState/tests/__snapshots__/emptyState.test.tsx.snap
+++ b/packages/emptyState/tests/__snapshots__/emptyState.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`EmptyState renders with primary and secondary actions 1`] = `
             class="css-67j5fi"
             data-cy="secondaryButton"
             tabindex="0"
+            type="button"
           >
             <span
               class=""
@@ -91,6 +92,7 @@ exports[`EmptyState renders with primary and secondary actions 1`] = `
             class="css-s9tdxz"
             data-cy="primaryButton"
             tabindex="0"
+            type="button"
           >
             <span
               class=""

--- a/packages/emptyState/tests/__snapshots__/emptyStateWithGraphic.test.tsx.snap
+++ b/packages/emptyState/tests/__snapshots__/emptyStateWithGraphic.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`EmptyStateWithGraphic renders with primary and secondary actions 1`] = 
         class="css-67j5fi"
         data-cy="secondaryButton"
         tabindex="0"
+        type="button"
       >
         <span
           class=""
@@ -103,6 +104,7 @@ exports[`EmptyStateWithGraphic renders with primary and secondary actions 1`] = 
         class="css-s9tdxz"
         data-cy="primaryButton"
         tabindex="0"
+        type="button"
       >
         <span
           class=""

--- a/packages/formStructure/tests/__snapshots__/fieldList.test.tsx.snap
+++ b/packages/formStructure/tests/__snapshots__/fieldList.test.tsx.snap
@@ -110,6 +110,7 @@ Array [
           class="css-1c1l20i"
           data-cy="fieldList-removeButton"
           disabled=""
+          type="button"
         >
           <div
             tabindex="-1"
@@ -213,6 +214,7 @@ Array [
         <button
           class="css-p8ocxc"
           data-cy="fieldList-removeButton"
+          type="button"
         >
           <div
             tabindex="-1"
@@ -316,6 +318,7 @@ Array [
         <button
           class="css-p8ocxc"
           data-cy="fieldList-removeButton"
+          type="button"
         >
           <div
             tabindex="-1"
@@ -342,6 +345,7 @@ Array [
       class="css-67j5fi"
       data-cy="secondaryButton"
       tabindex="0"
+      type="button"
     >
       <span
         class="css-cdylxf"

--- a/packages/fullscreenView/tests/__snapshots__/fullscreenView.test.tsx.snap
+++ b/packages/fullscreenView/tests/__snapshots__/fullscreenView.test.tsx.snap
@@ -264,6 +264,7 @@ exports[`FullscreenView renders FullscreenView 1`] = `
                       data-cy="secondaryButton"
                       onClick={[Function]}
                       tabIndex={0}
+                      type="button"
                     >
                       <span
                         className=""
@@ -303,6 +304,7 @@ exports[`FullscreenView renders FullscreenView 1`] = `
                       data-cy="primaryButton"
                       onClick={[Function]}
                       tabIndex={0}
+                      type="button"
                     >
                       <span
                         className=""

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -1089,6 +1089,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                 class="emotion-8 emotion-9"
                                 data-cy="secondaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -1104,6 +1105,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                 class="emotion-11 emotion-12"
                                 data-cy="primaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -1220,6 +1222,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                 class="emotion-8 css-1h85cd2"
                                 data-cy="secondaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -1235,6 +1238,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                 class="emotion-10 css-xcotv6"
                                 data-cy="primaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -1389,6 +1393,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                       class="emotion-8 css-1h85cd2"
                                       data-cy="secondaryButton"
                                       tabindex="0"
+                                      type="button"
                                     >
                                       <span
                                         class=""
@@ -1404,6 +1409,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                       class="emotion-10 css-xcotv6"
                                       data-cy="primaryButton"
                                       tabindex="0"
+                                      type="button"
                                     >
                                       <span
                                         class=""
@@ -1519,6 +1525,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         class="emotion-8 css-1h85cd2"
                                         data-cy="secondaryButton"
                                         tabindex="0"
+                                        type="button"
                                       >
                                         <span
                                           class=""
@@ -1534,6 +1541,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         class="emotion-10 css-xcotv6"
                                         data-cy="primaryButton"
                                         tabindex="0"
+                                        type="button"
                                       >
                                         <span
                                           class=""
@@ -1676,6 +1684,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         data-cy="secondaryButton"
                                         onClick={[Function]}
                                         tabIndex={0}
+                                        type="button"
                                       >
                                         <span
                                           className=""
@@ -1703,6 +1712,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         data-cy="primaryButton"
                                         onClick={[Function]}
                                         tabIndex={0}
+                                        type="button"
                                       >
                                         <span
                                           className=""
@@ -2261,6 +2271,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                               class="emotion-1 css-1h85cd2"
                               data-cy="secondaryButton"
                               tabindex="0"
+                              type="button"
                             >
                               <span
                                 class=""
@@ -2276,6 +2287,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                               class="emotion-6 css-xcotv6"
                               data-cy="primaryButton"
                               tabindex="0"
+                              type="button"
                             >
                               <span
                                 class=""
@@ -2727,6 +2739,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                               class="emotion-8 emotion-9"
                               data-cy="secondaryButton"
                               tabindex="0"
+                              type="button"
                             >
                               <span
                                 class=""
@@ -2742,6 +2755,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                               class="emotion-11 emotion-12"
                               data-cy="primaryButton"
                               tabindex="0"
+                              type="button"
                             >
                               <span
                                 class=""
@@ -3108,6 +3122,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                 class="emotion-1 emotion-2"
                                 data-cy="secondaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -3135,6 +3150,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                 class="emotion-7 emotion-8"
                                 data-cy="primaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -3217,6 +3233,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                 class="emotion-1 css-1h85cd2"
                                 data-cy="secondaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -3244,6 +3261,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                 class="emotion-6 css-xcotv6"
                                 data-cy="primaryButton"
                                 tabindex="0"
+                                type="button"
                               >
                                 <span
                                   class=""
@@ -3364,6 +3382,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                       class="emotion-1 css-1h85cd2"
                                       data-cy="secondaryButton"
                                       tabindex="0"
+                                      type="button"
                                     >
                                       <span
                                         class=""
@@ -3391,6 +3410,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                       class="emotion-6 css-xcotv6"
                                       data-cy="primaryButton"
                                       tabindex="0"
+                                      type="button"
                                     >
                                       <span
                                         class=""
@@ -3472,6 +3492,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                         class="emotion-1 css-1h85cd2"
                                         data-cy="secondaryButton"
                                         tabindex="0"
+                                        type="button"
                                       >
                                         <span
                                           class=""
@@ -3499,6 +3520,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                         class="emotion-6 css-xcotv6"
                                         data-cy="primaryButton"
                                         tabindex="0"
+                                        type="button"
                                       >
                                         <span
                                           class=""
@@ -3629,6 +3651,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                               data-cy="secondaryButton"
                                               onClick={[Function]}
                                               tabIndex={0}
+                                              type="button"
                                             >
                                               <span
                                                 className=""
@@ -3668,6 +3691,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                               data-cy="primaryButton"
                                               onClick={[Function]}
                                               tabIndex={0}
+                                              type="button"
                                             >
                                               <span
                                                 className=""

--- a/packages/textInput/tests/__snapshots__/TextInputWithButtons.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithButtons.test.tsx.snap
@@ -286,6 +286,7 @@ exports[`TextInputWithIcon renders 1`] = `
             <ResetButton>
               <button
                 className="emotion-3"
+                type="button"
               >
                 <div
                   tabIndex={-1}
@@ -325,6 +326,7 @@ exports[`TextInputWithIcon renders 1`] = `
             <ResetButton>
               <button
                 className="emotion-3"
+                type="button"
               >
                 <div
                   tabIndex={-1}
@@ -609,6 +611,7 @@ exports[`TextInputWithIcon renders with colored button 1`] = `
             <ResetButton>
               <button
                 className="emotion-3"
+                type="button"
               >
                 <div
                   tabIndex={-1}


### PR DESCRIPTION
These changes were made to accommodate buttons nested inside of a <form> element. Without the 'type' attribute set, buttons inside of a <form> element default to 'type=submit', which causes unwanted/premature form submissions. When kommander upgrades to a version of ui-kit that includes these changes, Jira ticket DCOS-62594 should be resolved.