### PR TITLE
Some fixes for react warnings

### DIFF
--- a/packages/appChrome/components/Sidebar.tsx
+++ b/packages/appChrome/components/Sidebar.tsx
@@ -53,12 +53,12 @@ const StyledNav = styled("nav")`
 `;
 
 class Sidebar extends React.PureComponent<SidebarProps, {}> {
-  public componentWillReceiveProps(nextProps: SidebarProps) {
+  public componentDidUpdate(prevProps: SidebarProps) {
     const { onOpen, onClose } = this.props;
 
-    if (nextProps.isOpen && onOpen) {
+    if (prevProps.isOpen && onOpen) {
       onOpen();
-    } else if (!nextProps.isOpen && onClose) {
+    } else if (!prevProps.isOpen && onClose) {
       onClose();
     }
   }

--- a/packages/dropdownable/components/Dropdownable.tsx
+++ b/packages/dropdownable/components/Dropdownable.tsx
@@ -93,7 +93,7 @@ class Dropdownable extends React.Component<DropdownableProps, State> {
     resizeEventManager.remove(this.setPositionFromCurrentProps);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: DropdownableProps) {
     if (nextProps.open) {
       this.setPosition(nextProps);
     }

--- a/packages/legacy/src/Dropdown/Dropdown.tsx
+++ b/packages/legacy/src/Dropdown/Dropdown.tsx
@@ -84,7 +84,7 @@ export class Dropdown extends React.Component<DropdownProps, any> {
     });
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const props = this.props;
     if (!props.persistentID) {
       this.setState({ selectedID: props.initialID });
@@ -104,7 +104,7 @@ export class Dropdown extends React.Component<DropdownProps, any> {
     }
   }
 
-  componentWillUpdate(_, nextState) {
+  UNSAFE_componentWillUpdate(_, nextState) {
     // If the open state changed, add or remove listener as needed.
     if (nextState.isOpen !== this.state.isOpen) {
       if (nextState.isOpen) {

--- a/packages/legacy/src/Modal/ModalContents.tsx
+++ b/packages/legacy/src/Modal/ModalContents.tsx
@@ -85,7 +85,7 @@ export default class ModalContents extends React.Component<
     }
   }
 
-  componentWillUpdate(nextProps) {
+  UNSAFE_componentWillUpdate(nextProps) {
     // Reset the height of the content to null when the modal is closing so
     // that the height will be recalculated next time it opens.
     if (this.props.open && !nextProps.open) {
@@ -98,7 +98,7 @@ export default class ModalContents extends React.Component<
     }
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (this.props.open) {
       document.body.classList.add("no-overflow");
     }

--- a/packages/legacy/src/Modal/ModalContents.tsx
+++ b/packages/legacy/src/Modal/ModalContents.tsx
@@ -73,17 +73,15 @@ export default class ModalContents extends React.Component<
     });
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.open !== nextProps.open) {
-      document.body.classList.toggle("no-overflow");
-    }
-  }
-
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: ModalProps) {
     // If we don't already know the height of the content, we calculate it.
     if (this.props.open) {
       this.lastViewportHeight = Math.ceil(DOMUtil.getViewportHeight());
       window.requestAnimationFrame(this.calculateContentHeight);
+    }
+
+    if (this.props.open !== prevProps.open) {
+      document.body.classList.toggle("no-overflow");
     }
   }
 

--- a/packages/textInput/components/TextInput.tsx
+++ b/packages/textInput/components/TextInput.tsx
@@ -168,6 +168,7 @@ export class TextInput<
       showInputLabel,
       type,
       errors,
+      tooltipContent,
       ...inputElementProps
     } = this.props as TextInputProps;
 

--- a/packages/textInput/components/TextInputWithBadges.tsx
+++ b/packages/textInput/components/TextInputWithBadges.tsx
@@ -76,6 +76,7 @@ export class TextInputWithBadges extends TextInputWithIcon<
     let baseProps = super.getInputElementProps();
     const {
       badges,
+      badgeAppearance,
       onBadgeChange,
       downshiftReset,
       addBadgeOnBlur,

--- a/packages/toaster/components/Toaster.tsx
+++ b/packages/toaster/components/Toaster.tsx
@@ -47,7 +47,7 @@ class Toaster extends React.PureComponent<ToasterProps, ToasterState> {
     this.restartTimeouts();
   }
 
-  public componentWillReceiveProps(nextProps: ToasterProps) {
+  public UNSAFE_componentWillReceiveProps(nextProps: ToasterProps) {
     const currentToasts = this.state.toasts || [];
     const childIds =
       (nextProps.children && nextProps.children.map(toast => toast.props.id)) ||

--- a/packages/toaster/tests/Toaster.test.tsx
+++ b/packages/toaster/tests/Toaster.test.tsx
@@ -97,7 +97,7 @@ describe("Toaster", () => {
     const instance = component.find(Toaster).instance() as Toaster;
 
     expect(instance.state.toasts && instance.state.toasts.length).toEqual(1);
-    instance.componentWillReceiveProps(newProps);
+    instance.UNSAFE_componentWillReceiveProps(newProps);
     expect(instance.state.toasts && instance.state.toasts.length).toEqual(2);
   });
 });


### PR DESCRIPTION
## Overview
In some cases, I converted componentWillReceiveProps to componentDidUpdate or just added the UNSAFE_ prefix if a more involved refactor would be necessary.

I also added a couple of properties to relevant props lists so they wouldn't be rendered onto an input dom element.

It appears that many react warnings could be resolved by upgrading to emotion 10. I found a migration guide that doesn't look too crazy: https://emotion.sh/docs/migrating-to-emotion-10

## Testing
I only used the storybook which admittedly doesn't show react warnings. I did not test the legacy modal.