### PR TITLE
feat(Textarea): allow for `tooltipContent`

### DIFF
--- a/packages/formStructure/tests/__snapshots__/fieldList.test.tsx.snap
+++ b/packages/formStructure/tests/__snapshots__/fieldList.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`FieldList renders 1`] = `
         data-cy="fieldList-cell"
       >
         <div
-          data-cy="textInput"
+          data-cy="textInput textInput.standard"
         >
           <label
             class="css-1lrhbps"
@@ -76,7 +76,7 @@ exports[`FieldList renders 1`] = `
         data-cy="fieldList-cell"
       >
         <div
-          data-cy="textInput"
+          data-cy="textInput textInput.standard"
         >
           <label
             class="css-1lrhbps"
@@ -141,7 +141,7 @@ exports[`FieldList renders 1`] = `
         data-cy="fieldList-cell"
       >
         <div
-          data-cy="textInput"
+          data-cy="textInput textInput.standard"
         >
           <label
             class="css-1lrhbps"
@@ -181,7 +181,7 @@ exports[`FieldList renders 1`] = `
         data-cy="fieldList-cell"
       >
         <div
-          data-cy="textInput"
+          data-cy="textInput textInput.standard"
         >
           <label
             class="css-1lrhbps"
@@ -245,7 +245,7 @@ exports[`FieldList renders 1`] = `
         data-cy="fieldList-cell"
       >
         <div
-          data-cy="textInput"
+          data-cy="textInput textInput.standard"
         >
           <label
             class="css-1lrhbps"
@@ -285,7 +285,7 @@ exports[`FieldList renders 1`] = `
         data-cy="fieldList-cell"
       >
         <div
-          data-cy="textInput"
+          data-cy="textInput textInput.standard"
         >
           <label
             class="css-1lrhbps"

--- a/packages/textInput/components/TextInput.tsx
+++ b/packages/textInput/components/TextInput.tsx
@@ -2,30 +2,19 @@ import { cx } from "emotion";
 import * as React from "react";
 import nextId from "react-id-generator";
 
-import {
-  greyLightDarken2,
-  iconSizeXs,
-  themeError
-} from "../../design-tokens/build/js/designTokens";
 import FormFieldWrapper from "../../shared/components/FormFieldWrapper";
 import {
   getInputAppearanceStyle,
-  inputContainer,
-  getLabelStyle
+  inputContainer
 } from "../../shared/styles/formStyles";
 import {
   flex,
   flexItem,
   inputReset,
-  margin,
-  padding,
-  tintText,
-  visuallyHidden
+  padding
 } from "../../shared/styles/styleUtils";
 import { InputAppearance } from "../../shared/types/inputAppearance";
-import Icon from "../../icon/components/Icon";
-import { SystemIcons } from "../../icons/dist/system-icons-enum";
-import Tooltip from "../../tooltip/components/Tooltip";
+import { renderLabel } from "../../utilities/label";
 
 export interface TextInputProps extends React.HTMLProps<HTMLInputElement> {
   /**
@@ -67,30 +56,23 @@ export class TextInput<P extends TextInputProps> extends React.Component<P> {
   placeholderId = nextId("textInput-");
 
   public render() {
-    const labelContent = this.getLabelContent();
-    const tooltipContent = this.getTooltipContent();
     const containerProps: { className?: string } = {};
     const appearance = this.getInputAppearance();
-    const dataCy = [
-      "textInput",
-      ...(appearance && appearance !== InputAppearance.Standard
-        ? [`textInput.${appearance}`]
-        : [])
-    ].join(" ");
+    const dataCy = `textInput textInput.${appearance}`;
 
     if (this.props.className) {
       containerProps.className = this.props.className;
     }
     return (
       <div {...containerProps} data-cy={dataCy}>
-        {tooltipContent ? (
-          <div className={flex({ align: "center" })}>
-            {labelContent}
-            {tooltipContent}
-          </div>
-        ) : (
-          labelContent
-        )}
+        {renderLabel({
+          appearance,
+          hidden: !this.props.showInputLabel,
+          id: this.getId(),
+          label: this.props.inputLabel,
+          required: this.props.required,
+          tooltipContent: this.props.tooltipContent
+        })}
         {this.getInputContent()}
       </div>
     );
@@ -98,26 +80,6 @@ export class TextInput<P extends TextInputProps> extends React.Component<P> {
 
   protected getInputAppearance(): string {
     return this.props.disabled ? "disabled" : this.props.appearance;
-  }
-
-  protected getLabelContent() {
-    const requiredContent = this.props.required ? (
-      <span className={cx(tintText(themeError))}> *</span>
-    ) : null;
-    const hasError = this.props.appearance === InputAppearance.Error;
-    const labelClassName = this.props.showInputLabel
-      ? getLabelStyle(hasError)
-      : cx(visuallyHidden);
-    return (
-      <label
-        className={labelClassName}
-        htmlFor={this.getId()}
-        data-cy="textInput-label"
-      >
-        {this.props.inputLabel}
-        {requiredContent}
-      </label>
-    );
   }
 
   protected getInputContent(): React.ReactNode {
@@ -202,30 +164,6 @@ export class TextInput<P extends TextInputProps> extends React.Component<P> {
         data-cy={dataCy}
         {...{ ...inputElementProps, onChange, value }}
       />
-    );
-  }
-
-  protected getTooltipContent(): React.ReactNode {
-    if (!this.props.tooltipContent) {
-      return null;
-    }
-
-    return (
-      <span className={cx(margin("left", "xs"), margin("bottom", "xxs"))}>
-        <Tooltip
-          trigger={
-            <Icon
-              color={greyLightDarken2}
-              shape={SystemIcons.CircleQuestion}
-              size={iconSizeXs}
-            />
-          }
-          id={`labelTooltip-${this.getId()}`}
-          maxWidth={200}
-        >
-          {this.props.tooltipContent}
-        </Tooltip>
-      </span>
     );
   }
 

--- a/packages/textInput/tests/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInput.test.tsx.snap
@@ -9,17 +9,22 @@ exports[`TextInput should display icon with tooltip if tooltipText is set 1`] = 
   font-weight: 500;
 }
 
-.emotion-1 {
-  margin-left: 8px;
-  margin-bottom: 4px;
-}
-
 .emotion-2 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
   height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -32,8 +37,13 @@ exports[`TextInput should display icon with tooltip if tooltipText is set 1`] = 
   width: auto;
 }
 
+.emotion-1 {
+  margin-left: 8px;
+  margin-bottom: 4px;
+}
+
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <div
     className="emotion-2"
@@ -120,7 +130,7 @@ exports[`TextInput should hide label if \`showInputLabel\` set to false 1`] = `
 }
 
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <label
     className="emotion-0"
@@ -295,7 +305,7 @@ exports[`TextInput should render all appearances focus 1`] = `
   type="text"
 >
   <div
-    data-cy="textInput"
+    data-cy="textInput textInput.standard"
   >
     <label
       className="emotion-0"
@@ -653,7 +663,7 @@ exports[`TextInput should render all appearances with props 1`] = `
 }
 
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <label
     className="emotion-0"
@@ -736,7 +746,7 @@ exports[`TextInput should render node as inputLabel 1`] = `
 }
 
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <label
     className="emotion-0"
@@ -765,7 +775,7 @@ exports[`TextInput should render string inputLabel 1`] = `
 }
 
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <label
     className="emotion-0"

--- a/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
@@ -291,7 +291,7 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
   type="text"
 >
   <div
-    data-cy="textInput"
+    data-cy="textInput textInput.standard"
   >
     <label
       className="emotion-0"
@@ -720,7 +720,7 @@ exports[`TextInputWithBadges renders empty 1`] = `
   type="text"
 >
   <div
-    data-cy="textInput"
+    data-cy="textInput textInput.standard"
   >
     <label
       className="emotion-0"
@@ -1045,7 +1045,7 @@ exports[`TextInputWithBadges renders with badges 1`] = `
   type="text"
 >
   <div
-    data-cy="textInput"
+    data-cy="textInput textInput.standard"
   >
     <label
       className="emotion-0"

--- a/packages/textInput/tests/__snapshots__/TextInputWithButtons.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithButtons.test.tsx.snap
@@ -250,7 +250,7 @@ exports[`TextInputWithIcon renders 1`] = `
   type="text"
 >
   <div
-    data-cy="textInput"
+    data-cy="textInput textInput.standard"
   >
     <label
       className="emotion-0"
@@ -574,7 +574,7 @@ exports[`TextInputWithIcon renders with colored button 1`] = `
   type="text"
 >
   <div
-    data-cy="textInput"
+    data-cy="textInput textInput.standard"
   >
     <label
       className="emotion-0"

--- a/packages/textInput/tests/__snapshots__/TextInputWithIcon.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithIcon.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`TextInputWithIcon should render all appearances with iconEnd 1`] = `
 }
 
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <label
     className="emotion-0"
@@ -93,7 +93,7 @@ exports[`TextInputWithIcon should render all appearances with iconStart 1`] = `
 }
 
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <label
     className="emotion-0"
@@ -176,7 +176,7 @@ exports[`TextInputWithIcon should render all appearances with twoIcons 1`] = `
 }
 
 <div
-  data-cy="textInput"
+  data-cy="textInput textInput.standard"
 >
   <label
     className="emotion-0"

--- a/packages/textarea/components/Textarea.tsx
+++ b/packages/textarea/components/Textarea.tsx
@@ -2,18 +2,14 @@ import * as React from "react";
 import { InputAppearance } from "../../shared/types/inputAppearance";
 import FormFieldWrapper from "../../shared/components/FormFieldWrapper";
 import { cx } from "emotion";
-import {
-  inputReset,
-  tintText,
-  visuallyHidden
-} from "../../shared/styles/styleUtils";
+import { inputReset } from "../../shared/styles/styleUtils";
 import {
   getInputAppearanceStyle,
-  inputContainer,
-  getLabelStyle
+  inputContainer
 } from "../../shared/styles/formStyles";
 import { textarea } from "../style";
-import { themeError } from "../../design-tokens/build/js/designTokens";
+import nextId from "react-id-generator";
+import { renderLabel } from "../../utilities/label";
 
 export interface TextareaProps extends React.HTMLProps<HTMLTextAreaElement> {
   /**
@@ -40,6 +36,10 @@ export interface TextareaProps extends React.HTMLProps<HTMLTextAreaElement> {
    * Sets the contents for validation errors. This will be displayed below the textarea element. Errors are only visible when the `Textarea` appearance is also set to `InputAppearance.Error`.
    */
   errors?: React.ReactNode[];
+  /**
+   * Sets the text content for the tooltip that can be displayed above the input.
+   */
+  tooltipContent?: React.ReactNode;
 }
 
 class Textarea extends React.PureComponent<TextareaProps, {}> {
@@ -49,18 +49,10 @@ class Textarea extends React.PureComponent<TextareaProps, {}> {
     rows: 3
   };
 
+  id = this.props.id ?? nextId("textarea-");
+
   public render() {
-    const {
-      appearance,
-      errors,
-      hintContent,
-      id,
-      inputLabel,
-      required,
-      showInputLabel,
-      value,
-      ...other
-    } = this.props;
+    const { appearance, errors, hintContent, id, value, ...other } = this.props;
     const hasError = appearance === InputAppearance.Error;
     let { onChange } = other;
     const inputAppearance = this.getInputAppearance();
@@ -69,34 +61,22 @@ class Textarea extends React.PureComponent<TextareaProps, {}> {
         event: React.FormEvent<HTMLTextAreaElement>
       ) => void;
     }
-    const parentDataCy = [
-      "textarea",
-      ...(inputAppearance !== InputAppearance.Standard
-        ? [`textarea.${this.getInputAppearance()}`]
-        : [])
-    ].join(" ");
-    const textareaDataCy = [
-      "textarea-textarea",
-      ...(inputAppearance !== InputAppearance.Standard
-        ? [`textarea-textarea.${this.getInputAppearance()}`]
-        : [])
-    ].join(" ");
+    const parentDataCy = `textarea textarea.${inputAppearance}`;
+    const textareaDataCy = `textarea-textarea textarea-textarea.${inputAppearance}`;
 
     return (
       <FormFieldWrapper id={id} errors={errors} hintContent={hintContent}>
         {({ getValidationErrors, getHintContent, isValid, describedByIds }) => (
           <div data-cy={parentDataCy}>
-            <label
-              className={cx(getLabelStyle(hasError), {
-                [visuallyHidden]: !showInputLabel
-              })}
-              htmlFor={id}
-            >
-              {inputLabel}
-              {required ? (
-                <span className={cx(tintText(themeError))}> *</span>
-              ) : null}
-            </label>
+            {renderLabel({
+              appearance,
+              hidden: !this.props.showInputLabel,
+              id: this.id,
+              label: this.props.inputLabel,
+              required: this.props.required,
+              tooltipContent: this.props.tooltipContent
+            })}
+
             <textarea
               aria-invalid={!isValid}
               aria-describedby={describedByIds}
@@ -108,7 +88,7 @@ class Textarea extends React.PureComponent<TextareaProps, {}> {
                 getInputAppearanceStyle(this.getInputAppearance()),
                 textarea
               )}
-              required={required}
+              required={this.props.required}
               data-cy="textarea-textarea"
               {...{ ...other, onChange }}
             />

--- a/packages/textarea/stories/Textarea.stories.tsx
+++ b/packages/textarea/stories/Textarea.stories.tsx
@@ -19,12 +19,14 @@ storiesOf("Forms|Textarea", module)
         id="error"
         inputLabel="Error"
         placeholder="Placeholder"
+        tooltipContent={<div>I'm a very informative tooltip!</div>}
       />
       <Textarea
         appearance={InputAppearance.Success}
         id="success"
         inputLabel="Success"
         placeholder="Placeholder"
+        tooltipContent={<div>I'm also a tooltip!</div>}
       />
       <Textarea
         id="value"

--- a/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
+++ b/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`Typeahead renders 1`] = `
               value=""
             >
               <div
-                data-cy="textInput"
+                data-cy="textInput textInput.standard"
               >
                 <label
                   className="emotion-0"
@@ -575,7 +575,7 @@ exports[`Typeahead renders a menu with a max height 1`] = `
               value=""
             >
               <div
-                data-cy="textInput"
+                data-cy="textInput textInput.standard"
               >
                 <label
                   className="emotion-0"

--- a/packages/utilities/label.tsx
+++ b/packages/utilities/label.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { InputAppearance } from "../shared/types/inputAppearance";
+import { cx } from "emotion";
+import {
+  tintText,
+  visuallyHidden,
+  flex,
+  margin
+} from "../shared/styles/styleUtils";
+import { getLabelStyle } from "../shared/styles/formStyles";
+import {
+  themeError,
+  greyLightDarken2,
+  iconSizeXs
+} from "../design-tokens/build/js/designTokens";
+import Tooltip from "../tooltip/components/Tooltip";
+import { Icon } from "../icon";
+import { SystemIcons as SI } from "../icons/dist/system-icons-enum";
+
+const trigger = (
+  <Icon color={greyLightDarken2} shape={SI.CircleQuestion} size={iconSizeXs} />
+);
+const reqStar = <span className={cx(tintText(themeError))}> *</span>;
+
+export const renderLabel: React.FC<{
+  appearance?: string;
+  hidden?: boolean;
+  id: string;
+  label?: React.ReactNode;
+  required?: boolean;
+  tooltipContent?: React.ReactNode;
+}> = ({ appearance, hidden, id, label, required, tooltipContent }) => {
+  const hasError = appearance === InputAppearance.Error;
+  const labelClassName = hidden ? cx(visuallyHidden) : getLabelStyle(hasError);
+  const labelNode = (
+    <label className={labelClassName} htmlFor={id} data-cy="textInput-label">
+      {label}
+      {required ? reqStar : null}
+    </label>
+  );
+  if (!tooltipContent) {
+    return labelNode;
+  }
+  return (
+    <div className={flex()}>
+      {labelNode}
+      {tooltipContent ? (
+        <span className={cx(margin("left", "xs"), margin("bottom", "xxs"))}>
+          <Tooltip trigger={trigger} id={`labelTooltip-${id}`} maxWidth={200}>
+            {tooltipContent}
+          </Tooltip>
+        </span>
+      ) : null}
+    </div>
+  );
+};


### PR DESCRIPTION
`TextInput` nicely provides us with the ability to specify a `tooltipContent`
and then displays an appropriate tooltip right besides the label above the
input.

`Textarea` now can do this too! :tada:



i first copied over all the parts but then decided to start a utility. 
so we extracted `getLabelContent` and `getTooltipContent` from `TextInput` and refactored those a bit. 
by now i feel that a next step could be to make that an `input`-utility and put even more
shared code there. but that's something for another PR. :)

also somehow some changes regarding our data-cy-classes emerged as i found those
way too noisy:

```diff
-    const dataCy = [
-      "textInput",
-      ...(appearance && appearance !== InputAppearance.Standard
-        ? [`textInput.${appearance}`]
-        : [])
-    ].join(" ");
+    const dataCy = `textInput textInput.${appearance}`;
```

i can of course revert that change, if there's something known to rely on
`textInput.standard` being absent.

<!-- See Checklist for PR creators below. -->

## Screenshots

<img width="811" alt="Forms | Textarea - default ⋅ Storybook 2020-08-26 16-51-34" src="https://user-images.githubusercontent.com/300861/91319285-7f126000-e7bc-11ea-9f89-d6c2b5bd19b7.png">
