### PR TITLE
fix: ensure both hintcontent and errors are shown below Textarea

### DIFF
--- a/packages/textarea/components/Textarea.tsx
+++ b/packages/textarea/components/Textarea.tsx
@@ -113,13 +113,8 @@ class Textarea extends React.PureComponent<TextareaProps, {}> {
               {...{ ...other, onChange }}
             />
             <div data-cy={textareaDataCy}>
-              {getHintContent ||
-                (hasError && getValidationErrors && (
-                  <React.Fragment>
-                    {getHintContent}
-                    {hasError && getValidationErrors}
-                  </React.Fragment>
-                ))}
+              {getHintContent}
+              {hasError ? getValidationErrors : null}
             </div>
           </div>
         )}

--- a/packages/textarea/stories/Textarea.stories.tsx
+++ b/packages/textarea/stories/Textarea.stories.tsx
@@ -54,6 +54,16 @@ storiesOf("Forms|Textarea", module)
       hintContent="Enter a body of text here"
     />
   ))
+  .add("hint text and error", () => (
+    <Textarea
+      id="hint"
+      appearance={InputAppearance.Error}
+      inputLabel="Standard"
+      placeholder="Placeholder"
+      hintContent="Enter a body of text here"
+      errors={["Something is wrong here"]}
+    />
+  ))
   .add("required", () => (
     <React.Fragment>
       <Textarea


### PR DESCRIPTION
## Testing

- See the new [hint text and error](http://localhost:6006/?path=/story/forms-textarea--hint-text-and-error) Textarea story and ensure you see both hint text and error message

## Trade-offs

## Dependencies

## Screenshots

Before
<img width="340" alt="Screen Shot 2020-08-20 at 11 15 28 AM" src="https://user-images.githubusercontent.com/19582796/90810666-32201c80-e2d8-11ea-90bd-fa927a76e3b1.png">

After
<img width="348" alt="Screen Shot 2020-08-20 at 11 27 28 AM" src="https://user-images.githubusercontent.com/19582796/90810683-377d6700-e2d8-11ea-975e-6030d256198e.png">

