### PR TITLE
Hides SidebarSubMenuItem focus outline in Firefox

### DIFF
--- a/packages/appChrome/style.ts
+++ b/packages/appChrome/style.ts
@@ -111,6 +111,7 @@ export const sidebarNavItem = (
             hoverBgColor || getCSSVarValue(themeBgHoverInverted)
           )};
 
+      &,
       a {
         outline: none;
       }

--- a/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
+++ b/packages/appChrome/tests/__snapshots__/Sidebar.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`Sidebar SidebarSubMenu renders 1`] = `
         </SidebarItemLabel>
       </div>
     }
-    labelClassName="css-1s85ixg"
+    labelClassName="css-1opfzkn"
   >
     <ul
       className="emotion-0"


### PR DESCRIPTION
macOS users: to focus anchor tags in Firefox, you need to change a setting in System Preferences.
1. Go to System Preferences > Keyboard > Shortcuts
2. Toggle the radio button at the bottom to be "All controls"

## Screenshots

Before:
![SidebarSubMenuItemFocusOutline-before](https://user-images.githubusercontent.com/2313998/76646712-db950200-6531-11ea-8aea-0676c81082d9.gif)

After:
![SidebarSubMenuItemFocusOutline-after](https://user-images.githubusercontent.com/2313998/76646721-df288900-6531-11ea-9f9b-20fafb2ec7e6.gif)
