### PR TITLE
Change ToggleWrapper back to a controlled component

### DIFF
--- a/packages/toggleBox/tests/__snapshots__/ToggleBox.test.tsx.snap
+++ b/packages/toggleBox/tests/__snapshots__/ToggleBox.test.tsx.snap
@@ -76,9 +76,9 @@ exports[`ToggleBox renders active 1`] = `
     >
       <input
         aria-checked={true}
+        checked={true}
         className="emotion-0"
         data-cy="toggleWrapper-input"
-        defaultChecked={true}
         disabled={false}
         id="active"
         onBlur={[Function]}

--- a/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
+++ b/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
@@ -149,9 +149,9 @@ exports[`ToggleBoxGroup renders default 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="exosphere"
                   name="default"
@@ -221,9 +221,9 @@ exports[`ToggleBoxGroup renders default 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="thermosphere"
                   name="default"
@@ -293,9 +293,9 @@ exports[`ToggleBoxGroup renders default 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="mesosphere"
                   name="default"
@@ -510,9 +510,9 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
                 >
                   <input
                     aria-checked={false}
+                    checked={false}
                     className="emotion-1"
                     data-cy="toggleWrapper-input"
-                    defaultChecked={false}
                     disabled={false}
                     id="exosphere"
                     name="default"
@@ -582,9 +582,9 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
                 >
                   <input
                     aria-checked={false}
+                    checked={false}
                     className="emotion-1"
                     data-cy="toggleWrapper-input"
-                    defaultChecked={false}
                     disabled={false}
                     id="thermosphere"
                     name="default"
@@ -654,9 +654,9 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
                 >
                   <input
                     aria-checked={false}
+                    checked={false}
                     className="emotion-1"
                     data-cy="toggleWrapper-input"
-                    defaultChecked={false}
                     disabled={false}
                     id="mesosphere"
                     name="default"
@@ -885,9 +885,9 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="exosphere"
                   name="selectedItems"
@@ -957,9 +957,9 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="thermosphere"
                   name="selectedItems"
@@ -1029,9 +1029,9 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
               >
                 <input
                   aria-checked={true}
+                  checked={true}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={true}
                   disabled={false}
                   id="mesosphere"
                   name="selectedItems"
@@ -1224,9 +1224,9 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="exosphere"
                   name="customLayoutProps"
@@ -1296,9 +1296,9 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="thermosphere"
                   name="customLayoutProps"
@@ -1368,9 +1368,9 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
               >
                 <input
                   aria-checked={false}
+                  checked={false}
                   className="emotion-0"
                   data-cy="toggleWrapper-input"
-                  defaultChecked={false}
                   disabled={false}
                   id="mesosphere"
                   name="customLayoutProps"

--- a/packages/toggleWrapper/components/ToggleWrapper.tsx
+++ b/packages/toggleWrapper/components/ToggleWrapper.tsx
@@ -69,7 +69,7 @@ class ToggleWrapper extends React.PureComponent<
         <input
           id={id}
           className={visuallyHidden}
-          defaultChecked={isActive}
+          checked={isActive}
           aria-checked={isActive}
           data-cy="toggleWrapper-input"
           onFocus={this.handleFocus}

--- a/packages/toggleWrapper/tests/__snapshots__/ToggleWrapper.test.tsx.snap
+++ b/packages/toggleWrapper/tests/__snapshots__/ToggleWrapper.test.tsx.snap
@@ -26,9 +26,9 @@ exports[`ToggleWrapper renders 1`] = `
   >
     <input
       aria-checked={true}
+      checked={true}
       className="emotion-0"
       data-cy="toggleWrapper-input"
-      defaultChecked={true}
       onBlur={[Function]}
       onFocus={[Function]}
       type="checkbox"
@@ -66,9 +66,9 @@ exports[`ToggleWrapper renders as a radio input 1`] = `
   >
     <input
       aria-checked={true}
+      checked={true}
       className="emotion-0"
       data-cy="toggleWrapper-input"
-      defaultChecked={true}
       onBlur={[Function]}
       onFocus={[Function]}
       type="radio"


### PR DESCRIPTION
When this changed to an uncontrolled component, it prevented the ToggleBoxGroup component from calling `onChange` in an edge case: https://github.com/mesosphere/kommander/pull/1945#pullrequestreview-371033905