### PR TITLE
D2IQ-68105: removes styles that affect layout

### DIFF
--- a/packages/avatar/style.ts
+++ b/packages/avatar/style.ts
@@ -1,16 +1,24 @@
 import { css } from "emotion";
 import { AvatarSizes } from "./components/Avatar";
-import {
-  themeBgSecondary,
-  greyLightLighten5
-} from "../design-tokens/build/js/designTokens";
+import { themeBgSecondary } from "../design-tokens/build/js/designTokens";
 
 export const avatarContainer = css`
   background-color: ${themeBgSecondary};
-  border: 1px solid ${greyLightLighten5};
   border-radius: 25%;
   overflow: hidden;
-  vertical-align: middle;
+  position: relative;
+
+  &:after {
+    border-radius: inherit;
+    bottom: 0;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+    content: "";
+    display: block;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
 `;
 
 export const avatarSize = (size: AvatarSizes) => css`
@@ -20,6 +28,7 @@ export const avatarSize = (size: AvatarSizes) => css`
 
 export const avatarImg = css`
   border: 0;
+  display: block;
   height: 100%;
   object-fit: cover;
   width: 100%;

--- a/packages/avatar/tests/__snapshots__/avatar.test.tsx.snap
+++ b/packages/avatar/tests/__snapshots__/avatar.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Avatar renders default 1`] = `
 .emotion-0 {
   border: 0;
+  display: block;
   height: 100%;
   object-fit: cover;
   width: 100%;
@@ -10,12 +11,23 @@ exports[`Avatar renders default 1`] = `
 
 .emotion-1 {
   background-color: var(--themeBgSecondary,#F7F8F9);
-  border: 1px solid #F7F8F9;
   border-radius: 25%;
   overflow: hidden;
-  vertical-align: middle;
+  position: relative;
   height: 32px;
   width: 32px;
+}
+
+.emotion-1:after {
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 <div
@@ -34,6 +46,7 @@ exports[`Avatar renders default 1`] = `
 exports[`Avatar renders with a src, size, and label 1`] = `
 .emotion-0 {
   border: 0;
+  display: block;
   height: 100%;
   object-fit: cover;
   width: 100%;
@@ -41,12 +54,23 @@ exports[`Avatar renders with a src, size, and label 1`] = `
 
 .emotion-1 {
   background-color: var(--themeBgSecondary,#F7F8F9);
-  border: 1px solid #F7F8F9;
   border-radius: 25%;
   overflow: hidden;
-  vertical-align: middle;
+  position: relative;
   height: 64px;
   width: 64px;
+}
+
+.emotion-1:after {
+  border-radius: inherit;
+  bottom: 0;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+  content: "";
+  display: block;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 <div


### PR DESCRIPTION
These changes also include styles that show an outline around avatars so they are visible when they are on a background that is the same color

Closes D2IQ-68105

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

### Before:
Layout quirks:
<img width="1242" alt="Screen Shot 2020-05-18 at 6 20 53 PM" src="https://user-images.githubusercontent.com/2313998/82267743-389aa300-993b-11ea-83b7-a6022984d3a9.png">
<img width="728" alt="Screen Shot 2020-05-18 at 6 21 11 PM" src="https://user-images.githubusercontent.com/2313998/82267744-39333980-993b-11ea-8251-a6937fbd16b2.png">

On top of the same background color:
<img width="1676" alt="Screen Shot 2020-05-18 at 6 28 37 PM" src="https://user-images.githubusercontent.com/2313998/82268040-050c4880-993c-11ea-972d-6a04197469e5.png">





### After:
Layout quirks:
<img width="1263" alt="Screen Shot 2020-05-18 at 6 23 20 PM" src="https://user-images.githubusercontent.com/2313998/82268106-29682500-993c-11ea-8244-32363a063f29.png">
![Screen Shot 2020-05-18 at 6 26 37 PM](https://user-images.githubusercontent.com/2313998/82268108-29682500-993c-11ea-82cb-7027f4d87e6f.png)


On top of the same background color:
<img width="1679" alt="Screen Shot 2020-05-18 at 6 27 59 PM" src="https://user-images.githubusercontent.com/2313998/82268074-15242800-993c-11ea-9428-2218be4f98aa.png">

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
