### PR TITLE
D2IQ-70983: constrain dimensions of dropdown element passed to Dropdownable to the dimensions of the viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -987,7 +987,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
           "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
@@ -9609,7 +9609,7 @@
         },
         "query-string": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
@@ -10665,7 +10665,7 @@
       "dependencies": {
         "jest-worker": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
           "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
           "dev": true,
           "requires": {
@@ -12861,7 +12861,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         }
@@ -16226,7 +16226,7 @@
         },
         "jest-diff": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
           "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
           "dev": true,
           "requires": {
@@ -16238,7 +16238,7 @@
         },
         "pretty-format": {
           "version": "22.4.3",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
           "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
           "dev": true,
           "requires": {
@@ -19968,13 +19968,13 @@
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+          "resolved": "",
           "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -19983,17 +19983,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -20662,7 +20662,7 @@
     },
     "p-cancelable": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "resolved": "http://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
       "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
       "dev": true
     },
@@ -20688,7 +20688,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -21179,6 +21179,11 @@
       "requires": {
         "@babel/runtime": "^7.2.0"
       }
+    },
+    "popper-max-size-modifier": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
+      "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg=="
     },
     "popper.js": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "emotion-theming": "9.2.9",
     "memoize-one": "4.0.2",
     "@popperjs/core": "2.4.0",
+    "popper-max-size-modifier": "0.2.0",
     "react-chartist": "^0.13.3",
     "react-click-outside": "3.0.1",
     "react-delegate-component": "1.0.0",

--- a/packages/accordion/accordion.stories.tsx
+++ b/packages/accordion/accordion.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
 import { Flex, FlexItem } from "../styleUtils/layout";
 import { SecondaryButton } from "../button";
 import {
@@ -9,8 +10,10 @@ import {
   AccordionItemContent,
   AccordionItemTitleInteractive
 } from "./";
+const readme = require("./README.md");
 
 storiesOf("Navigation|Accordion", module)
+  .addDecorator(withReadme([readme]))
   .add("default", () => (
     <Accordion>
       <AccordionItem>

--- a/packages/dropdownMenu/tests/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/dropdownMenu/tests/__snapshots__/DropdownMenu.test.tsx.snap
@@ -1193,10 +1193,11 @@ exports[`Dropdown renders an open dropdown with multiple sections 1`] = `
                       >
                         <div
                           aria-labelledby="downshift-1-label"
-                          class="emotion-9"
+                          class="css-jcddh3"
                           data-cy="popover"
                           id="downshift-1-menu"
                           role="listbox"
+                          style="overflow: auto; max-height: 768px; max-width: 0px;"
                         >
                           <div
                             class=""

--- a/packages/popover/components/PopoverBox.tsx
+++ b/packages/popover/components/PopoverBox.tsx
@@ -30,7 +30,8 @@ const Popover = (props: PopoverProps) => {
       <div
         className={cx(menuList, border("all"), {
           [alignContainerWithCaretStyles(direction)]: showPointerCaret,
-          [hideHoriztonalScroll]: !width && !maxWidth
+          [hideHoriztonalScroll]:
+            !width && !maxWidth && !other.style?.maxWidth && !other.style?.width
         })}
         ref={menuRef}
         style={{ width, maxHeight, maxWidth }}


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

## Testing
Try opening a dropdown menu powered by dropdownable (Typeahead, DropdownMenu) that has too many items to fit in the viewport.
The dropdown menu should be scrollable

Bonus: test this in Kommander using the workspace selection dropdown populated with a bunch of workspaces

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
https://share.getcloudapp.com/eDuBl7BJ

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
