### PR TITLE
feat(textarea): overrides monospace font-family in Chrome 83+

### DIFF
--- a/packages/shared/styles/normalize.ts
+++ b/packages/shared/styles/normalize.ts
@@ -19,4 +19,8 @@ export const normalize = `
     a {
         ${defaultLinkStyles};
     }
+
+    textarea {
+        font-family: inherit;
+    }
 `;


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

## Testing
Using Chrome version 83 or higher, confirm that our `Textarea` is set in a sans-serif font, not a monospace font.

## Trade-offs
I don't actually understand the reason Chrome added this default style. I'm just changing this because I know our design team will ask us to.

If any reviewers have a reason we shouldn't override the monospace font style, please let me know!

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

Before:
<img width="341" alt="Screen Shot 2020-05-27 at 9 07 08 PM" src="https://user-images.githubusercontent.com/2313998/83087746-020e0800-a060-11ea-8fce-ace2dc5e3fad.png">

After:
<img width="406" alt="Screen Shot 2020-05-27 at 9 06 58 PM" src="https://user-images.githubusercontent.com/2313998/83087744-020e0800-a060-11ea-9c50-a7b1f1b4a737.png">

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
