### PR TITLE
Don't submit a form when pressing enter inside of a TextInputWithBadges

### DIFF
--- a/packages/textInput/components/TextInputWithBadges.tsx
+++ b/packages/textInput/components/TextInputWithBadges.tsx
@@ -83,6 +83,14 @@ export class TextInputWithBadges extends TextInputWithIcon<
     } = baseProps as TextInputWithBadgesProps;
     inputProps.onKeyDown = this.handleKeyDown;
     inputProps.onKeyUp = this.handleKeyUp;
+    inputProps.onKeyPress = e => {
+      if (this.props.onKeyPress) {
+        this.props.onKeyPress(e);
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+      }
+    };
     inputProps.onBlur = this.handleBlur.bind(this, inputProps.onBlur);
     inputProps.type = "text";
     inputProps.ref = this.inputRef;
@@ -198,6 +206,7 @@ export class TextInputWithBadges extends TextInputWithIcon<
 
   private handleKeyUp(e) {
     if (e.key === "Enter") {
+      e.preventDefault();
       this.handleTagAdd(getStringAsBadgeDatum(e.target.value));
     }
 

--- a/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
@@ -567,6 +567,7 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
           onBlur={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
+          onKeyPress={[Function]}
           onKeyUp={[Function]}
           type="text"
         />
@@ -743,6 +744,7 @@ exports[`TextInputWithBadges renders empty 1`] = `
           onBlur={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
+          onKeyPress={[Function]}
           onKeyUp={[Function]}
           type="text"
         />
@@ -1319,6 +1321,7 @@ exports[`TextInputWithBadges renders with badges 1`] = `
           onBlur={[Function]}
           onFocus={[Function]}
           onKeyDown={[Function]}
+          onKeyPress={[Function]}
           onKeyUp={[Function]}
           type="text"
         />


### PR DESCRIPTION
These changes prevent a form from being submitted when pressing the "Enter" key inside of a TextInputWithBadges input.