### PR TITLE
D2IQ-63790: darken the text color for sidebar submenu items on a light background

### DIFF
--- a/packages/appChrome/components/SidebarSubMenuItem.tsx
+++ b/packages/appChrome/components/SidebarSubMenuItem.tsx
@@ -11,7 +11,6 @@ import Clickable from "../../clickable/components/clickable";
 import { withTheme } from "emotion-theming";
 import getCSSVarValue from "../../utilities/getCSSVarValue";
 import {
-  themeTextColorSecondary,
   themeTextColorPrimary,
   themeTextColorPrimaryInverted,
   themeTextColorSecondaryInverted,
@@ -50,7 +49,7 @@ class SidebarSubMenuItem extends React.PureComponent<
       tintContent(
         pickReadableTextColor(
           sidebarBgColor,
-          getCSSVarValue(themeTextColorSecondary),
+          getCSSVarValue(themeTextColorPrimary),
           getCSSVarValue(themeTextColorSecondaryInverted)
         )
       ),


### PR DESCRIPTION
Closes [D2IQ-63790](https://jira.d2iq.com/browse/D2IQ-63790)

## Screenshot
<img width="1678" alt="Screen Shot 2020-02-10 at 6 04 17 PM" src="https://user-images.githubusercontent.com/2313998/74264321-7a79d480-4cce-11ea-8de6-c0ef7fc6c030.png">
