### PR TITLE
D2IQ-70625: adds bottom border to accordion item titles

### DIFF
--- a/packages/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/packages/accordion/__snapshots__/accordion.test.tsx.snap
@@ -425,7 +425,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                   isExpanded={true}
                 >
                   <div
-                    className="css-1spvuwg"
+                    className="css-3n1jto"
                     data-cy="accordionItemTitle"
                   >
                     <h3
@@ -537,7 +537,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                   isExpanded={true}
                 >
                   <div
-                    className="css-1spvuwg"
+                    className="css-3n1jto"
                     data-cy="accordionItemTitle"
                   >
                     <h3
@@ -649,7 +649,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                   isExpanded={true}
                 >
                   <div
-                    className="css-1spvuwg"
+                    className="css-3n1jto"
                     data-cy="accordionItemTitle"
                   >
                     <h3

--- a/packages/accordion/style.ts
+++ b/packages/accordion/style.ts
@@ -27,7 +27,6 @@ export const accordionTitle = css`
 `;
 
 export const accordionTitleExpanded = css`
-  border-bottom-width: 0;
   border-radius: ${borderRadiusSmall} ${borderRadiusSmall} 0 0;
 `;
 


### PR DESCRIPTION
Closes D2IQ-70625

<!-- See Checklist for PR creators below. -->

## Testing

Go to the accordion stories (http://localhost:6006/?path=/story/navigation-accordion--default).
Confirm that accordion title and accordion panel content is separated by a border.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

Before:
![Screen Shot 2020-08-10 at 5 38 26 PM](https://user-images.githubusercontent.com/2313998/89834953-ca2c4200-db31-11ea-9b68-dafa195cc88b.png)

After:
![Screen Shot 2020-08-10 at 5 37 27 PM](https://user-images.githubusercontent.com/2313998/89834971-d0222300-db31-11ea-9f37-3c8bbbea52ba.png)

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
