### PR TITLE
chore: remove some warnings that appear during jest

### DIFF
--- a/packages/checkboxInput/components/CheckboxInput.tsx
+++ b/packages/checkboxInput/components/CheckboxInput.tsx
@@ -118,7 +118,7 @@ class CheckboxInput extends React.PureComponent<
                 disabled={disabled}
                 value={value}
                 aria-invalid={!isValid}
-                aria-describedBy={describedByIds}
+                aria-describedby={describedByIds}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
                 data-cy={inputDataCy}

--- a/packages/checkboxInput/tests/__snapshots__/CheckboxInput.test.tsx.snap
+++ b/packages/checkboxInput/tests/__snapshots__/CheckboxInput.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`CheckboxInput renders all appearances 1`] = `
               className="emotion-1"
             >
               <input
-                aria-describedBy=""
+                aria-describedby=""
                 aria-invalid={false}
                 className="emotion-0"
                 data-cy="checkboxInput-input"
@@ -276,7 +276,7 @@ exports[`CheckboxInput renders all appearances 2`] = `
               className="emotion-1"
             >
               <input
-                aria-describedBy=""
+                aria-describedby=""
                 aria-invalid={false}
                 className="emotion-0"
                 data-cy="checkboxInput-input checkboxInput-input.error"
@@ -427,7 +427,7 @@ exports[`CheckboxInput renders all appearances 3`] = `
               className="emotion-1"
             >
               <input
-                aria-describedBy=""
+                aria-describedby=""
                 aria-invalid={false}
                 className="emotion-0"
                 data-cy="checkboxInput-input checkboxInput-input.success"
@@ -605,7 +605,7 @@ exports[`CheckboxInput renders indeterminate 1`] = `
               className="emotion-3"
             >
               <input
-                aria-describedBy=""
+                aria-describedby=""
                 aria-invalid={false}
                 className="emotion-0"
                 data-cy="checkboxInput-input checkboxInput-input.indeterminate"
@@ -788,7 +788,7 @@ exports[`CheckboxInput renders with a hidden label 1`] = `
               className="emotion-1"
             >
               <input
-                aria-describedBy=""
+                aria-describedby=""
                 aria-invalid={false}
                 className="emotion-0"
                 data-cy="checkboxInput-input"

--- a/packages/toggleBox/tests/__snapshots__/ToggleBox.test.tsx.snap
+++ b/packages/toggleBox/tests/__snapshots__/ToggleBox.test.tsx.snap
@@ -76,9 +76,9 @@ exports[`ToggleBox renders active 1`] = `
     >
       <input
         aria-checked={true}
-        checked={true}
         className="emotion-0"
         data-cy="toggleWrapper-input"
+        defaultChecked={true}
         disabled={false}
         id="active"
         onBlur={[Function]}

--- a/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
+++ b/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
@@ -149,9 +149,9 @@ exports[`ToggleBoxGroup renders default 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="exosphere"
                   name="default"
@@ -221,9 +221,9 @@ exports[`ToggleBoxGroup renders default 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="thermosphere"
                   name="default"
@@ -293,9 +293,9 @@ exports[`ToggleBoxGroup renders default 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="mesosphere"
                   name="default"
@@ -523,9 +523,9 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="exosphere"
                   name="selectedItems"
@@ -595,9 +595,9 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="thermosphere"
                   name="selectedItems"
@@ -667,9 +667,9 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
               >
                 <input
                   aria-checked={true}
-                  checked={true}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={true}
                   disabled={false}
                   id="mesosphere"
                   name="selectedItems"
@@ -862,9 +862,9 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="exosphere"
                   name="customLayoutProps"
@@ -934,9 +934,9 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="thermosphere"
                   name="customLayoutProps"
@@ -1006,9 +1006,9 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
               >
                 <input
                   aria-checked={false}
-                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
+                  defaultChecked={false}
                   disabled={false}
                   id="mesosphere"
                   name="customLayoutProps"

--- a/packages/toggleInputList/tests/__snapshots__/ToggleInputList.test.tsx.snap
+++ b/packages/toggleInputList/tests/__snapshots__/ToggleInputList.test.tsx.snap
@@ -203,7 +203,7 @@ exports[`ToggleInputList renders default 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -269,7 +269,7 @@ exports[`ToggleInputList renders default 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -335,7 +335,7 @@ exports[`ToggleInputList renders default 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -597,7 +597,7 @@ exports[`ToggleInputList renders with error label appearance 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -663,7 +663,7 @@ exports[`ToggleInputList renders with error label appearance 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -729,7 +729,7 @@ exports[`ToggleInputList renders with error label appearance 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -1007,7 +1007,7 @@ exports[`ToggleInputList renders with errors 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -1073,7 +1073,7 @@ exports[`ToggleInputList renders with errors 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -1139,7 +1139,7 @@ exports[`ToggleInputList renders with errors 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -1395,7 +1395,7 @@ exports[`ToggleInputList renders with hidden label 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -1461,7 +1461,7 @@ exports[`ToggleInputList renders with hidden label 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -1527,7 +1527,7 @@ exports[`ToggleInputList renders with hidden label 1`] = `
                         className="emotion-2"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"
@@ -1797,7 +1797,7 @@ exports[`ToggleInputList renders with required 1`] = `
                         className="emotion-3"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-2"
@@ -1863,7 +1863,7 @@ exports[`ToggleInputList renders with required 1`] = `
                         className="emotion-3"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-2"
@@ -1929,7 +1929,7 @@ exports[`ToggleInputList renders with required 1`] = `
                         className="emotion-3"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-2"
@@ -2207,7 +2207,7 @@ exports[`ToggleInputList renders with selected items 1`] = `
                         className="emotion-4"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={true}
                           className="emotion-1"
@@ -2297,7 +2297,7 @@ exports[`ToggleInputList renders with selected items 1`] = `
                         className="emotion-4"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={true}
                           className="emotion-1"
@@ -2387,7 +2387,7 @@ exports[`ToggleInputList renders with selected items 1`] = `
                         className="emotion-20"
                       >
                         <input
-                          aria-describedBy=""
+                          aria-describedby=""
                           aria-invalid={false}
                           checked={false}
                           className="emotion-1"

--- a/packages/toggleWrapper/components/ToggleWrapper.tsx
+++ b/packages/toggleWrapper/components/ToggleWrapper.tsx
@@ -69,7 +69,7 @@ class ToggleWrapper extends React.PureComponent<
         <input
           id={id}
           className={visuallyHidden}
-          checked={isActive}
+          defaultChecked={isActive}
           aria-checked={isActive}
           data-cy="toggleWrapper-input"
           onFocus={this.handleFocus}

--- a/packages/toggleWrapper/tests/__snapshots__/ToggleWrapper.test.tsx.snap
+++ b/packages/toggleWrapper/tests/__snapshots__/ToggleWrapper.test.tsx.snap
@@ -26,9 +26,9 @@ exports[`ToggleWrapper renders 1`] = `
   >
     <input
       aria-checked={true}
-      checked={true}
       className="emotion-0"
       data-cy="toggleWrapper-input"
+      defaultChecked={true}
       onBlur={[Function]}
       onFocus={[Function]}
       type="checkbox"
@@ -66,9 +66,9 @@ exports[`ToggleWrapper renders as a radio input 1`] = `
   >
     <input
       aria-checked={true}
-      checked={true}
       className="emotion-0"
       data-cy="toggleWrapper-input"
+      defaultChecked={true}
       onBlur={[Function]}
       onFocus={[Function]}
       type="radio"


### PR DESCRIPTION
they most likely also appear during runtime.

there are 3 warnings left that need some more attention than just changing some
prop names. :/

👇 those are no more!
![pbeitz ❐ main ● 1  tmux  2020-02-26 23-34-29](https://user-images.githubusercontent.com/300861/75394711-07d53f80-58f1-11ea-9a2a-298bf930c75c.png)
