### PR TITLE
D2IQ-68837: creates a new row in a fieldlist when tabbing off last input

### DIFF
--- a/packages/formStructure/components/FieldListAddButton.tsx
+++ b/packages/formStructure/components/FieldListAddButton.tsx
@@ -2,9 +2,20 @@ import * as React from "react";
 import SecondaryButton from "../../button/components/SecondaryButton";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { ButtonProps } from "../../button/components/ButtonBase";
+import { Context as FieldListContext } from "./FieldListContext";
 
-const FieldListAddButton: React.SFC<ButtonProps> = props => (
-  <SecondaryButton iconStart={SystemIcons.Plus} {...props} />
-);
+const FieldListAddButton: React.FC<ButtonProps> = ({ onClick, ...other }) => {
+  const fieldListContext = React.useContext(FieldListContext);
+  const handleClick = fieldListContext
+    ? () => fieldListContext.addListItem()
+    : onClick;
+  return (
+    <SecondaryButton
+      iconStart={SystemIcons.Plus}
+      onClick={handleClick}
+      {...other}
+    />
+  );
+};
 
 export default FieldListAddButton;

--- a/packages/formStructure/components/FieldListColumn.tsx
+++ b/packages/formStructure/components/FieldListColumn.tsx
@@ -9,7 +9,7 @@ interface RenderProps<T> {
   /** Whether field is disabled */
   disabled?: boolean;
   /** The data to populate a the field */
-  fieldData: Array<{ [key: string]: any }>;
+  fieldData: Record<string, any>;
   /** The callback for when an input value is changed */
   onChange?: (e: React.FormEvent<HTMLInputElement>) => void;
   /** The index of the row of the current field */

--- a/packages/formStructure/components/FieldListContext.tsx
+++ b/packages/formStructure/components/FieldListContext.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { FieldListProps } from "./FieldList";
+
+interface FieldListProviderProps extends Omit<FieldListProps, "disabledRows"> {
+  setData: React.Dispatch<React.SetStateAction<Array<Record<string, any>>>>;
+}
+
+type FieldListContext = {
+  addListItem: (
+    rowId?: string | number,
+    itemToAdd?: Record<string, any>
+  ) => void;
+  removeListItem: (rowIndex: number) => () => void;
+};
+
+export const Context = React.createContext<FieldListContext | null>(null);
+
+export const FieldListProvider: React.FC<FieldListProviderProps> = ({
+  onAddItem,
+  children,
+  data,
+  pathToUniqueKey,
+  onRemoveItem,
+  setData
+}) => {
+  const addListItem = (
+    rowId?: string | number,
+    itemToAdd?: Record<string, any>
+  ) => {
+    const rowToAdd =
+      itemToAdd ||
+      Object.keys(data[0] || {}).reduce(
+        (acc, curr) => ((acc[curr] = ""), acc),
+        {}
+      );
+    if (pathToUniqueKey && !Boolean(rowToAdd[pathToUniqueKey])) {
+      rowToAdd[pathToUniqueKey] = rowId || data.length;
+    }
+
+    if (onAddItem) {
+      onAddItem(rowToAdd);
+    } else {
+      setData([...data, rowToAdd]);
+    }
+  };
+
+  const removeListItem = (rowIndex: number) => {
+    if (onRemoveItem) {
+      return onRemoveItem(rowIndex);
+    }
+
+    return () => {
+      setData(data.filter((_, i) => rowIndex !== i));
+    };
+  };
+
+  return (
+    <Context.Provider
+      value={{
+        addListItem,
+        removeListItem
+      }}
+    >
+      {children}
+    </Context.Provider>
+  );
+};

--- a/packages/formStructure/stories/fieldList.stories.tsx
+++ b/packages/formStructure/stories/fieldList.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from "..";
 import { TextInput } from "../../textInput";
 import FieldListHelper from "./helpers/FieldListStoryHelper";
+import { MonospaceText } from "../../styleUtils/typography";
 
 const mockItems = [
   {
@@ -31,9 +32,6 @@ const mockItems = [
   }
 ];
 
-const testRemoveHandler = rowIndex => () => {
-  alert(`remove row ${rowIndex}`);
-};
 const testFieldUpdateHandler = (rowIndex, pathToValue) => () =>
   action(
     `update row ${rowIndex} with the property that has the key ${pathToValue}`
@@ -41,63 +39,77 @@ const testFieldUpdateHandler = (rowIndex, pathToValue) => () =>
 
 storiesOf("Forms|Form layout/Grouped fields/FieldList", module)
   .add(
-    "interactive example",
+    "editable fields (controlled inputs)",
     () => (
       <FieldListHelper items={mockItems}>
-        {({ removeItemHander, addItemHandler, fieldUpdateHandler, items }) => (
-          <FieldList
-            data={items}
-            onRemoveItem={removeItemHander}
-            pathToUniqueKey="id"
-          >
-            <FieldListColumn
-              key="name"
-              header="Name"
-              pathToValue="name"
-              onChange={fieldUpdateHandler}
+        {({ removeItemHander, onAddItem, fieldUpdateHandler, items }) => (
+          <>
+            <FieldList
+              data={items}
+              onRemoveItem={removeItemHander}
+              onAddItem={() =>
+                onAddItem({
+                  name: "",
+                  role: "",
+                  city: "",
+                  id: Math.random()
+                })
+              }
+              pathToUniqueKey="id"
             >
-              {({ defaultProps, onChange, value }) => (
-                <TextInput
-                  value={value}
-                  onChange={onChange}
-                  {...defaultProps}
-                />
-              )}
-            </FieldListColumn>
-            <FieldListColumn
-              key="role"
-              header="Role"
-              pathToValue="role"
-              onChange={fieldUpdateHandler}
-            >
-              {({ defaultProps, onChange, value }) => (
-                <TextInput
-                  value={value}
-                  onChange={onChange}
-                  {...defaultProps}
-                />
-              )}
-            </FieldListColumn>
-            <FieldListColumn
-              key="city"
-              header="City"
-              pathToValue="city"
-              onChange={fieldUpdateHandler}
-            >
-              {({ defaultProps, onChange, value }) => (
-                <TextInput
-                  value={value}
-                  onChange={onChange}
-                  {...defaultProps}
-                />
-              )}
-            </FieldListColumn>
-            <FieldListAddButton
-              onClick={() => addItemHandler({ name: "", role: "", city: "" })}
-            >
-              Add Field
-            </FieldListAddButton>
-          </FieldList>
+              <FieldListColumn
+                key="name"
+                header="Name"
+                pathToValue="name"
+                onChange={fieldUpdateHandler}
+              >
+                {({ defaultProps, onChange, value }) => (
+                  <TextInput
+                    value={value}
+                    onChange={onChange}
+                    {...defaultProps}
+                  />
+                )}
+              </FieldListColumn>
+              <FieldListColumn
+                key="role"
+                header="Role"
+                pathToValue="role"
+                onChange={fieldUpdateHandler}
+              >
+                {({ defaultProps, onChange, value }) => (
+                  <TextInput
+                    value={value}
+                    onChange={onChange}
+                    {...defaultProps}
+                  />
+                )}
+              </FieldListColumn>
+              <FieldListColumn
+                key="city"
+                header="City"
+                pathToValue="city"
+                onChange={fieldUpdateHandler}
+              >
+                {({ defaultProps, onChange, value }) => (
+                  <TextInput
+                    value={value}
+                    onChange={onChange}
+                    {...defaultProps}
+                  />
+                )}
+              </FieldListColumn>
+              <FieldListAddButton>Add Field</FieldListAddButton>
+            </FieldList>
+            <div style={{ marginTop: "1em" }}>
+              <div>FieldList data:</div>
+              <div style={{ background: "#eee", padding: "0.5em" }}>
+                <MonospaceText tag="pre">
+                  {JSON.stringify(items, null, 2)}
+                </MonospaceText>
+              </div>
+            </div>
+          </>
         )}
       </FieldListHelper>
     ),
@@ -108,12 +120,34 @@ storiesOf("Forms|Form layout/Grouped fields/FieldList", module)
       }
     }
   )
+  .add("default (uncontrolled inputs)", () => {
+    return (
+      <FieldList data={mockItems} pathToUniqueKey="id">
+        <FieldListColumn
+          key="name"
+          header="Name"
+          pathToValue="name"
+          onChange={testFieldUpdateHandler}
+        >
+          {({ defaultProps, onChange, value }) => (
+            <TextInput value={value} onChange={onChange} {...defaultProps} />
+          )}
+        </FieldListColumn>
+        <FieldListColumn key="role" header="Role" pathToValue="role">
+          {({ defaultProps, onChange, value }) => (
+            <TextInput value={value} onChange={onChange} {...defaultProps} />
+          )}
+        </FieldListColumn>
+        <FieldListColumn key="city" header="City" pathToValue="city">
+          {({ defaultProps, onChange, value }) => (
+            <TextInput value={value} onChange={onChange} {...defaultProps} />
+          )}
+        </FieldListColumn>
+      </FieldList>
+    );
+  })
   .add("varied column widths", () => (
-    <FieldList
-      data={mockItems}
-      onRemoveItem={testRemoveHandler}
-      pathToUniqueKey="id"
-    >
+    <FieldList data={mockItems} pathToUniqueKey="id">
       <FieldListColumn
         key="name"
         header="Name"
@@ -149,12 +183,7 @@ storiesOf("Forms|Form layout/Grouped fields/FieldList", module)
     </FieldList>
   ))
   .add("disabled rows", () => (
-    <FieldList
-      data={mockItems}
-      onRemoveItem={testRemoveHandler}
-      disabledRows={[1]}
-      pathToUniqueKey="id"
-    >
+    <FieldList data={mockItems} disabledRows={[1]} pathToUniqueKey="id">
       <FieldListColumn
         key="name"
         header="Name"
@@ -203,11 +232,7 @@ storiesOf("Forms|Form layout/Grouped fields/FieldList", module)
     </FieldList>
   ))
   .add("w/ add button", () => (
-    <FieldList
-      data={mockItems}
-      onRemoveItem={testRemoveHandler}
-      pathToUniqueKey="id"
-    >
+    <FieldList data={mockItems} pathToUniqueKey="id">
       <FieldListColumn
         key="name"
         header="Name"
@@ -242,11 +267,7 @@ storiesOf("Forms|Form layout/Grouped fields/FieldList", module)
     </FieldList>
   ))
   .add("w/ column separators", () => (
-    <FieldList
-      data={mockItems}
-      onRemoveItem={testRemoveHandler}
-      pathToUniqueKey="id"
-    >
+    <FieldList data={mockItems} pathToUniqueKey="id">
       <FieldListColumn
         key="name"
         header="Name"

--- a/packages/formStructure/tests/fieldList.test.tsx
+++ b/packages/formStructure/tests/fieldList.test.tsx
@@ -86,6 +86,53 @@ describe("FieldList", () => {
     ).toMatchSnapshot();
   });
 
+  it("calls onAddItem when clicking the add button", () => {
+    const newItem = { id: 42 };
+    const testAddHandlerInner = jest.fn();
+    const testAddHandler = jest.fn(itemToAdd => () => {
+      testAddHandlerInner(itemToAdd);
+    });
+    const testFieldUpdateHandler = jest.fn((_rowIndex, _pathToValue) => _e => {
+      jest.fn();
+    });
+    const fieldListComponent = mount(
+      <FieldList
+        data={mockItems}
+        onAddItem={testAddHandler(newItem)}
+        pathToUniqueKey="id"
+      >
+        <FieldListColumn
+          key="name"
+          header="Name"
+          pathToValue="name"
+          onChange={testFieldUpdateHandler}
+        >
+          {({ defaultProps, onChange, value }) => (
+            <TextInput value={value} onChange={onChange} {...defaultProps} />
+          )}
+        </FieldListColumn>
+        <FieldListColumn
+          key="role"
+          header="Role"
+          pathToValue="role"
+          onChange={testFieldUpdateHandler}
+        >
+          {({ defaultProps, onChange, value }) => (
+            <TextInput value={value} onChange={onChange} {...defaultProps} />
+          )}
+        </FieldListColumn>
+        <FieldListAddButton>Add Item</FieldListAddButton>
+      </FieldList>
+    );
+    const addButton = fieldListComponent
+      .find('button[data-cy="secondaryButton"]')
+      .first();
+
+    expect(testAddHandlerInner).not.toHaveBeenCalled();
+    addButton.simulate("click");
+    expect(testAddHandlerInner).toHaveBeenCalledWith(newItem);
+  });
+
   it("calls onRemoveItem when clicking the remove button", () => {
     const testRemoveHandlerInner = jest.fn();
     const testRemoveHandler = jest.fn(rowIndex => () => {


### PR DESCRIPTION
Closes D2IQ-68837

<!-- See Checklist for PR creators below. -->

## Testing

- Go to any FieldList story
- Tab through the last row and confirm a new row appears when you tab from the last input to the last close button
- Tab through the new row _without typing values in the inputs_ and confirm that a new row is not added when you tab from the last input to the last close button

## Trade-offs

I'm using `onKeyUp` and checking for the "Tab" key to add a new row. I tried a few approaches using onBlur and onFocus, but they felt even more hacky

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

https://share.getcloudapp.com/2Nuy9ZLX

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
