### PR TITLE
feat(Expandable): add onchange handler prop

### DIFF
--- a/packages/expandable/components/Expandable.tsx
+++ b/packages/expandable/components/Expandable.tsx
@@ -15,6 +15,7 @@ export interface ExpandableProps {
   isOpen?: boolean;
   label: React.ReactElement<HTMLElement> | string;
   labelClassName?: string;
+  onChange?: (open: boolean) => void;
 }
 
 class Expandable extends React.PureComponent<ExpandableProps, {}> {
@@ -24,11 +25,16 @@ class Expandable extends React.PureComponent<ExpandableProps, {}> {
       children,
       label,
       isOpen,
-      controlledIsOpen
+      controlledIsOpen,
+      onChange
     } = this.props;
 
     return (
-      <Toggle defaultOn={Boolean(isOpen)} on={controlledIsOpen}>
+      <Toggle
+        defaultOn={Boolean(isOpen)}
+        on={controlledIsOpen}
+        onToggle={onChange}
+      >
         {({ on, getTogglerProps }) => (
           <div>
             <ResetButton


### PR DESCRIPTION
Added an optional `onChange` handler to the Expandable component so that
users can be notified when the Toggle is clicked and handle updates.

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
