### PR TITLE
D2IQ-66278: adds PromoBanner, PromoInline, and PromoContent

### DIFF
--- a/packages/index.ts
+++ b/packages/index.ts
@@ -81,6 +81,7 @@ export {
 } from "./modal";
 export { PageHeader, PageHeaderTabs } from "./pageheader";
 export { ProgressBar } from "./progressbar";
+export { PromoBanner, PromoInline } from "./promo";
 export { SegmentedControl, SegmentedControlButton } from "./segmentedControl";
 export { SelectInput } from "./selectInput";
 export {

--- a/packages/promo/README.md
+++ b/packages/promo/README.md
@@ -1,0 +1,51 @@
+# Promo
+
+The `PromoBanner` and `PromoCard` component are used to bring the user's attention to important content.
+
+## Types of promos
+
+### PromoBanner
+
+The `PromoBanner` component is used for informational content relevant to the page it's being displayed on. It typically appears below the `PageHeader`.
+
+### PromoInline
+
+The `PromoCard` component is less attention-grabbing than the `PromoInline`. It appears inline with the other content on the page.
+
+## Content
+
+Required content:
+
+- A headline that succintly captures the primary message of the promo
+- Body text with more detailed information
+
+Optional content:
+
+- graphic
+- primary CTA
+- secondary CTA
+
+## Hiding and showing the promo
+
+The promo will be visible until the user dismisses it.
+
+Any promo must be hidden when the user clicks the close button in the upper-right corner.
+
+Since this component is intentionally attention-grabbing, it's recommended to let users prevent the promo from re-appearing when checking the "Do not show again" checkbox.
+
+If a user has checked the "Do not show again" checkbox, the banner can only be made visible again by some user-initiated action. For example, the banner on the Projects page can be brought back by clicking the "Help" button in the project page's header.
+
+## Do's and Dont's
+
+### Do
+
+- Use a promo to communicate important information that a user would care about
+- Allow users to prevent a promo from being shown again
+- Keep headline text and body text as short as possible
+- Avoid showing a PromoBanner and PromoInline on the same page at the same time
+
+### Don't
+
+- Show a promo just to add visual interest to the page
+- Show more than one PromoBanner on a page at the same time
+- Use a PromoBanner inline with regular content

--- a/packages/promo/__snapshots__/promos.test.tsx.snap
+++ b/packages/promo/__snapshots__/promos.test.tsx.snap
@@ -1,0 +1,442 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Promos renders PromoBanner 1`] = `
+<div
+  class="css-1l9o2e0"
+  data-cy="spacingBox"
+>
+  <div
+    class="css-1fe32n8"
+    data-cy="promoContent"
+  >
+    <button
+      class="css-1ylfqc6"
+      type="button"
+    >
+      <div
+        tabindex="-1"
+      >
+        <svg
+          aria-label="system-close icon"
+          class="css-zgvqkl"
+          data-cy="icon"
+          height="16"
+          preserveAspectRatio="xMinYMin meet"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <use
+            href="#system-close"
+          />
+        </svg>
+      </div>
+    </button>
+    <div
+      class="css-138vlob"
+      data-cy="flex"
+    >
+      <div
+        class="css-14eehpp"
+        data-cy="flexItem"
+      >
+        <div
+          class="css-18axn3y"
+          data-cy="spacingBox"
+        >
+          <div
+            class="css-ilu7d6"
+            data-cy="spacingBox"
+          >
+            <h3
+              class="rmTextMargins css-178l9ir"
+              data-cy="headingText1"
+            >
+              Promo Banner
+            </h3>
+          </div>
+          <div
+            class="css-fpj0jb"
+            data-cy="spacingBox"
+          >
+            Some promo details
+          </div>
+          <div
+            class="css-1yaruh1"
+            data-cy="flex"
+          >
+            <div
+              class="css-149ndna"
+              data-cy="flexItem"
+            >
+              <button>
+                Primary Action
+              </button>
+            </div>
+            <div
+              class="css-149ndna"
+              data-cy="flexItem"
+            >
+              <button>
+                Secondary Action
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="css-c5uz38"
+        data-cy="flexItem"
+      >
+        <div
+          class="css-111p8uk"
+          data-cy="spacingBox"
+        >
+          <div
+            class="css-7j3xjb"
+            data-cy="box"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1v61zfx"
+        data-cy="flexItem"
+      >
+        <div
+          class="css-1jnujn3"
+          data-cy="spacingBox"
+        >
+          <div
+            class="css-deizzc"
+            data-cy="checkboxInput"
+          >
+            <label
+              class="css-14bj381"
+              for="dismissPromoCheckbox1"
+            >
+              <div
+                class="css-ew6x4b"
+              >
+                <div
+                  class="css-1iuiyz2"
+                >
+                  <input
+                    aria-describedby=""
+                    aria-invalid="false"
+                    class="css-epge75"
+                    data-cy="checkboxInput-input"
+                    id="dismissPromoCheckbox1"
+                    type="checkbox"
+                  />
+                </div>
+              </div>
+              <div
+                class="css-19gm8iw"
+              >
+                Do not show again
+              </div>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
+<div
+  class="css-cht2m7"
+  data-cy="spacingBox"
+>
+  <div
+    class="css-1fe32n8"
+    data-cy="promoContent"
+  >
+    <button
+      class="css-1ylfqc6"
+      type="button"
+    >
+      <div
+        tabindex="-1"
+      >
+        <svg
+          aria-label="system-close icon"
+          class="css-zgvqkl"
+          data-cy="icon"
+          height="16"
+          preserveAspectRatio="xMinYMin meet"
+          role="img"
+          viewBox="0 0 16 16"
+          width="16"
+        >
+          <use
+            href="#system-close"
+          />
+        </svg>
+      </div>
+    </button>
+    <div
+      class="css-138vlob"
+      data-cy="flex"
+    >
+      <div
+        class="css-14eehpp"
+        data-cy="flexItem"
+      >
+        <div
+          class="css-18axn3y"
+          data-cy="spacingBox"
+        >
+          <div
+            class="css-ilu7d6"
+            data-cy="spacingBox"
+          >
+            <h3
+              class="rmTextMargins css-178l9ir"
+              data-cy="headingText1"
+            >
+              Promo Banner
+            </h3>
+          </div>
+          <div
+            class="css-fpj0jb"
+            data-cy="spacingBox"
+          >
+            Some promo details
+          </div>
+          <div
+            class="css-1yaruh1"
+            data-cy="flex"
+          >
+            <div
+              class="css-149ndna"
+              data-cy="flexItem"
+            >
+              <button>
+                Primary Action
+              </button>
+            </div>
+            <div
+              class="css-149ndna"
+              data-cy="flexItem"
+            >
+              <button>
+                Secondary Action
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="css-c5uz38"
+        data-cy="flexItem"
+      >
+        <div
+          class="css-111p8uk"
+          data-cy="spacingBox"
+        >
+          <div
+            class="css-7j3xjb"
+            data-cy="box"
+          />
+        </div>
+      </div>
+      <div
+        class="css-1v61zfx"
+        data-cy="flexItem"
+      >
+        <div
+          class="css-1jnujn3"
+          data-cy="spacingBox"
+        >
+          <div
+            class="css-deizzc"
+            data-cy="checkboxInput"
+          >
+            <label
+              class="css-14bj381"
+              for="dismissPromoCheckbox2"
+            >
+              <div
+                class="css-ew6x4b"
+              >
+                <div
+                  class="css-1iuiyz2"
+                >
+                  <input
+                    aria-describedby=""
+                    aria-invalid="false"
+                    class="css-epge75"
+                    data-cy="checkboxInput-input"
+                    id="dismissPromoCheckbox2"
+                    type="checkbox"
+                  />
+                </div>
+              </div>
+              <div
+                class="css-19gm8iw"
+              >
+                Do not show again
+              </div>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Promos renders PromoInline 1`] = `
+<div
+  class="css-1whabpp"
+  data-cy="card"
+>
+  <div
+    class="css-1xsu0i2"
+  >
+    <div
+      class="css-1o6stfp"
+      data-cy="spacingBox"
+    >
+      <div
+        class="css-1fe32n8"
+        data-cy="promoContent"
+      >
+        <button
+          class="css-1ylfqc6"
+          type="button"
+        >
+          <div
+            tabindex="-1"
+          >
+            <svg
+              aria-label="system-close icon"
+              class="css-zgvqkl"
+              data-cy="icon"
+              height="16"
+              preserveAspectRatio="xMinYMin meet"
+              role="img"
+              viewBox="0 0 16 16"
+              width="16"
+            >
+              <use
+                href="#system-close"
+              />
+            </svg>
+          </div>
+        </button>
+        <div
+          class="css-138vlob"
+          data-cy="flex"
+        >
+          <div
+            class="css-14eehpp"
+            data-cy="flexItem"
+          >
+            <div
+              class="css-18axn3y"
+              data-cy="spacingBox"
+            >
+              <div
+                class="css-ilu7d6"
+                data-cy="spacingBox"
+              >
+                <h3
+                  class="rmTextMargins css-178l9ir"
+                  data-cy="headingText1"
+                >
+                  Promo Inline
+                </h3>
+              </div>
+              <div
+                class="css-fpj0jb"
+                data-cy="spacingBox"
+              >
+                Some promo details
+              </div>
+              <div
+                class="css-1yaruh1"
+                data-cy="flex"
+              >
+                <div
+                  class="css-149ndna"
+                  data-cy="flexItem"
+                >
+                  <button>
+                    Primary Action
+                  </button>
+                </div>
+                <div
+                  class="css-149ndna"
+                  data-cy="flexItem"
+                >
+                  <button>
+                    Secondary Action
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="css-c5uz38"
+            data-cy="flexItem"
+          >
+            <div
+              class="css-111p8uk"
+              data-cy="spacingBox"
+            >
+              <div
+                class="css-7j3xjb"
+                data-cy="box"
+              />
+            </div>
+          </div>
+          <div
+            class="css-1v61zfx"
+            data-cy="flexItem"
+          >
+            <div
+              class="css-1jnujn3"
+              data-cy="spacingBox"
+            >
+              <div
+                class="css-deizzc"
+                data-cy="checkboxInput"
+              >
+                <label
+                  class="css-14bj381"
+                  for="dismissPromoCheckbox3"
+                >
+                  <div
+                    class="css-ew6x4b"
+                  >
+                    <div
+                      class="css-1iuiyz2"
+                    >
+                      <input
+                        aria-describedby=""
+                        aria-invalid="false"
+                        class="css-epge75"
+                        data-cy="checkboxInput-input"
+                        id="dismissPromoCheckbox3"
+                        type="checkbox"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="css-19gm8iw"
+                  >
+                    Do not show again
+                  </div>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/promo/components/PromoBanner.tsx
+++ b/packages/promo/components/PromoBanner.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cx } from "emotion";
+import { designTokens as dt, SpacingBox } from "../../";
+import PromoContent from "./PromoContent";
+import { PromoProps, GradientStyle } from "../types";
+import { getBackgroundGradient, gradientStyles } from "../style";
+
+interface PromoBannerProps extends PromoProps {
+  gradientStyle?: GradientStyle;
+}
+
+const darkGradientStyles: GradientStyle[] = ["purple"];
+
+const PromoBanner: React.StatelessComponent<PromoBannerProps> = ({
+  gradientStyle,
+  isDarkBackground,
+  ...other
+}) => (
+  <SpacingBox
+    bgColor={
+      gradientStyle ? gradientStyles[gradientStyle][0] : dt.themeBgSecondary
+    }
+    className={cx({
+      [getBackgroundGradient(gradientStyle)]: Boolean(gradientStyle)
+    })}
+    spacingSize="l"
+    side="horiz"
+  >
+    <PromoContent
+      isDarkBackground={
+        (gradientStyle && darkGradientStyles.includes(gradientStyle)) ||
+        isDarkBackground
+      }
+      {...other}
+    />
+  </SpacingBox>
+);
+
+export default PromoBanner;

--- a/packages/promo/components/PromoContent.tsx
+++ b/packages/promo/components/PromoContent.tsx
@@ -1,0 +1,115 @@
+import * as React from "react";
+import { useId } from "react-id-generator";
+import {
+  Box,
+  CheckboxInput,
+  designTokens as dt,
+  Flex,
+  FlexItem,
+  HeadingText1,
+  Icon,
+  ResetButton,
+  SpacingBox
+} from "../../";
+import { SystemIcons } from "../../icons/dist/system-icons-enum";
+import { PromoProps } from "../types";
+import {
+  bannerContainer,
+  bodyTextMaxWidth,
+  checkboxContainer,
+  dismissButton,
+  graphicContainer,
+  heroImg
+} from "../style";
+
+const PromoContent: React.StatelessComponent<PromoProps> = props => {
+  const {
+    bodyContent,
+    dismissHandler,
+    headingText,
+    isDarkBackground,
+    graphicSrc,
+    optOutBanner,
+    optOutHandler,
+    primaryAction,
+    secondaryAction
+  } = props;
+  const [dismissCheckboxId] = useId(1, "dismissPromoCheckbox");
+  return (
+    <div
+      className={bannerContainer(isDarkBackground)}
+      data-cy={props["data-cy"]}
+    >
+      {dismissHandler && (
+        <ResetButton className={dismissButton} onClick={dismissHandler}>
+          <Icon shape={SystemIcons.Close} size={dt.iconSizeXs} />
+        </ResetButton>
+      )}
+      <Flex direction={{ default: "column", medium: "row" }} align="stretch">
+        <FlexItem order={1}>
+          <SpacingBox
+            spacingSizePerSide={{
+              vert: "l",
+              right: { default: "none", medium: "l" }
+            }}
+          >
+            <SpacingBox spacingSize="m" side="bottom">
+              <HeadingText1 color="inherit">{headingText}</HeadingText1>
+            </SpacingBox>
+            <SpacingBox
+              spacingSize="l"
+              side="bottom"
+              className={bodyTextMaxWidth}
+            >
+              {bodyContent}
+            </SpacingBox>
+            {primaryAction && secondaryAction ? (
+              <Flex align="center" gutterSize="m">
+                <FlexItem flex="shrink">{primaryAction}</FlexItem>
+                <FlexItem flex="shrink">{secondaryAction}</FlexItem>
+              </Flex>
+            ) : (
+              primaryAction || secondaryAction
+            )}
+          </SpacingBox>
+        </FlexItem>
+        {graphicSrc ? (
+          <FlexItem
+            order={{ default: 0, medium: 1 }}
+            flex={{ default: "grow", small: "shrink", large: "grow" }}
+          >
+            <SpacingBox spacingSize="s" className={graphicContainer}>
+              <Box
+                bgImageUrl={graphicSrc}
+                bgImageOptions={{ position: "center", size: "contain" }}
+                className={heroImg}
+              />
+            </SpacingBox>
+          </FlexItem>
+        ) : null}
+        {Boolean(optOutHandler) ? (
+          <FlexItem flex="shrink" order={2}>
+            <SpacingBox
+              spacingSize="l"
+              side="vert"
+              className={checkboxContainer}
+            >
+              <CheckboxInput
+                id={dismissCheckboxId}
+                inputLabel="Do not show again"
+                checked={optOutBanner}
+                onChange={optOutHandler}
+              />
+            </SpacingBox>
+          </FlexItem>
+        ) : null}
+      </Flex>
+    </div>
+  );
+};
+
+PromoContent.defaultProps = {
+  ["data-cy"]: "promoContent"
+};
+
+export default PromoContent;

--- a/packages/promo/components/PromoInline.tsx
+++ b/packages/promo/components/PromoInline.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { Card, SpacingBox } from "../../";
+import { PromoProps } from "../types";
+import PromoContent from "./PromoContent";
+
+const PromoInline: React.StatelessComponent<PromoProps> = props => (
+  <Card paddingSize="none">
+    <SpacingBox side="horiz" spacingSize="m">
+      <PromoContent {...props} />
+    </SpacingBox>
+  </Card>
+);
+
+export default PromoInline;

--- a/packages/promo/index.ts
+++ b/packages/promo/index.ts
@@ -1,0 +1,2 @@
+export { default as PromoBanner } from "./components/PromoBanner";
+export { default as PromoInline } from "./components/PromoInline";

--- a/packages/promo/promos.test.tsx
+++ b/packages/promo/promos.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { mount, render } from "enzyme";
+import toJSON from "enzyme-to-json";
+
+import { PromoBanner, PromoInline } from "./";
+import PromoContent from "./components/PromoContent";
+
+describe("Promos", () => {
+  const dismissHandler = jest.fn();
+  const optOutHandler = jest.fn();
+  it("renders PromoBanner", () => {
+    expect(
+      toJSON(
+        render(
+          <PromoBanner
+            graphicSrc="http://placehold.it/350x150"
+            primaryAction={<button>Primary Action</button>}
+            secondaryAction={<button>Secondary Action</button>}
+            headingText="Promo Banner"
+            bodyContent="Some promo details"
+            dismissHandler={dismissHandler}
+            optOutHandler={optOutHandler}
+          />
+        )
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("renders PromoBanner with a gradientStyle", () => {
+    expect(
+      toJSON(
+        render(
+          <PromoBanner
+            gradientStyle="lightBlue"
+            graphicSrc="http://placehold.it/350x150"
+            primaryAction={<button>Primary Action</button>}
+            secondaryAction={<button>Secondary Action</button>}
+            headingText="Promo Banner"
+            bodyContent="Some promo details"
+            dismissHandler={dismissHandler}
+            optOutHandler={optOutHandler}
+          />
+        )
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("renders PromoInline", () => {
+    expect(
+      toJSON(
+        render(
+          <PromoInline
+            graphicSrc="http://placehold.it/350x150"
+            primaryAction={<button>Primary Action</button>}
+            secondaryAction={<button>Secondary Action</button>}
+            headingText="Promo Inline"
+            bodyContent="Some promo details"
+            dismissHandler={dismissHandler}
+            optOutHandler={optOutHandler}
+          />
+        )
+      )
+    ).toMatchSnapshot();
+  });
+
+  it("calls optOutHandler when the opt out checkbox is checked", () => {
+    const component = mount(
+      <PromoContent
+        graphicSrc="http://placehold.it/350x150"
+        primaryAction={<button>Primary Action</button>}
+        secondaryAction={<button>Secondary Action</button>}
+        headingText="Promo Inline"
+        bodyContent="Some promo details"
+        dismissHandler={dismissHandler}
+        optOutHandler={optOutHandler}
+      />
+    );
+
+    expect(optOutHandler).not.toHaveBeenCalled();
+    component.find("input").simulate("change", { target: { checked: true } });
+    expect(optOutHandler).toHaveBeenCalled();
+  });
+
+  it("calls optOutHandler when the opt out checkbox is checked", () => {
+    const component = mount(
+      <PromoContent
+        graphicSrc="http://placehold.it/350x150"
+        primaryAction={<button>Primary Action</button>}
+        secondaryAction={<button>Secondary Action</button>}
+        headingText="Promo Inline"
+        bodyContent="Some promo details"
+        dismissHandler={dismissHandler}
+        optOutHandler={optOutHandler}
+      />
+    );
+
+    expect(dismissHandler).not.toHaveBeenCalled();
+    component.find('[aria-label*="system-close"]').simulate("click");
+    expect(dismissHandler).toHaveBeenCalled();
+  });
+});

--- a/packages/promo/stories/promoBanner.stories.tsx
+++ b/packages/promo/stories/promoBanner.stories.tsx
@@ -1,0 +1,102 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { withKnobs, select } from "@storybook/addon-knobs";
+import { PageHeader, SpacingBox, PrimaryButton, SecondaryButton } from "../../";
+import { PromoBanner } from "../";
+import PromoContent from "../components/PromoContent";
+import { gradientStyles } from "../style";
+
+const readme = require("../README.md");
+
+storiesOf("Feedback|PromoBanner", module)
+  .addDecorator(withKnobs)
+  .addParameters({
+    info: {
+      text: readme
+    }
+  })
+  .addParameters({
+    info: {
+      propTablesExclude: [
+        PageHeader,
+        SpacingBox,
+        PrimaryButton,
+        SecondaryButton
+      ],
+      propTables: [PromoContent]
+    }
+  })
+  .add("headline and body", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <PromoBanner
+        headingText="Promo Banner"
+        bodyContent="The PromoBanner component is used to bring the user's attention to informational content relevant to the page it's being displayed on. It typically appears below the PageHeader."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Do not show this promo again")}
+      />
+      <SpacingBox spacingSize="l">Primary page content</SpacingBox>
+    </>
+  ))
+  .add("user opted out of seeing banner", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <PromoBanner
+        headingText="Promo Banner"
+        bodyContent="The PromoBanner component is used to bring the user's attention to informational content relevant to the page it's being displayed on. It typically appears below the PageHeader."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Show this promo again")}
+        optOutBanner={true}
+      />
+      <SpacingBox spacingSize="l">Primary page content</SpacingBox>
+    </>
+  ))
+  .add("w/ gradient background", () => {
+    const gradients = Object.keys(gradientStyles).reduce((acc, curr) => {
+      acc[curr] = curr;
+      return acc;
+    }, {});
+    const gradient = select("gradientStyle", gradients, "lightBlue");
+
+    return (
+      <>
+        <PageHeader breadcrumbElements={["Page Header"]} />
+        <PromoBanner
+          gradientStyle={gradient}
+          headingText="Use knobs panel to change gradient"
+          bodyContent="The PromoBanner component is used to bring the user's attention to informational content relevant to the page it's being displayed on. It typically appears below the PageHeader."
+          dismissHandler={action("Hide the promo")}
+          optOutHandler={action("Do not show this promo again")}
+        />
+        <SpacingBox spacingSize="l">Primary page content</SpacingBox>
+      </>
+    );
+  })
+  .add("w/ a graphic", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <PromoBanner
+        graphicSrc="http://placehold.it/350x150"
+        headingText="Promo Banner"
+        bodyContent="The PromoBanner component is used to bring the user's attention to informational content relevant to the page it's being displayed on. It typically appears below the PageHeader."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Do not show this promo again")}
+      />
+      <SpacingBox spacingSize="l">Primary page content</SpacingBox>
+    </>
+  ))
+  .add("w/ primary and secondary actions", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <PromoBanner
+        primaryAction={<PrimaryButton>Primary Action</PrimaryButton>}
+        secondaryAction={<SecondaryButton>Secondary Action</SecondaryButton>}
+        headingText="Promo Banner"
+        bodyContent="The PromoBanner component is used to bring the user's attention to informational content relevant to the page it's being displayed on. It typically appears below the PageHeader."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Do not show this promo again")}
+      />
+      <SpacingBox spacingSize="l">Primary page content</SpacingBox>
+    </>
+  ));

--- a/packages/promo/stories/promoInline.stories.tsx
+++ b/packages/promo/stories/promoInline.stories.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { storiesOf } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { PageHeader, SpacingBox, PrimaryButton, SecondaryButton } from "../../";
+import { PromoInline } from "../";
+import PromoContent from "../components/PromoContent";
+
+const readme = require("../README.md");
+
+storiesOf("Feedback|PromoInline", module)
+  .addParameters({
+    info: {
+      text: readme
+    }
+  })
+  .addParameters({
+    info: {
+      propTablesExclude: [
+        PageHeader,
+        SpacingBox,
+        PrimaryButton,
+        SecondaryButton
+      ],
+      propTables: [PromoContent]
+    }
+  })
+  .add("headline and body", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <SpacingBox spacingSize="l">Some page content</SpacingBox>
+      <PromoInline
+        headingText="Promo Card"
+        bodyContent="The PromoInline component is less attention-grabbing than the PromoBanner. It appears inline with the other content on the page."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Do not show this promo again")}
+      />
+      <SpacingBox spacingSize="l">Some more page content</SpacingBox>
+    </>
+  ))
+  .add("user opted out of seeing promo", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <SpacingBox spacingSize="l">Some page content</SpacingBox>
+      <PromoInline
+        headingText="Promo Card"
+        bodyContent="The PromoInline component is less attention-grabbing than the PromoBanner. It appears inline with the other content on the page."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Show this promo again")}
+        optOutBanner={true}
+      />
+      <SpacingBox spacingSize="l">Some more page content</SpacingBox>
+    </>
+  ))
+  .add("w/ a graphic", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <SpacingBox spacingSize="l">Some page content</SpacingBox>
+      <PromoInline
+        graphicSrc="http://placehold.it/350x150"
+        headingText="Promo Card"
+        bodyContent="The PromoInline component is less attention-grabbing than the PromoBanner. It appears inline with the other content on the page."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Do not show this promo again")}
+      />
+      <SpacingBox spacingSize="l">Some more page content</SpacingBox>
+    </>
+  ))
+  .add("w/ primary and secondary actions", () => (
+    <>
+      <PageHeader breadcrumbElements={["Page Header"]} />
+      <SpacingBox spacingSize="l">Some page content</SpacingBox>
+      <PromoInline
+        primaryAction={<PrimaryButton>Primary Action</PrimaryButton>}
+        secondaryAction={<SecondaryButton>Secondary Action</SecondaryButton>}
+        headingText="Promo Card"
+        bodyContent="The PromoInline component is less attention-grabbing than the PromoBanner. It appears inline with the other content on the page."
+        dismissHandler={action("Hide the promo")}
+        optOutHandler={action("Do not show this promo again")}
+      />
+      <SpacingBox spacingSize="l">Some more page content</SpacingBox>
+    </>
+  ));

--- a/packages/promo/style.ts
+++ b/packages/promo/style.ts
@@ -1,0 +1,58 @@
+import { css } from "emotion";
+import { GradientColors, GradientStyle } from "./types";
+import {
+  blueLighten4,
+  spaceS,
+  textBlockWidth,
+  themeBgSecondary,
+  themeTextColorPrimaryInverted
+} from "../design-tokens/build/js/designTokens";
+
+export const bannerContainer = (isDarkBackground?: boolean) => css`
+  position: relative;
+  color: ${isDarkBackground ? themeTextColorPrimaryInverted : "inherit"};
+`;
+export const dismissButton = css`
+  cursor: pointer;
+  position: absolute;
+  right: 0;
+  top: ${spaceS};
+`;
+export const heroImg = css`
+  height: 100%;
+  min-height: 150px;
+  min-width: 200px;
+`;
+export const checkboxContainer = css`
+  align-items: flex-end;
+  box-sizing: border-box;
+  display: flex;
+  height: 100%;
+  justify-content: flex-end;
+`;
+
+export const bodyTextMaxWidth = css`
+  max-width: ${textBlockWidth};
+`;
+
+export const graphicContainer = css`
+  box-sizing: border-box;
+  height: 100%;
+`;
+
+export const gradientStyles: Record<GradientStyle, GradientColors> = {
+  lightBlue: [themeBgSecondary, blueLighten4],
+  // these colors are not in ui-kit, but this is what was spec'd by the design team
+  purple: ["#440099", "#36007A"]
+};
+
+export const getBackgroundGradient = (gradientStyle?: GradientStyle) =>
+  gradientStyle
+    ? css`
+        background-image: linear-gradient(
+          90deg,
+          ${gradientStyles[gradientStyle][0]} 0%,
+          ${gradientStyles[gradientStyle][1]} 100%
+        );
+      `
+    : "";

--- a/packages/promo/types.ts
+++ b/packages/promo/types.ts
@@ -1,0 +1,25 @@
+export interface PromoProps {
+  /** The primary banner content */
+  bodyContent: React.ReactNode;
+  /** A function that gets called when the banner is dismissed */
+  dismissHandler?: () => void;
+  /** A consise summary of the banner's message */
+  headingText: string;
+  /** Whether the content is on a dark background. Changes text color to be readable. */
+  isDarkBackground?: boolean;
+  /** A link to the graphic's image file. The graphic (typically an illustration) should be relevant to the banner's message. Ideally the graphic should not just be decorative, but it reinforces the banner's overall message. */
+  graphicSrc?: string;
+  /** Whether a user has opted not to see the banner */
+  optOutBanner?: boolean;
+  /** A function that gets called when the user checks the "Do not show again" checkbox */
+  optOutHandler?: (e: React.SyntheticEvent<HTMLInputElement>) => void;
+  /** The most relevant action a user can take in response to the banner's message */
+  primaryAction?: React.ReactNode;
+  /** An additional action a user can take in response to the banner's message. This can also just be a link to more information relevant to the banner's message. */
+  secondaryAction?: React.ReactNode;
+  /** The Cypress selector */
+  ["data-cy"]?: string;
+}
+
+export type GradientStyle = "lightBlue" | "purple";
+export type GradientColors = [string, string];


### PR DESCRIPTION
## Testing
Navigate to the PromoInline and PromoBanner stories to make sure they look correct, and the documentation is useful and easy to follow.

Note: the top and bottom padding in PromoCard is intentionally smaller than what is in Kommander.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
![Screen Shot 2020-03-30 at 5 30 26 PM](https://user-images.githubusercontent.com/2313998/77965450-02339680-72af-11ea-97d4-0e8e11461796.png)
![Screen Shot 2020-03-30 at 5 30 42 PM](https://user-images.githubusercontent.com/2313998/77965451-02339680-72af-11ea-822c-4cfe0aa157f1.png)


## Checklist for PR creator

- [x] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
