### PR TITLE
D2IQ-69416: moves Expandable's indicator icon to the left side

### DIFF
--- a/packages/expandable/components/Expandable.tsx
+++ b/packages/expandable/components/Expandable.tsx
@@ -1,8 +1,13 @@
 import * as React from "react";
 import { cx } from "emotion";
 import Toggle from "react-toggled";
-import { buttonReset, display, flex } from "../../shared/styles/styleUtils";
+import { display } from "../../shared/styles/styleUtils";
 import { toggler } from "../style";
+import { ResetButton } from "../../button";
+import { Icon } from "../../icon";
+import { SystemIcons } from "../../icons/dist/system-icons-enum";
+import { iconSizeXs } from "../../design-tokens/build/js/designTokens";
+import { Flex, FlexItem } from "../../styleUtils/layout";
 
 export interface ExpandableProps {
   children: React.ReactElement<HTMLElement> | string;
@@ -26,18 +31,23 @@ class Expandable extends React.PureComponent<ExpandableProps, {}> {
       <Toggle defaultOn={Boolean(isOpen)} on={controlledIsOpen}>
         {({ on, getTogglerProps }) => (
           <div>
-            <button
+            <ResetButton
               {...getTogglerProps({
-                className: cx(
-                  buttonReset,
-                  labelClassName,
-                  toggler(on),
-                  flex({ align: "center", justify: "space-between" })
-                )
+                className: cx(labelClassName, toggler)
               })}
             >
-              {label}
-            </button>
+              <Flex align="center">
+                <FlexItem flex="shrink">
+                  <Icon
+                    shape={
+                      on ? SystemIcons.TriangleDown : SystemIcons.TriangleRight
+                    }
+                    size={iconSizeXs}
+                  />
+                </FlexItem>
+                <FlexItem>{label}</FlexItem>
+              </Flex>
+            </ResetButton>
             {/* TODO: investigate whether display: none is a11y-friendly in this situation */}
             <div className={cx({ [display("none")]: !on })}>{children}</div>
           </div>

--- a/packages/expandable/style.ts
+++ b/packages/expandable/style.ts
@@ -1,43 +1,6 @@
 import { css } from "emotion";
 
-// TODO: better name than "details"?
-// export const details = (isOpen?: boolean) => css`
-//   height: ${isOpen ? "auto" : 0};
-//   overflow: hidden;
-//   visibility: ${isOpen ? "visible" : "hidden"};
-// `;
-
-const arrowDownBorders = css`
-  border-top-color: inherit;
-  border-left-width: 5px;
-  border-right-width: 5px;
-  border-bottom-width: 0;
-  border-top-width: 6px;
-`;
-
-const arrowRightBorders = css`
-  border-left-color: inherit;
-  border-left-width: 6px;
-  border-bottom-width: 5px;
-  border-right-width: 0;
-  border-top-width: 5px;
-`;
-
-export const toggler = (isOpen: boolean) => css`
+export const toggler = css`
+  display: block;
   width: 100%;
-
-  &:after {
-    border-style: solid;
-    border-color: transparent;
-    content: "";
-    display: inline-block;
-    height: 0;
-    line-height: 0;
-    width: 0;
-    ${isOpen ? arrowDownBorders : arrowRightBorders};
-  }
-
-  &:focus {
-    outline: 0;
-  }
 `;

--- a/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
+++ b/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
@@ -1,7 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Sidebar renders 1`] = `
-.emotion-0 {
+.emotion-5 {
+  display: block;
+  width: 100%;
+}
+
+.emotion-4 {
   background: none;
   border: 0;
   color: inherit;
@@ -10,16 +15,49 @@ exports[`Sidebar renders 1`] = `
   overflow: visible;
   padding: 0;
   text-align: inherit;
+  display: block;
   width: 100%;
+  cursor: pointer;
+}
+
+.emotion-4::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.emotion-4 > div:focus {
+  outline: none;
+}
+
+.emotion-4:focus > div {
+  outline-color: Highlight;
+  outline-width: thin;
+}
+
+@media (-webkit-min-device-pixel-ratio:0) {
+  .emotion-4:focus > div {
+    outline-color: -webkit-focus-ring-color;
+    outline-style: auto;
+    outline-width: unset;
+  }
+}
+
+.emotion-3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   height: auto;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -28,31 +66,49 @@ exports[`Sidebar renders 1`] = `
   min-height: 0;
 }
 
-.emotion-0::-moz-focus-inner {
-  border: 0;
-  padding: 0;
+.emotion-3 > div {
+  width: auto;
 }
 
-.emotion-0:after {
-  border-style: solid;
-  border-color: transparent;
-  content: "";
-  display: inline-block;
-  height: 0;
-  line-height: 0;
-  width: 0;
-  border-top-color: inherit;
-  border-left-width: 5px;
-  border-right-width: 5px;
-  border-bottom-width: 0;
-  border-top-width: 6px;
+.emotion-3 > *:not(:first-child) {
+  padding-left: 0;
+  padding-top: 0;
 }
 
-.emotion-0:focus {
-  outline: 0;
+.emotion-1 {
+  box-sizing: border-box;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: initial;
 }
 
-.emotion-0 > div {
+.emotion-0 {
+  vertical-align: middle;
+  fill: currentColor;
+}
+
+.emotion-0 use {
+  pointer-events: none;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
   width: auto;
 }
 
@@ -65,14 +121,76 @@ exports[`Sidebar renders 1`] = `
     onToggle={[Function]}
   >
     <div>
-      <button
+      <ResetButton
         aria-expanded={true}
-        className="emotion-0"
+        className="emotion-5"
         onClick={[Function]}
         tabIndex={0}
       >
-        Label
-      </button>
+        <button
+          aria-expanded={true}
+          className="emotion-4"
+          onClick={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <div
+            tabIndex={-1}
+          >
+            <Flex
+              align="center"
+              direction="row"
+              gutterSize="none"
+              justify="flex-start"
+              wrap="nowrap"
+            >
+              <div
+                className="emotion-3"
+                data-cy="flex"
+              >
+                <FlexItem
+                  flex="shrink"
+                >
+                  <div
+                    className="emotion-1"
+                    data-cy="flexItem"
+                  >
+                    <Icon
+                      shape="system-triangle-down"
+                      size="16px"
+                    >
+                      <svg
+                        aria-label="system-triangle-down icon"
+                        className="emotion-0"
+                        data-cy="icon"
+                        height={16}
+                        preserveAspectRatio="xMinYMin meet"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width={16}
+                      >
+                        <use
+                          xlinkHref="#system-triangle-down"
+                        />
+                      </svg>
+                    </Icon>
+                  </div>
+                </FlexItem>
+                <FlexItem
+                  flex="grow"
+                >
+                  <div
+                    className="emotion-2"
+                    data-cy="flexItem"
+                  >
+                    Label
+                  </div>
+                </FlexItem>
+              </div>
+            </Flex>
+          </div>
+        </button>
+      </ResetButton>
       <div
         className=""
       >

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -58,6 +58,7 @@ export {
   EmptyStateWithGraphic,
   EmptyStateWrapper
 } from "./emptyState";
+export { Expandable } from "./expandable";
 export * from "./formStructure";
 export { FullscreenView } from "./fullscreenView";
 export { Icon } from "./icon";


### PR DESCRIPTION
Closes D2IQ-69416

<!-- See Checklist for PR creators below. -->

## Testing

Confirm the triangle icon appears to the left of the text label

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
<img width="553" alt="Screen Shot 2020-07-13 at 7 43 25 PM" src="https://user-images.githubusercontent.com/2313998/87364915-d927d080-c542-11ea-9f9b-96900640d1f8.png">


## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
