### PR TITLE
Adds a prop to open button links in a new tab

### DIFF
--- a/packages/button/components/ButtonBase.tsx
+++ b/packages/button/components/ButtonBase.tsx
@@ -76,6 +76,10 @@ export interface ButtonProps {
    * a url the user will be navigated to when clicking the button. This also changes the tag to `<a>`
    */
   url?: string;
+  /**
+   * if the `url` prop is set, this will open that link in a new tab
+   */
+  openInNewTab?: boolean;
 }
 
 export interface ButtonBaseProps extends ButtonProps {
@@ -104,6 +108,7 @@ class ButtonBase extends React.PureComponent<ButtonBaseProps, {}> {
       onClick,
       type = "button",
       url,
+      openInNewTab,
       ...other
     } = this.props;
 
@@ -130,6 +135,7 @@ class ButtonBase extends React.PureComponent<ButtonBaseProps, {}> {
             className={buttonClassName}
             onClick={this.onClick}
             tabIndex={0}
+            target={openInNewTab ? "_blank" : "_self"}
             {...other}
           >
             {this.getButtonContent()}

--- a/packages/button/stories/DefaultButton.stories.tsx
+++ b/packages/button/stories/DefaultButton.stories.tsx
@@ -241,4 +241,60 @@ storiesOf("Buttons/Default", module)
         propTables: [StandardButton]
       }
     }
+  )
+  .add(
+    "used as a link that opens in a new tab",
+    () => (
+      <React.Fragment>
+        <ButtonAppearanceSample>
+          <StandardButton url="http://google.com" openInNewTab={true}>
+            Button
+          </StandardButton>
+          <StandardButton
+            url="http://google.com"
+            openInNewTab={true}
+            disabled={true}
+          >
+            Button
+          </StandardButton>
+          <StandardButton
+            url="http://google.com"
+            openInNewTab={true}
+            isProcessing={true}
+          >
+            Button
+          </StandardButton>
+        </ButtonAppearanceSample>
+        <ButtonAppearanceSample isInverse={true}>
+          <StandardButton
+            url="http://google.com"
+            openInNewTab={true}
+            isInverse={true}
+          >
+            Button
+          </StandardButton>
+          <StandardButton
+            url="http://google.com"
+            openInNewTab={true}
+            disabled={true}
+            isInverse={true}
+          >
+            Button
+          </StandardButton>
+          <StandardButton
+            url="http://google.com"
+            openInNewTab={true}
+            isProcessing={true}
+            isInverse={true}
+          >
+            Button
+          </StandardButton>
+        </ButtonAppearanceSample>
+      </React.Fragment>
+    ),
+    {
+      info: {
+        propTables: [StandardButton]
+      }
+    }
   );


### PR DESCRIPTION
There are already plans to improve how we deal with links in ui-kit ([D2IQ-61570](https://jira.d2iq.com/browse/D2IQ-61570)), but I'm not sure when that ticket will get worked on. 

This is an issue that causes enough headaches that I think this quick fix makes sense.