### PR TITLE
D2IQ-63606: add new icons used in Kommander

### DIFF
--- a/packages/icons/src/icon-product/cluster-attach-inverse.svg
+++ b/packages/icons/src/icon-product/cluster-attach-inverse.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="-41.426" y1="-42.495" x2="-41.426" y2="-41.949" gradientTransform="matrix(10.051 0 0 8.058 432.371 356.716)">
+            <stop offset="0" stop-color="#fff" stop-opacity=".6"/>
+            <stop offset="1" stop-color="#fff" stop-opacity=".4"/>
+        </linearGradient>
+        <linearGradient id="b" gradientUnits="userSpaceOnUse" x1="16" y1="2" x2="16" y2="14" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#fff"/>
+            <stop offset="1" stop-color="#fff" stop-opacity=".8"/>
+        </linearGradient>
+        <linearGradient id="c" gradientUnits="userSpaceOnUse" x1="6.5" y1="13" x2="6.5" y2="22" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#fff"/>
+            <stop offset="1" stop-color="#fff" stop-opacity=".8"/>
+        </linearGradient>
+    </defs>
+    <path d="M15.4 14.3v2l-2.2 1.6c.3.2.6.5.8.8l2-1.5 2 1.5c.2-.3.5-.6.8-.8l-2.2-1.6v-2c-.4.1-.8.1-1.2 0z" fill="url(#a)"/>
+    <path d="M12.2 22C11 22 10 21 10 19.8s1-2.2 2.2-2.2 2.2 1 2.2 2.2-1 2.2-2.2 2.2zm7.6 0c-1.2 0-2.2-1-2.2-2.2s1-2.2 2.2-2.2 2.2 1 2.2 2.2-1 2.2-2.2 2.2zM16 14.4c-1.2 0-2.2-1-2.2-2.2s1-2.2 2.2-2.2 2.2 1 2.2 2.2-1 2.2-2.2 2.2z" fill="url(#b)"/>
+    <path d="M2 3c0-.5.5-1 1-1h7c.6 0 1 .5 1 1v7c0 .6-.4 1-1 1H3c-.5 0-1-.4-1-1V3zm5.2 2.7V3.1H5.7v2.6H3.2v1.4h2.5v2.8h1.5V7.1h2.6V5.7H7.2z" fill="url(#c)"/>
+</svg>

--- a/packages/icons/src/icon-product/cluster-attach.svg
+++ b/packages/icons/src/icon-product/cluster-attach.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="-41.426" y1="-42.495" x2="-41.426" y2="-41.949" gradientTransform="matrix(10.051 0 0 8.058 432.371 356.716)">
+            <stop offset="0" stop-color="#9779ff" stop-opacity=".4"/>
+            <stop offset="1" stop-color="#7d58ff" stop-opacity=".4"/>
+        </linearGradient>
+        <linearGradient id="b" gradientUnits="userSpaceOnUse" x1="16" y1="2" x2="16" y2="14" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#9779ff"/>
+            <stop offset="1" stop-color="#7d58ff"/>
+        </linearGradient>
+        <linearGradient id="c" gradientUnits="userSpaceOnUse" x1="6.5" y1="13" x2="6.5" y2="22" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#9779ff"/>
+            <stop offset="1" stop-color="#7d58ff"/>
+        </linearGradient>
+    </defs>
+    <path d="M15.4 14.3v2l-2.2 1.6c.3.2.6.5.8.8l2-1.5 2 1.5c.2-.3.5-.6.8-.8l-2.2-1.6v-2c-.4.1-.8.1-1.2 0z" fill="url(#a)"/>
+    <path d="M12.2 22C11 22 10 21 10 19.8s1-2.2 2.2-2.2 2.2 1 2.2 2.2-1 2.2-2.2 2.2zm7.6 0c-1.2 0-2.2-1-2.2-2.2s1-2.2 2.2-2.2 2.2 1 2.2 2.2-1 2.2-2.2 2.2zM16 14.4c-1.2 0-2.2-1-2.2-2.2s1-2.2 2.2-2.2 2.2 1 2.2 2.2-1 2.2-2.2 2.2z" fill="url(#b)"/>
+    <path d="M2 3c0-.5.5-1 1-1h7c.6 0 1 .5 1 1v7c0 .6-.4 1-1 1H3c-.5 0-1-.4-1-1V3zm5.2 2.7V3.1H5.7v2.6H3.2v1.4h2.5v2.8h1.5V7.1h2.6V5.7H7.2z" fill="url(#c)"/>
+</svg>

--- a/packages/icons/src/icon-product/file-yaml-inverse.svg
+++ b/packages/icons/src/icon-product/file-yaml-inverse.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="9.85" y1="22.527" x2="9.85" y2=".349" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#fff" stop-opacity=".6"/>
+            <stop offset="1" stop-color="#fff" stop-opacity=".4"/>
+        </linearGradient>
+        <linearGradient id="b" gradientUnits="userSpaceOnUse" x1="14.67" y1="26.63" x2="14.67" y2="-10.865" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#fff"/>
+            <stop offset="1" stop-color="#fff" stop-opacity=".8"/>
+        </linearGradient>
+    </defs>
+    <path d="M7.5 19.6c-.6 0-1.2-.5-1.2-1.1v-5.2c0-.6.5-1.1 1.2-1.1h11.2V8.7L11 1H2.1C1.5 1 1 1.5 1 2.1v19.8c0 .6.5 1.1 1.1 1.1h15.5c.6 0 1.1-.5 1.1-1.1v-2.3H7.5z" fill="url(#a)"/>
+    <path d="M12.3 14.8l.5 1.6h-1.1l.6-1.6zM23 13.3v5.2c0 .6-.5 1.1-1.1 1.1H7.5c-.6 0-1.2-.5-1.2-1.1v-5.2c0-.6.5-1.1 1.2-1.1h14.4c.6-.1 1.1.4 1.1 1.1zm-13.6 3l1.4-2.4h-.7l-.9 1.6-.9-1.6h-.9l1.3 2.4v1.5h.7v-1.5zm4.6 1.4l-1.3-3.8h-.8l-1.3 3.8h.7l.2-.7H13l.2.7h.8zm4.4-3.8h-.9l-1 2.7-1-2.7h-.9v3.8h.7V15l1 2.7h.5l1-2.6v2.7h.7v-3.9zm3.5 3.2h-1.8V14h-.7v3.8h2.5v-.7zM11 1v6.6c0 .6.5 1.1 1.1 1.1h6.6L11 1z" fill="url(#b)"/>
+</svg>

--- a/packages/icons/src/icon-product/file-yaml.svg
+++ b/packages/icons/src/icon-product/file-yaml.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="4.999" y1="22.282" x2="12.071" y2="2.336" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#9678ff"/>
+            <stop offset="1" stop-color="#7d58ff"/>
+        </linearGradient>
+        <linearGradient id="b" gradientUnits="userSpaceOnUse" x1="14.67" y1="26.63" x2="14.67" y2="-10.865" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#9678ff"/>
+            <stop offset="1" stop-color="#7d58ff"/>
+        </linearGradient>
+    </defs>
+    <path d="M7.5 19.6c-.6 0-1.2-.5-1.2-1.1v-5.2c0-.6.5-1.1 1.2-1.1h11.2V8.7L11 1H2.1C1.5 1 1 1.5 1 2.1v19.8c0 .6.5 1.1 1.1 1.1h15.5c.6 0 1.1-.5 1.1-1.1v-2.3H7.5z" opacity=".4" fill="url(#a)"/>
+    <path d="M12.3 14.8l.5 1.6h-1.1l.6-1.6zM23 13.3v5.2c0 .6-.5 1.1-1.1 1.1H7.5c-.6 0-1.2-.5-1.2-1.1v-5.2c0-.6.5-1.1 1.2-1.1h14.4c.6-.1 1.1.4 1.1 1.1zm-13.6 3l1.4-2.4h-.7l-.9 1.6-.9-1.6h-.9l1.3 2.4v1.5h.7v-1.5zm4.6 1.4l-1.3-3.8h-.8l-1.3 3.8h.7l.2-.7H13l.2.7h.8zm4.4-3.8h-.9l-1 2.7-1-2.7h-.9v3.8h.7V15l1 2.7h.5l1-2.6v2.7h.7v-3.9zm3.5 3.2h-1.8V14h-.7v3.8h2.5v-.7zM11 1v6.6c0 .6.5 1.1 1.1 1.1h6.6L11 1z" fill="url(#b)"/>
+</svg>

--- a/packages/icons/src/icon-product/global-inverse.svg
+++ b/packages/icons/src/icon-product/global-inverse.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <defs>
+        <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="1.77" y1="8.37" x2="17.594" y2="8.37" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#fff" stop-opacity=".4"/>
+            <stop offset="1" stop-color="#fff" stop-opacity=".6"/>
+        </linearGradient>
+        <linearGradient id="b" gradientUnits="userSpaceOnUse" x1="1" y1="12" x2="23" y2="12" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#fff"/>
+            <stop offset="1" stop-color="#fff" stop-opacity=".8"/>
+        </linearGradient>
+    </defs>
+    <circle cx="8.4" cy="15.6" r="3.6" fill="url(#a)"/>
+    <path d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zM8.4 19.3c-2 0-3.6-1.6-3.6-3.6S6.4 12 8.4 12s3.6 1.6 3.6 3.6-1.6 3.7-3.6 3.7z" fill="url(#b)"/>
+</svg>

--- a/packages/icons/src/icon-product/global.svg
+++ b/packages/icons/src/icon-product/global.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <defs>
+        <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="1.77" y1="8.37" x2="17.594" y2="8.37" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#9779ff"/>
+            <stop offset="1" stop-color="#7d58ff"/>
+        </linearGradient>
+        <linearGradient id="b" gradientUnits="userSpaceOnUse" x1="1" y1="12" x2="23" y2="12" gradientTransform="matrix(1 0 0 -1 0 24)">
+            <stop offset="0" stop-color="#9779ff"/>
+            <stop offset="1" stop-color="#7d58ff"/>
+        </linearGradient>
+    </defs>
+    <circle cx="8.4" cy="15.6" r="3.6" opacity=".4" fill="url(#a)"/>
+    <path d="M12 1C5.9 1 1 5.9 1 12s4.9 11 11 11 11-4.9 11-11S18.1 1 12 1zM8.4 19.3c-2 0-3.6-1.6-3.6-3.6S6.4 12 8.4 12s3.6 1.6 3.6 3.6-1.6 3.7-3.6 3.7z" fill="url(#b)"/>
+</svg>


### PR DESCRIPTION
Adds product icons for representing:
- the global level of an organization's hierarchy
- attaching a cluster to a management cluster
- YAML files

Closes D2IQ-64258, D2IQ-64264, and D2IQ-64265

## Screenshot
<img width="1134" alt="Image 2020-02-18 at 12 00 54 PM" src="https://user-images.githubusercontent.com/2313998/74759781-50349380-5247-11ea-95b5-53045034793c.png">
