### PR TITLE
DCOS-62619: globally style all anchor tags

### DIFF
--- a/packages/shared/styles/global.ts
+++ b/packages/shared/styles/global.ts
@@ -6,9 +6,12 @@ import {
   themeTextColorPrimary,
   themeBgPrimary
 } from "../../design-tokens/build/js/designTokens";
+import { normalize } from "./normalize";
 
 export const injectGlobalCss = () => {
   return injectGlobal`
+    ${normalize};
+
     .ReactVirtualized__Grid {
       outline: none;
     }

--- a/packages/shared/styles/normalize.ts
+++ b/packages/shared/styles/normalize.ts
@@ -1,0 +1,9 @@
+import { themeTextColorInteractive } from "../../design-tokens/build/js/designTokens";
+
+// TODO: follow-up with Jira ticket DCOS-62772 (a more thorough set of normalize styles)
+export const normalize = `
+    a {
+        text-decoration: none;
+        color: ${themeTextColorInteractive};
+    }
+`;


### PR DESCRIPTION
Before:
<img width="259" alt="Screen Shot 2020-01-09 at 5 34 46 PM" src="https://user-images.githubusercontent.com/2313998/72110644-b653ff80-3306-11ea-8707-2cf27db0e479.png">

After:
<img width="259" alt="Screen Shot 2020-01-09 at 5 34 25 PM" src="https://user-images.githubusercontent.com/2313998/72110654-ba801d00-3306-11ea-9008-6875c67a10e1.png">
