### PR TITLE
fix: enables SystemIcons.Spinner SVG to take a fill color

### DIFF
--- a/packages/icons/src/icon-system/spinner.svg
+++ b/packages/icons/src/icon-system/spinner.svg
@@ -1,33 +1,33 @@
 <svg class="lds-spinner" width="200px"  height="200px"  xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid" style="background: none;"><g transform="rotate(0 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="-0.6124999999999999s" repeatCount="indefinite"></animate>
   </rect>
 </g><g transform="rotate(45 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="-0.5249999999999999s" repeatCount="indefinite"></animate>
   </rect>
 </g><g transform="rotate(90 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="-0.4375s" repeatCount="indefinite"></animate>
   </rect>
 </g><g transform="rotate(135 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="-0.35s" repeatCount="indefinite"></animate>
   </rect>
 </g><g transform="rotate(180 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="-0.26249999999999996s" repeatCount="indefinite"></animate>
   </rect>
 </g><g transform="rotate(225 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="-0.175s" repeatCount="indefinite"></animate>
   </rect>
 </g><g transform="rotate(270 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="-0.0875s" repeatCount="indefinite"></animate>
   </rect>
 </g><g transform="rotate(315 50 50)">
-  <rect x="43" y="2" rx="129" ry="6" width="14" height="28" fill="#1B2029">
+  <rect x="43" y="2" rx="129" ry="6" width="14" height="28">
     <animate attributeName="opacity" values="1;0" times="0;1" dur="0.7s" begin="0s" repeatCount="indefinite"></animate>
   </rect>
 </g></svg>


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

## Testing

Confirm that `<Icon shape={SystemIcons.Spinner} color="red" />` renders a red spinner.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<img width="1680" alt="Screen Shot 2020-09-03 at 4 14 31 PM" src="https://user-images.githubusercontent.com/2313998/92163249-56fcaf80-ee01-11ea-83b4-7e83682e5d02.png">


## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
