### PR TITLE
D2IQ-64871: make Storybook easier to navigate

### DIFF
--- a/cypress/integration/storybook-cy.js
+++ b/cypress/integration/storybook-cy.js
@@ -6,6 +6,6 @@ describe("Storybook", () => {
   });
 
   it("Avatar has no error", () => {
-    navigateToStory("Avatar");
+    navigateToStory("Graphic Elements ", "Avatar");
   });
 });

--- a/cypress/utils/navigateToStory.js
+++ b/cypress/utils/navigateToStory.js
@@ -6,12 +6,14 @@ function noOp() {}
  * @param {String} name name of the story to test
  * @param {Function} cb callback to run assertions in
  */
-function navigateToStory(name, cb) {
+function navigateToStory(category, name, cb) {
   cy.visit("/");
-  cy.get("#explorerappchrome").click(); // make sure everything is closed
+  cy.get("#explorerpage-structure-appchrome").click(); // make sure everything is closed
 
   // Navigate to story with the name
-  cy.get("#explorer" + name.toLowerCase()).click();
+  cy.get(
+    "#" + category.replace(/\s+/g, "-").toLowerCase() + name.toLowerCase()
+  ).click();
   cy.get("nav section .css-0 a")
     .first()
     .click();

--- a/packages/appChrome/stories/AppChrome.stories.tsx
+++ b/packages/appChrome/stories/AppChrome.stories.tsx
@@ -41,7 +41,7 @@ import { Icon } from "../../icon";
 
 const readme = require("../README.md");
 
-storiesOf("AppChrome", module)
+storiesOf("Page structure|AppChrome", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .addParameters({

--- a/packages/avatar/stories/avatar.stories.tsx
+++ b/packages/avatar/stories/avatar.stories.tsx
@@ -14,7 +14,7 @@ import { serviceImg } from "./helpers/serviceImg";
 const readme = require("../README.md");
 const iconSizes = [iconSizeXs, iconSizeS, iconSizeM, iconSizeL, iconSizeXl];
 
-storiesOf("Avatar", module)
+storiesOf("Graphic elements|Avatar", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => <Avatar src={serviceImg} label="Kubernetes" />)
   .add("all sizes", () => (

--- a/packages/badge/stories/badge.stories.tsx
+++ b/packages/badge/stories/badge.stories.tsx
@@ -7,7 +7,7 @@ import { Badge, BadgeButton } from "../../index";
 
 const readme = require("../README.md");
 
-storiesOf("Badge", module)
+storiesOf("Graphic elements|Badge", module)
   .addDecorator(withReadme([readme]))
   .add("Default", () => <Badge>Default</Badge>)
   .add("Success", () => <Badge appearance="success">Success</Badge>, {

--- a/packages/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -6,7 +6,7 @@ import { Breadcrumb } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Breadcrumb", module)
+storiesOf("Navigation|Breadcrumb", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <Breadcrumb>

--- a/packages/button/stories/DefaultButton.stories.tsx
+++ b/packages/button/stories/DefaultButton.stories.tsx
@@ -19,7 +19,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 
 const readme = require("../README.md");
 
-storiesOf("Buttons/Default", module)
+storiesOf("Actions|Default button", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/button/stories/DropdownButton.stories.tsx
+++ b/packages/button/stories/DropdownButton.stories.tsx
@@ -13,7 +13,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 
 const readme = require("../README.md");
 
-storiesOf("Buttons/Dropdown", module)
+storiesOf("Actions|Dropdown button", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/button/stories/ResetButton.stories.tsx
+++ b/packages/button/stories/ResetButton.stories.tsx
@@ -6,9 +6,9 @@ import { Text } from "../../styleUtils/typography";
 
 const readme = require("../README.md");
 
-storiesOf("Buttons", module)
+storiesOf("Actions|ResetButton", module)
   .addDecorator(withReadme([readme]))
-  .add("ResetButton", () => (
+  .add("default", () => (
     <div>
       The{" "}
       <Text tag="span" color="red">

--- a/packages/card/stories/ButtonCard.stories.tsx
+++ b/packages/card/stories/ButtonCard.stories.tsx
@@ -2,12 +2,15 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { withReadme } from "storybook-readme";
 import { action } from "@storybook/addon-actions";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { SpaceSize } from "../../shared/styles/styleUtils/modifiers/modifierUtils";
 import ButtonCard from "../components/ButtonCard";
 import { SpacingBox } from "../../styleUtils/modifiers";
 
 const readme = require("../README.md");
 
-storiesOf("Card/ButtonCard", module)
+storiesOf("Actions|ButtonCard", module)
+  .addDecorator(withKnobs)
   .addDecorator(withReadme([readme]))
   .add("default", () => <ButtonCard>default</ButtonCard>)
   .add("active", () => <ButtonCard isActive={true}>isActive</ButtonCard>)
@@ -23,4 +26,37 @@ storiesOf("Card/ButtonCard", module)
   ))
   .add("with onClick", () => (
     <ButtonCard onClick={action("button clicked")}>default</ButtonCard>
+  ))
+  .add("paddingSize", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("paddingSize", sizes, "m");
+
+    return (
+      <ButtonCard paddingSize={size as SpaceSize}>
+        Use the Knobs panel to change the padding
+      </ButtonCard>
+    );
+  })
+  .add("responsive paddingSize", () => (
+    <ButtonCard
+      paddingSize={{
+        default: "s",
+        small: "m",
+        medium: "l",
+        large: "xl",
+        jumbo: "xxl"
+      }}
+    >
+      Resize the viewport to see the padding change
+    </ButtonCard>
+  ))
+  .add("2:1 aspect ratio", () => (
+    <div style={{ maxWidth: "400px" }}>
+      <ButtonCard aspectRatio={[2, 1]}>I stay at a 2:1 aspect ratio</ButtonCard>
+    </div>
   ));

--- a/packages/card/stories/Card.stories.tsx
+++ b/packages/card/stories/Card.stories.tsx
@@ -2,12 +2,12 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { withReadme } from "storybook-readme";
 import { withKnobs, select } from "@storybook/addon-knobs";
-import { Card } from "../index";
+import { ButtonCard, Card, LinkCard } from "../index";
 import { SpaceSize } from "../../shared/styles/styleUtils/modifiers/modifierUtils";
 
 const readme = require("../README.md");
 
-storiesOf("Card", module)
+storiesOf("Layout|Card", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => <Card>default</Card>)
@@ -43,4 +43,10 @@ storiesOf("Card", module)
     <div style={{ maxWidth: "400px" }}>
       <Card aspectRatio={[2, 1]}>I stay at a 2:1 aspect ratio</Card>
     </div>
-  ));
+  ))
+  .add("LinkCard", () => (
+    <LinkCard url="http://google.com" linkDescription="Google">
+      default
+    </LinkCard>
+  ))
+  .add("ButtonCard", () => <ButtonCard>default</ButtonCard>);

--- a/packages/card/stories/LinkCard.stories.tsx
+++ b/packages/card/stories/LinkCard.stories.tsx
@@ -1,12 +1,15 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { withReadme } from "storybook-readme";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { SpaceSize } from "../../shared/styles/styleUtils/modifiers/modifierUtils";
 import LinkCard from "../components/LinkCard";
 
 const readme = require("../README.md");
 
-storiesOf("Card/LinkCard", module)
+storiesOf("Navigation|LinkCard", module)
   .addDecorator(withReadme([readme]))
+  .addDecorator(withKnobs)
   .add("default", () => (
     <LinkCard url="http://google.com" linkDescription="Google">
       default
@@ -20,4 +23,49 @@ storiesOf("Card/LinkCard", module)
     >
       default
     </LinkCard>
+  ))
+  .add("paddingSize", () => {
+    const sizes = {
+      s: "s",
+      m: "m",
+      l: "l",
+      xl: "xl"
+    };
+    const size = select("paddingSize", sizes, "m");
+
+    return (
+      <LinkCard
+        paddingSize={size as SpaceSize}
+        url="http://google.com"
+        linkDescription="Google"
+      >
+        Use the Knobs panel to change the padding
+      </LinkCard>
+    );
+  })
+  .add("responsive paddingSize", () => (
+    <LinkCard
+      paddingSize={{
+        default: "s",
+        small: "m",
+        medium: "l",
+        large: "xl",
+        jumbo: "xxl"
+      }}
+      url="http://google.com"
+      linkDescription="Google"
+    >
+      Resize the viewport to see the padding change
+    </LinkCard>
+  ))
+  .add("2:1 aspect ratio", () => (
+    <div style={{ maxWidth: "400px" }}>
+      <LinkCard
+        aspectRatio={[2, 1]}
+        url="http://google.com"
+        linkDescription="Google"
+      >
+        I stay at a 2:1 aspect ratio
+      </LinkCard>
+    </div>
   ));

--- a/packages/chart/stories/LineChart.stories.tsx
+++ b/packages/chart/stories/LineChart.stories.tsx
@@ -6,7 +6,7 @@ import { LineChart } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Charts/LineChart", module)
+storiesOf("Charts|LineChart", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <LineChart

--- a/packages/checkboxInput/stories/CheckboxInput.stories.tsx
+++ b/packages/checkboxInput/stories/CheckboxInput.stories.tsx
@@ -8,7 +8,7 @@ import { inputStoryWrapper } from "../../../decorators/inputStoryWrapper";
 
 const readme = require("../README.md");
 
-storiesOf("Forms/CheckboxInput", module)
+storiesOf("Forms|CheckboxInput", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(inputStoryWrapper)
   .add("default", () => (

--- a/packages/clickable/stories/clickable.stories.tsx
+++ b/packages/clickable/stories/clickable.stories.tsx
@@ -6,7 +6,7 @@ import { action } from "@storybook/addon-actions";
 
 const readme = require("../README.md");
 
-storiesOf("Clickable", module)
+storiesOf("Utils|Clickable", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <Clickable action={action("action trigger")} tabIndex="0">

--- a/packages/clicktocopybutton/stories/ClickToCopyButton.stories.tsx
+++ b/packages/clicktocopybutton/stories/ClickToCopyButton.stories.tsx
@@ -9,7 +9,7 @@ import { Box } from "../../styleUtils/modifiers";
 const readme = require("../README.md");
 const textToCopy = "Nobody likes a copycat";
 
-storiesOf("ClickToCopyButton", module)
+storiesOf("Actions|ClickToCopyButton", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => <ClickToCopyButton textToCopy={textToCopy} />)
   .add("show tooltip onCopy", () => (

--- a/packages/codesnippet/stories/CodeSnippet.stories.tsx
+++ b/packages/codesnippet/stories/CodeSnippet.stories.tsx
@@ -9,7 +9,7 @@ const readme = require("../README.md");
 
 const snippetContent = `cd ui-kit && npm start`;
 
-storiesOf("CodeSnippet", module)
+storiesOf("Typography|Containers/CodeSnippet", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => <CodeSnippet>{snippetContent}</CodeSnippet>)
   .add("with textToCopy", () => (

--- a/packages/configurationmap/stories/ConfigurationMap.stories.tsx
+++ b/packages/configurationmap/stories/ConfigurationMap.stories.tsx
@@ -17,7 +17,7 @@ import { configurationMapStoryWrapper } from "./helpers/ConfigurationMapStoryWra
 const readme = require("../README.md");
 const rowAction = action("row action");
 
-storiesOf("ConfigurationMap/ConfigurationMap", module)
+storiesOf("Data listing|ConfigurationMap", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(configurationMapStoryWrapper)
   .add("default", () => (

--- a/packages/configurationmap/stories/HashMap.stories.tsx
+++ b/packages/configurationmap/stories/HashMap.stories.tsx
@@ -6,7 +6,7 @@ import { configurationMapStoryWrapper } from "./helpers/ConfigurationMapStoryWra
 
 const readme = require("../README.md");
 
-storiesOf("ConfigurationMap/HashMap", module)
+storiesOf("Data listing|HashMap", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(configurationMapStoryWrapper)
   .add("default", () => (

--- a/packages/donutChart/stories/DonutChart.stories.tsx
+++ b/packages/donutChart/stories/DonutChart.stories.tsx
@@ -11,7 +11,7 @@ const chartWrapper = css`
   max-width: 150px;
 `;
 
-storiesOf("Charts/DonutChart", module)
+storiesOf("Charts|DonutChart", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <div className={chartWrapper}>

--- a/packages/dropdownMenu/stories/Dropdown.stories.tsx
+++ b/packages/dropdownMenu/stories/Dropdown.stories.tsx
@@ -15,7 +15,7 @@ import PrimaryDropdownButton from "../../button/components/PrimaryDropdownButton
 
 const readme = require("../README.md");
 
-storiesOf("DropdownMenu", module)
+storiesOf("Overlays|DropdownMenu", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <DropdownMenu trigger={<PrimaryDropdownButton>Menu</PrimaryDropdownButton>}>

--- a/packages/dropdownable/stories/Dropdownable.stories.tsx
+++ b/packages/dropdownable/stories/Dropdownable.stories.tsx
@@ -9,7 +9,7 @@ import Dropdownable, { Direction } from "../components/Dropdownable";
 import DropdownStory from "./helpers/DropdownStory";
 import DropdownStoryFit from "./helpers/DropdownStoryFit";
 
-storiesOf("Dropdownable", module)
+storiesOf("Utils|Dropdownable", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/emptyState/stories/emptyState.stories.tsx
+++ b/packages/emptyState/stories/emptyState.stories.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from "../../pageheader";
 
 const readme = require("../README.md");
 
-storiesOf("EmptyState", module)
+storiesOf("Feedback|EmptyState", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/emptyState/stories/emptyStateWithGraphic.stories.tsx
+++ b/packages/emptyState/stories/emptyStateWithGraphic.stories.tsx
@@ -7,7 +7,7 @@ import { PageHeader } from "../../pageheader";
 
 const readme = require("../README.md");
 
-storiesOf("EmptyState/EmptyStateWithGraphic", module)
+storiesOf("Feedback|EmptyStateWithGraphic", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/expandable/stories/Expandable.stories.tsx
+++ b/packages/expandable/stories/Expandable.stories.tsx
@@ -6,7 +6,7 @@ import { tintText } from "../../shared/styles/styleUtils";
 
 const readme = require("../README.md");
 
-storiesOf("Expandable", module)
+storiesOf("Actions|Expandable", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <Expandable label="Expand for content">

--- a/packages/formStructure/stories/fieldGroup.stories.tsx
+++ b/packages/formStructure/stories/fieldGroup.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from "@storybook/react";
 import { FieldGroup } from "..";
 import { TextInput } from "../../textInput";
 
-storiesOf("Form structure/Grouped fields/FieldGroup", module)
+storiesOf("Forms|Form layout/FieldGroup", module)
   .addParameters({
     info: {
       propTablesExclude: [TextInput]

--- a/packages/formStructure/stories/fieldList.stories.tsx
+++ b/packages/formStructure/stories/fieldList.stories.tsx
@@ -39,7 +39,7 @@ const testFieldUpdateHandler = (rowIndex, pathToValue) => () =>
     `update row ${rowIndex} with the property that has the key ${pathToValue}`
   );
 
-storiesOf("Form structure/Grouped fields/FieldList", module)
+storiesOf("Forms|Form layout/Grouped fields/FieldList", module)
   .add(
     "interactive example",
     () => (

--- a/packages/formStructure/stories/formStructure.stories.tsx
+++ b/packages/formStructure/stories/formStructure.stories.tsx
@@ -27,7 +27,7 @@ const onRemoveSubSection = () => {
   alert("the box would be removed");
 };
 
-storiesOf("Form structure/Overall form layout", module)
+storiesOf("Forms|Form layout", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .addParameters({

--- a/packages/fullscreenView/stories/fullscreenView.stories.tsx
+++ b/packages/fullscreenView/stories/fullscreenView.stories.tsx
@@ -24,7 +24,7 @@ const onClose = () => {
 
 const readme = require("../README.md");
 
-storiesOf("FullscreenView", module)
+storiesOf("Page structure|FullscreenView", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <div style={{ height: "500px" }}>

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -3,15 +3,3 @@
 Icons can live within other components, such as buttons. They should take on the text color of that component.
 Icons have a default color, but can be styled with any color.
 Icons have a default size, but can be resized to any of the predetermined icon sizes from our design tokens.
-
-## Icon sets
-
-### System Icons
-
-System icons are glyphs we can use as stand alone actions or to support labels in actions.
-
-### Product Icons
-
-Product icons are used to represent and convey the DC/OS suite features and capabilities (e.g. Universe, Network, Security, etc...). Unlike DC/OS system icons, product icons are not meant to be paired with actions.
-
-The primary purpose of product icons is way-finding, context, and messaging. Each product icon is unique in its own right, though all product icons share a similar artistic style that is consistent with the DC/OS product look & feel.

--- a/packages/icon/stories/Icon.stories.tsx
+++ b/packages/icon/stories/Icon.stories.tsx
@@ -4,8 +4,6 @@ import { withReadme } from "storybook-readme";
 import { select, withKnobs } from "@storybook/addon-knobs";
 import { Icon } from "../index";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
-import { ProductIcons } from "../../icons/dist/product-icons-enum";
-import IconGrid from "./helpers/IconPreviewGrid";
 import {
   blue,
   green,
@@ -54,7 +52,7 @@ const shapes = {
   ["SystemIcons.Users"]: SystemIcons.Users
 };
 
-storiesOf("Icon", module)
+storiesOf("Graphic elements|Icon", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => {
@@ -66,14 +64,4 @@ storiesOf("Icon", module)
     return (
       <Icon shape={shape} color={color} size={size} ariaLabel="Sample icon" />
     );
-  })
-  .add("system icons preview", () => (
-    <IconGrid iconEnum={SystemIcons} iconEnumTitle="SystemIcons" />
-  ))
-  .add("product icons preview", () => (
-    <IconGrid
-      iconEnum={ProductIcons}
-      iconEnumTitle="ProductIcons"
-      darkMode={true}
-    />
-  ));
+  });

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,0 +1,9 @@
+## System Icons
+
+System icons are glyphs we can use as stand alone actions or to support labels in actions.
+
+## Product Icons
+
+Product icons are used to represent and convey the DC/OS suite features and capabilities (e.g. Universe, Network, Security, etc...). Unlike DC/OS system icons, product icons are not meant to be paired with actions.
+
+The primary purpose of product icons is way-finding, context, and messaging. Each product icon is unique in its own right, though all product icons share a similar artistic style that is consistent with the DC/OS product look & feel.

--- a/packages/icons/iconPreview.stories.tsx
+++ b/packages/icons/iconPreview.stories.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { SystemIcons } from "./dist/system-icons-enum";
+import { ProductIcons } from "./dist/product-icons-enum";
+import IconGrid from "../icon/stories/helpers/IconPreviewGrid";
+
+storiesOf("Visual Design Core|Icons", module)
+  .add("system icons", () => (
+    <IconGrid iconEnum={SystemIcons} iconEnumTitle="SystemIcons" />
+  ))
+  .add("product icons", () => (
+    <IconGrid
+      iconEnum={ProductIcons}
+      iconEnumTitle="ProductIcons"
+      darkMode={true}
+    />
+  ));

--- a/packages/infobox/stories/InfoBoxBanner.stories.tsx
+++ b/packages/infobox/stories/InfoBoxBanner.stories.tsx
@@ -8,7 +8,7 @@ import InfoBoxStoryContainer from "./helpers/InfoBoxStoryContainer";
 
 const readme = require("../README.md");
 
-storiesOf("InfoBox/Banner", module)
+storiesOf("Feedback|InfoBoxBanner", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/infobox/stories/InfoBoxInline.stories.tsx
+++ b/packages/infobox/stories/InfoBoxInline.stories.tsx
@@ -7,7 +7,7 @@ import InfoBoxStoryContainer from "./helpers/InfoBoxStoryContainer";
 
 const readme = require("../README.md");
 
-storiesOf("InfoBox/Inline", module)
+storiesOf("Feedback|InfoBoxInline", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/inlineBorderedItems/stories/inlineBorderedItems.stories.tsx
+++ b/packages/inlineBorderedItems/stories/inlineBorderedItems.stories.tsx
@@ -7,7 +7,7 @@ import { SpaceSize } from "../../shared/styles/styleUtils/modifiers/modifierUtil
 
 const readme = require("../README.md");
 
-storiesOf("InlineBorderedItems", module)
+storiesOf("Layout|InlineBorderedItems", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/link/stories/link.stories.tsx
+++ b/packages/link/stories/link.stories.tsx
@@ -6,7 +6,7 @@ import { Text } from "../../styleUtils/typography";
 
 const readme = require("../README.md");
 
-storiesOf("Link", module)
+storiesOf("Navigation|Link", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/list/stories/borderedList.stories.tsx
+++ b/packages/list/stories/borderedList.stories.tsx
@@ -5,7 +5,7 @@ import { BorderedList } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Vertical lists/BorderedList", module)
+storiesOf("Data listing|BorderedList", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <BorderedList>

--- a/packages/list/stories/list.stories.tsx
+++ b/packages/list/stories/list.stories.tsx
@@ -6,7 +6,7 @@ import { List } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Vertical lists/List", module)
+storiesOf("Data listing|List", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/loadingIndicator/stories/loadingIndicator.stories.tsx
+++ b/packages/loadingIndicator/stories/loadingIndicator.stories.tsx
@@ -13,7 +13,7 @@ import { InlineLoadingIndicator, SectionLoadingIndicator } from "../";
 
 const readme = require("../README.md");
 
-storiesOf("Loading indicators", module)
+storiesOf("Feedback|Loading indicators", module)
   .addDecorator(withReadme([readme]))
   .add(
     "SectionLoadingIndicator in place of page content",

--- a/packages/modal/stories/Modal.stories.tsx
+++ b/packages/modal/stories/Modal.stories.tsx
@@ -28,7 +28,7 @@ import { fullscreenModalTitle } from "../../fullscreenView/style";
 
 const readme = require("../README.md");
 
-storiesOf("Modal", module)
+storiesOf("Overlays|Modal", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/pageheader/stories/PageHeader.stories.tsx
+++ b/packages/pageheader/stories/PageHeader.stories.tsx
@@ -11,7 +11,7 @@ import { Tabs, TabItem, TabTitle } from "../../tabs";
 const readme = require("../README.md");
 const action = () => alert("Action triggered");
 
-storiesOf("PageHeader", module)
+storiesOf("Page structure|PageHeader", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <PageHeader

--- a/packages/progressbar/stories/ProgressBar.stories.tsx
+++ b/packages/progressbar/stories/ProgressBar.stories.tsx
@@ -7,7 +7,7 @@ import { green, yellow } from "../../design-tokens/build/js/designTokens";
 
 const readme = require("../README.md");
 
-storiesOf("Charts/ProgressBar", module)
+storiesOf("Charts|ProgressBar", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => <ProgressBar data={[{ percentage: 40 }]} />)
   .add("custom fill color", () => (

--- a/packages/segmentedControl/stories/SegmentedControl.stories.tsx
+++ b/packages/segmentedControl/stories/SegmentedControl.stories.tsx
@@ -10,7 +10,7 @@ import { iconSizeXs } from "../../design-tokens/build/js/designTokens";
 
 const readme = require("../README.md");
 
-storiesOf("SegmentedControl", module)
+storiesOf("Forms|SegmentedControl", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <SegmentedControlStoryHelper>

--- a/packages/selectInput/stories/selectInput.stories.tsx
+++ b/packages/selectInput/stories/selectInput.stories.tsx
@@ -21,7 +21,7 @@ const defaultOptions = [
   { value: "disabled", label: "Can't touch this", disabled: true }
 ];
 
-storiesOf("Forms/SelectInput", module)
+storiesOf("Forms|SelectInput", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(inputStoryWrapper)
   .add("default", () => (

--- a/packages/shared/stories/color.stories.tsx
+++ b/packages/shared/stories/color.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
-import { withReadme } from "storybook-readme";
 import styled from "react-emotion";
 import { coreColors } from "../../design-tokens/build/js/colorsForStyleguide";
 import { Tooltip } from "../../tooltip";
@@ -76,6 +75,6 @@ const ColorTable = () => (
   </React.Fragment>
 );
 
-storiesOf("Colors", module)
-  .addDecorator(withReadme([``]))
-  .add("Color table", () => <ColorTable />);
+storiesOf("Visual design core|Colors", module).add("Color table", () => (
+  <ColorTable />
+));

--- a/packages/styleUtils/layout/container/stories/Container.stories.tsx
+++ b/packages/styleUtils/layout/container/stories/Container.stories.tsx
@@ -18,7 +18,7 @@ const contentBg = css`
   background-color: ${themeBgPrimary};
 `;
 
-storiesOf("Style utilities/Layout/Container", module)
+storiesOf("Layout|Container", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <div className={baseBg}>

--- a/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
+++ b/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
@@ -25,7 +25,7 @@ const DemoChild = styled("div")`
   text-align: center;
 `;
 
-storiesOf("Style utilities/Layout/Flex", module)
+storiesOf("Layout|Flex", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/layout/flexbox/stories/flexItem.stories.tsx
+++ b/packages/styleUtils/layout/flexbox/stories/flexItem.stories.tsx
@@ -23,7 +23,7 @@ const DemoChild = styled("div")`
   text-align: center;
 `;
 
-storiesOf("Style utilities/Layout/FlexItem", module)
+storiesOf("Layout|FlexItem", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/layout/gridList/stories/GridList.stories.tsx
+++ b/packages/styleUtils/layout/gridList/stories/GridList.stories.tsx
@@ -18,7 +18,7 @@ const gridChildren = new Array(12).fill(0).map((_, i) => (
   </li>
 ));
 
-storiesOf("Style utilities/Layout/GridList", module)
+storiesOf("Layout|GridList", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("columnCount", () => {

--- a/packages/styleUtils/layout/stack/stories/stack.stories.tsx
+++ b/packages/styleUtils/layout/stack/stories/stack.stories.tsx
@@ -7,7 +7,7 @@ import { SpaceSize } from "../../../../shared/styles/styleUtils/modifiers/modifi
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Layout/Stack", module)
+storiesOf("Layout|Stack", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/modifiers/stories/BorderedBox.stories.tsx
+++ b/packages/styleUtils/modifiers/stories/BorderedBox.stories.tsx
@@ -9,7 +9,7 @@ import SpacingBox from "../components/SpacingBox";
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Modifiers/BorderedBox", module)
+storiesOf("Style utilities|BorderedBox", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("side", () => {

--- a/packages/styleUtils/modifiers/stories/Box.stories.tsx
+++ b/packages/styleUtils/modifiers/stories/Box.stories.tsx
@@ -18,7 +18,7 @@ type VerticalAlignments = "top" | "bottom" | "center";
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Modifiers/Box", module)
+storiesOf("Style utilities|Box", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("bgColor", () => {

--- a/packages/styleUtils/modifiers/stories/SpacingBox.stories.tsx
+++ b/packages/styleUtils/modifiers/stories/SpacingBox.stories.tsx
@@ -11,7 +11,7 @@ import {
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Modifiers/SpacingBox", module)
+storiesOf("Style utilities|SpacingBox", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .addDecorator(outlineDecorator)

--- a/packages/styleUtils/typography/stories/captionText.stories.tsx
+++ b/packages/styleUtils/typography/stories/captionText.stories.tsx
@@ -5,7 +5,7 @@ import { CaptionText } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/CaptionText", module)
+storiesOf("Typography|CaptionText", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <CaptionText>

--- a/packages/styleUtils/typography/stories/dangerText.stories.tsx
+++ b/packages/styleUtils/typography/stories/dangerText.stories.tsx
@@ -7,7 +7,7 @@ import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize"
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/DangerText", module)
+storiesOf("Typography|DangerText", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/typography/stories/headingText1.stories.tsx
+++ b/packages/styleUtils/typography/stories/headingText1.stories.tsx
@@ -6,7 +6,7 @@ import { HeadingText1 } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/HeadingText1", module)
+storiesOf("Typography|HeadingText1", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => <HeadingText1>Primary Heading</HeadingText1>)

--- a/packages/styleUtils/typography/stories/headingText2.stories.tsx
+++ b/packages/styleUtils/typography/stories/headingText2.stories.tsx
@@ -6,7 +6,7 @@ import { HeadingText2 } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/HeadingText2", module)
+storiesOf("Typography|HeadingText2", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => <HeadingText2>Secondary Heading</HeadingText2>)

--- a/packages/styleUtils/typography/stories/headingText3.stories.tsx
+++ b/packages/styleUtils/typography/stories/headingText3.stories.tsx
@@ -6,7 +6,7 @@ import { HeadingText3 } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/HeadingText3", module)
+storiesOf("Typography|HeadingText3", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => <HeadingText3>Tertiary Heading</HeadingText3>)

--- a/packages/styleUtils/typography/stories/interactiveText.stories.tsx
+++ b/packages/styleUtils/typography/stories/interactiveText.stories.tsx
@@ -7,7 +7,7 @@ import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize"
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/InteractiveText", module)
+storiesOf("Typography|InteractiveText", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => <InteractiveText>Click me</InteractiveText>)

--- a/packages/styleUtils/typography/stories/monospaceText.stories.tsx
+++ b/packages/styleUtils/typography/stories/monospaceText.stories.tsx
@@ -13,7 +13,7 @@ import {
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/MonospaceText", module)
+storiesOf("Typography|MonospaceText", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/typography/stories/smallText.stories.tsx
+++ b/packages/styleUtils/typography/stories/smallText.stories.tsx
@@ -12,7 +12,7 @@ import {
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/SmallText", module)
+storiesOf("Typography|SmallText", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/typography/stories/successText.stories.tsx
+++ b/packages/styleUtils/typography/stories/successText.stories.tsx
@@ -7,7 +7,7 @@ import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize"
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/SuccessText", module)
+storiesOf("Typography|SuccessText", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/typography/stories/text.stories.tsx
+++ b/packages/styleUtils/typography/stories/text.stories.tsx
@@ -15,7 +15,7 @@ import { Text } from "../";
 const readme = require("../README.md");
 type WrapVals = "truncate" | "nowrap" | "wrap";
 
-storiesOf("Style utilities/Typography/Text", module)
+storiesOf("Typography|Text", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/styleUtils/typography/stories/textBlock.stories.tsx
+++ b/packages/styleUtils/typography/stories/textBlock.stories.tsx
@@ -13,7 +13,7 @@ import {
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/TextBlock", module)
+storiesOf("Typography|Containers/TextBlock", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <Container>

--- a/packages/styleUtils/typography/stories/warningText.stories.tsx
+++ b/packages/styleUtils/typography/stories/warningText.stories.tsx
@@ -7,7 +7,7 @@ import { FontSize } from "../../../shared/styles/styleUtils/typography/textSize"
 
 const readme = require("../README.md");
 
-storiesOf("Style utilities/Typography/WarningText", module)
+storiesOf("Typography|WarningText", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/table/stories/CheckboxTable.stories.tsx
+++ b/packages/table/stories/CheckboxTable.stories.tsx
@@ -43,7 +43,7 @@ const veryLongRenderer = () => (
   </TextCell>
 );
 
-storiesOf("Table/CheckboxTable", module)
+storiesOf("Data listing|Table/CheckboxTable", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/table/stories/Table.stories.tsx
+++ b/packages/table/stories/Table.stories.tsx
@@ -48,7 +48,7 @@ const veryLongRenderer = () => (
 
 const empty = () => <Cell>empty</Cell>;
 
-storiesOf("Table", module)
+storiesOf("Data listing|Table", module)
   .addDecorator(withReadme([readme]))
   .add("collection table", () => (
     <div

--- a/packages/tableView/stories/TableView.stories.tsx
+++ b/packages/tableView/stories/TableView.stories.tsx
@@ -6,7 +6,7 @@ import DemoTable from "./helpers/DemoTable";
 
 const readme = require("../README.md");
 
-storiesOf("TableView", module)
+storiesOf("Page structure|TableView", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/tabs/stories/Tabs.stories.tsx
+++ b/packages/tabs/stories/Tabs.stories.tsx
@@ -36,7 +36,7 @@ class Example extends React.Component<
   }
 }
 
-storiesOf("Tabs", module)
+storiesOf("Navigation|Tabs", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => <Example />)
   .add("vertical", () => <Example direction="vert" />)

--- a/packages/textInput/stories/TextInput.stories.tsx
+++ b/packages/textInput/stories/TextInput.stories.tsx
@@ -9,7 +9,7 @@ import { InputAppearance } from "../../shared/types/inputAppearance";
 
 const readme = require("../README.md");
 
-storiesOf("Forms/TextInput", module)
+storiesOf("Forms|TextInput", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(inputStoryWrapper)
   .add("default", () => (

--- a/packages/textInput/stories/TextInputWithBadges.stories.tsx
+++ b/packages/textInput/stories/TextInputWithBadges.stories.tsx
@@ -33,7 +33,7 @@ const defaultBadges = [
   }
 ];
 
-storiesOf("Forms/TextInputWithBadges", module)
+storiesOf("Forms|TextInputWithBadges", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(inputStoryWrapper)
   .add("default", () => (

--- a/packages/textInput/stories/TextInputWithButtons.stories.tsx
+++ b/packages/textInput/stories/TextInputWithButtons.stories.tsx
@@ -13,7 +13,7 @@ const btnClickFn = () => {
   alert("button one clicked");
 };
 
-storiesOf("Forms/TextInputWithButtons", module)
+storiesOf("Forms|TextInputWithButtons", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(inputStoryWrapper)
   .addParameters({

--- a/packages/textInput/stories/TextInputWithIcon.stories.tsx
+++ b/packages/textInput/stories/TextInputWithIcon.stories.tsx
@@ -8,7 +8,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 
 const readme = require("../README.md");
 
-storiesOf("Forms/TextInputWithIcon", module)
+storiesOf("Forms|TextInputWithIcon", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(inputStoryWrapper)
   .add("iconStart", () => (

--- a/packages/textarea/stories/Textarea.stories.tsx
+++ b/packages/textarea/stories/Textarea.stories.tsx
@@ -8,7 +8,7 @@ import { inputStoryWrapper } from "../../../decorators/inputStoryWrapper";
 
 const readme = require("../README.md");
 
-storiesOf("Forms/Textarea", module)
+storiesOf("Forms|Textarea", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(inputStoryWrapper)
   .add("default", () => (

--- a/packages/themes/stories/UIKitThemeProvider.stories.tsx
+++ b/packages/themes/stories/UIKitThemeProvider.stories.tsx
@@ -18,7 +18,7 @@ import {
 
 const readme = require("../README.md");
 
-storiesOf("UIKitThemeProvider", module)
+storiesOf("Utils|UIKitThemeProvider", module)
   .addDecorator(withReadme([readme]))
   .add("dark mode", () => (
     <UIKitThemeProvider

--- a/packages/toaster/stories/Toaster.stories.tsx
+++ b/packages/toaster/stories/Toaster.stories.tsx
@@ -69,7 +69,7 @@ class ToasterContainer extends React.PureComponent<
   }
 }
 
-storiesOf("Toaster", module)
+storiesOf("Feedback|Toaster", module)
   .addDecorator(withReadme([readme]))
   .addParameters({
     info: {

--- a/packages/toggleBox/stories/ToggleBox.stories.tsx
+++ b/packages/toggleBox/stories/ToggleBox.stories.tsx
@@ -6,7 +6,7 @@ import ToggleBoxStoryHelper from "./helpers/ToggleBoxStoryHelper";
 
 const readme = require("../README.md");
 
-storiesOf("Forms/ToggleBox", module)
+storiesOf("Forms|ToggleBox", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <ToggleBoxStoryHelper>

--- a/packages/toggleBox/stories/ToggleBoxGroup.stories.tsx
+++ b/packages/toggleBox/stories/ToggleBoxGroup.stories.tsx
@@ -8,7 +8,7 @@ import { SpaceSize } from "../../shared/styles/styleUtils/modifiers/modifierUtil
 
 const readme = require("../README.md");
 
-storiesOf("Forms/ToggleBoxGroup", module)
+storiesOf("Forms|ToggleBoxGroup", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (

--- a/packages/toggleContent/stories/toggleContent.stories.tsx
+++ b/packages/toggleContent/stories/toggleContent.stories.tsx
@@ -8,7 +8,7 @@ const readme = require("../README.md");
 const primary = () => <div>primary component</div>;
 const secondary = () => <div>secondary component</div>;
 
-storiesOf("Toggle", module)
+storiesOf("Utils|Toggle", module)
   .addDecorator(withReadme([readme]))
   .add("string", () => <ToggleContent contentOn="Hello" contentOff="Bye" />)
   .add("component", () => (

--- a/packages/toggleInputList/stories/ToggleInputList.stories.tsx
+++ b/packages/toggleInputList/stories/ToggleInputList.stories.tsx
@@ -12,7 +12,7 @@ const options = [
   { inputLabel: "Stratosphere", id: "id.3", value: "stratosphere" }
 ];
 
-storiesOf("Forms/ToggleInputList", module)
+storiesOf("Forms|ToggleInputList", module)
   .addDecorator(withReadme([readme]))
   .add(
     "checkbox",

--- a/packages/toggleWrapper/stories/ToggleWrapper.stories.tsx
+++ b/packages/toggleWrapper/stories/ToggleWrapper.stories.tsx
@@ -5,7 +5,7 @@ import { ToggleWrapper } from "../index";
 
 const readme = require("../README.md");
 
-storiesOf("ToggleWrapper", module)
+storiesOf("Utils|ToggleWrapper", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <ToggleWrapper>

--- a/packages/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/tooltip/stories/Tooltip.stories.tsx
@@ -18,7 +18,7 @@ const tooltipStoryDecorator = storyFn => (
   </div>
 );
 
-storiesOf("Tooltip", module)
+storiesOf("Overlays|Tooltip", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(tooltipStoryDecorator)
   .add("default", () => (

--- a/packages/typeahead/stories/Typeahead.stories.tsx
+++ b/packages/typeahead/stories/Typeahead.stories.tsx
@@ -14,7 +14,7 @@ const storyWrapper = css`
   width: 300px;
 `;
 
-storiesOf("Forms/Typeahead", module)
+storiesOf("Forms|Typeahead", module)
   .addDecorator(withReadme([readme]))
   .add("default", () => (
     <div className={storyWrapper}>


### PR DESCRIPTION
## Testing
Look at Storybook's sidebar navigation and let me know if you find it easier to navigate to whatever story you're looking for.

## Trade-offs
The categories (e.g.: Page structure, Layout, Forms) are not ordered in any way. When we upgrade to Storybook 5.2 or higher, we should be able to use the [sortStories](https://storybook.js.org/docs/configurations/options-parameter/#sorting-stories) option to put the categories into some logical order.

## Screenshot
![Screen Shot 2020-03-27 at 3 12 21 PM](https://user-images.githubusercontent.com/2313998/77793395-58e76900-7040-11ea-9bb4-ea1ccfc935cb.png)
