### PR TITLE
refactor: remove immutable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -987,7 +987,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
@@ -9431,7 +9431,7 @@
         },
         "query-string": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
@@ -10487,7 +10487,7 @@
       "dependencies": {
         "jest-worker": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
           "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
           "dev": true,
           "requires": {
@@ -12400,7 +12400,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         }
@@ -12759,7 +12759,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -12780,12 +12781,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -12800,17 +12803,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -12927,7 +12933,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -12939,6 +12946,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -12953,6 +12961,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -12960,12 +12969,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12984,6 +12995,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -13064,7 +13076,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -13076,6 +13089,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13161,7 +13175,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13197,6 +13212,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13216,6 +13232,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13259,12 +13276,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -14161,11 +14180,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-1.12.1.tgz",
       "integrity": "sha512-3fmKM6ovaqDt0CdC9daXpNi5x/YCYS3i4cwLdTVkhJdk5jrDXoPs7lCm3IqM3yhfSnz4tjjxbRG2CziQ7m8ztg==",
       "dev": true
-    },
-    "immutable": {
-      "version": "4.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
-      "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -15735,7 +15749,7 @@
         },
         "jest-diff": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
           "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
           "dev": true,
           "requires": {
@@ -15747,7 +15761,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -17528,11 +17542,6 @@
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true,
       "optional": true
-    },
-    "nanoid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.3.tgz",
-      "integrity": "sha512-NbaoqdhIYmY6FXDRB4eYtDVC9Z9eCbn8TyaiC16LNKtpPv/aqa0tOPD8y6gNE4yUNnaZ7LLhYtXOev/6+cBtfw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -19476,13 +19485,13 @@
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -19491,17 +19500,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": false,
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -20170,7 +20179,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
       "dev": true
     },
@@ -20196,7 +20205,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -23249,14 +23258,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "shortid": {
-      "version": "2.2.14",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
-      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
-      "requires": {
-        "nanoid": "^2.0.0"
-      }
-    },
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
@@ -24203,7 +24204,7 @@
       "dependencies": {
         "colors": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "downshift": "3.2.10",
     "emotion": "9.2.12",
     "emotion-theming": "9.2.9",
-    "immutable": "^4.0.0-rc.12",
     "memoize-one": "4.0.2",
     "react-chartist": "^0.13.3",
     "react-click-outside": "3.0.1",

--- a/packages/table/components/Table.tsx
+++ b/packages/table/components/Table.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import Immutable from "immutable";
 import Draggable from "react-draggable";
 import { cx, css } from "emotion";
 import memoizeOne from "memoize-one";
@@ -74,7 +73,7 @@ export interface TableProps {
 export interface TableState {
   isScrolling: boolean;
   hoveredRowIndex: number;
-  resizedColWidths: Immutable.Map<string, number>;
+  resizedColWidths: Map<string, number>;
   resizeIndex: number;
 }
 
@@ -209,11 +208,11 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
           child.props.maxWidth || width
         );
         remainingWidth -= clampedWidth;
-        return resizedColWidths.get(currentIndex.toString(), clampedWidth);
+        return resizedColWidths.get(currentIndex.toString()) || clampedWidth;
       });
 
       const colSizeCacheVals = colSizeCache.map((colSize, i) => {
-        const colWidth = resizedColWidths.get(i.toString(), colSize);
+        const colWidth = resizedColWidths.get(i.toString()) || colSize;
         return colWidth;
       });
 
@@ -253,7 +252,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
     this.state = {
       isScrolling: false,
       hoveredRowIndex: -1,
-      resizedColWidths: Immutable.Map(),
+      resizedColWidths: new Map(),
       resizeIndex: -1
     };
   }
@@ -305,7 +304,7 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
       width
     );
 
-    return resizedColWidths.get(index.toString(), columnSizes[index]);
+    return resizedColWidths.get(index.toString()) || columnSizes[index];
   }
 
   public resizeColumn(args: { dragDelta: number; index: string }) {
@@ -318,9 +317,10 @@ export class Table<T> extends React.PureComponent<TableProps, TableState> {
     let columnWidth = this.getColumnWidth(index, this.getContainerWidth());
     columnWidth = columnWidth + dragDelta;
 
+    const newResizedColWidths = new Map(resizedColWidths);
     this.setState(
       {
-        resizedColWidths: resizedColWidths.set(index, columnWidth)
+        resizedColWidths: newResizedColWidths.set(index, columnWidth)
       },
       () => {
         if (columns[index].props.onResize) {

--- a/packages/table/stories/helpers/ResizableTableOnResizeDemo.tsx
+++ b/packages/table/stories/helpers/ResizableTableOnResizeDemo.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
-import Immutable from "immutable";
 import { cx } from "emotion";
 import { Table, Column, HeaderCell, TextCell } from "../..";
 import { items } from "./mocks";
 import { listReset, padding } from "../../../shared/styles/styleUtils";
 
 interface ResizableTableDemoState {
-  resizedVals: Immutable.Map<string, number>;
+  resizedVals: Map<string, number>;
 }
 
 const nameCellRenderer = ({ name }: { name?: string }) => (
@@ -32,7 +31,7 @@ class ResizableTableDemo extends React.Component<{}, ResizableTableDemoState> {
     super(props);
 
     this.state = {
-      resizedVals: Immutable.Map()
+      resizedVals: new Map()
     };
 
     this.handleResize = this.handleResize.bind(this);
@@ -41,8 +40,9 @@ class ResizableTableDemo extends React.Component<{}, ResizableTableDemoState> {
   handleResize(columnName, resizedColWidth) {
     const { resizedVals } = this.state;
 
+    const newResizedVals = new Map(resizedVals);
     this.setState({
-      resizedVals: resizedVals.set(columnName, resizedColWidth)
+      resizedVals: newResizedVals.set(columnName, resizedColWidth)
     });
   }
 
@@ -52,9 +52,9 @@ class ResizableTableDemo extends React.Component<{}, ResizableTableDemoState> {
     return (
       <div>
         <ul className={cx(listReset, padding("bottom"))}>
-          <li>Name resized value: {resizedVals.get("name", "unset")}</li>
-          <li>Role resized value: {resizedVals.get("role", "unset")}</li>
-          <li>State resized value: {resizedVals.get("state", "unset")}</li>
+          <li>Name resized value: {resizedVals.get("name") || "unset"}</li>
+          <li>Role resized value: {resizedVals.get("role") || "unset"}</li>
+          <li>State resized value: {resizedVals.get("state") || "unset"}</li>
         </ul>
         <div
           style={{


### PR DESCRIPTION
it seems overkill to have a big library for handling two places that need
immutable data.

this should trim down the size of the build a bit (like ~15kb gzipped on dcos-ui).