### PR TITLE
D2IQ-71117: EmptyState error appearance + width update

### DIFF
--- a/packages/emptyState/components/EmptyState.tsx
+++ b/packages/emptyState/components/EmptyState.tsx
@@ -1,13 +1,22 @@
 import * as React from "react";
-import { emptyStateContainer } from "../style";
+import { emptyStateContainer, vertAlignHeading } from "../style";
 import { Card } from "../../card";
 import { SpacingBox } from "../../styleUtils/modifiers";
 import { HeadingText2 } from "../../styleUtils/typography";
 import { breakWord } from "../../shared/styles/styleUtils";
 import EmptyStateActions from "./EmptyStateActions";
+import { Icon } from "../../icon";
+import { SystemIcons } from "../../icons/dist/system-icons-enum";
+import {
+  themeError,
+  iconSizeXs
+} from "../../design-tokens/build/js/designTokens";
 
 export interface EmptyStateProps {
-  children?: React.ReactNode;
+  /**
+   * The tone of the message
+   */
+  appearance?: "error" | "standard";
   /**
    * A heading to provide a brief overview of why an empty state is appearing
    */
@@ -22,19 +31,40 @@ export interface EmptyStateProps {
   secondaryAction?: React.ReactNode;
 }
 
-const EmptyState: React.SFC<EmptyStateProps> = ({
+const EmptyState: React.FC<EmptyStateProps> = ({
+  appearance,
   heading,
   children,
   primaryAction,
   secondaryAction
-}: EmptyStateProps) => {
+}) => {
   const hasActions = primaryAction || secondaryAction;
 
   return (
     <div className={emptyStateContainer} data-cy="emptyState">
       <Card paddingSize="xxl">
         <SpacingBox side="bottom" spacingSize="xs">
-          <HeadingText2 align="center">{heading}</HeadingText2>
+          <HeadingText2 align="center">
+            {appearance === "error" ? (
+              <>
+                <Icon
+                  shape={SystemIcons.CircleClose}
+                  color={themeError}
+                  size={iconSizeXs}
+                />
+                <SpacingBox
+                  tag="span"
+                  side="left"
+                  spacingSize="xs"
+                  className={vertAlignHeading}
+                >
+                  {heading}
+                </SpacingBox>
+              </>
+            ) : (
+              heading
+            )}
+          </HeadingText2>
         </SpacingBox>
         {children && (
           <SpacingBox
@@ -55,6 +85,10 @@ const EmptyState: React.SFC<EmptyStateProps> = ({
       </Card>
     </div>
   );
+};
+
+EmptyState.defaultProps = {
+  appearance: "standard"
 };
 
 export default EmptyState;

--- a/packages/emptyState/stories/emptyState.stories.tsx
+++ b/packages/emptyState/stories/emptyState.stories.tsx
@@ -19,6 +19,11 @@ storiesOf("Feedback|EmptyState", module)
       Define policy to start allowing groups and roles access to your clusters.
     </EmptyState>
   ))
+  .add("appearance='error'", () => (
+    <EmptyState heading="No policy set" appearance="error">
+      Define policy to start allowing groups and roles access to your clusters.
+    </EmptyState>
+  ))
   .add(
     "wrapped with EmptyStateWrapper",
     () => (

--- a/packages/emptyState/style.ts
+++ b/packages/emptyState/style.ts
@@ -1,9 +1,13 @@
 import { css } from "emotion";
 
 export const emptyStateContainer = css`
-  margin: 0 auto;
-  max-width: 450px;
-  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(min(450px, 100%), min-content);
+  justify-content: center;
+`;
+
+export const vertAlignHeading = css`
+  vertical-align: middle;
 `;
 
 export const emptyStateWithGraphicBody = css`

--- a/packages/emptyState/tests/__snapshots__/emptyState.test.tsx.snap
+++ b/packages/emptyState/tests/__snapshots__/emptyState.test.tsx.snap
@@ -1,8 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EmptyState appearance='error' 1`] = `
+<div
+  class="css-3qkzfp"
+  data-cy="emptyState"
+>
+  <div
+    class="css-1whabpp"
+    data-cy="card"
+  >
+    <div
+      class="css-yy1d4r"
+    >
+      <div
+        class="css-1c71uxj"
+        data-cy="spacingBox"
+      >
+        <h2
+          class="rmTextMargins css-1rl5bwh"
+          data-cy="headingText2"
+        >
+          <svg
+            aria-label="system-circle-close icon"
+            class="css-pgwe9l"
+            data-cy="icon"
+            height="16"
+            preserveAspectRatio="xMinYMin meet"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <use
+              href="#system-circle-close"
+            />
+          </svg>
+          <span
+            class="css-93yxf5"
+            data-cy="spacingBox"
+          >
+            Heading
+          </span>
+        </h2>
+      </div>
+      <div
+        class="css-dbyz3d"
+        data-cy="spacingBox"
+      >
+        Body content
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`EmptyState default 1`] = `
 <div
-  class="css-1b4ui7p"
+  class="css-3qkzfp"
   data-cy="emptyState"
 >
   <div
@@ -36,7 +89,7 @@ exports[`EmptyState default 1`] = `
 
 exports[`EmptyState renders with primary and secondary actions 1`] = `
 <div
-  class="css-1b4ui7p"
+  class="css-3qkzfp"
   data-cy="emptyState"
 >
   <div

--- a/packages/emptyState/tests/emptyState.test.tsx
+++ b/packages/emptyState/tests/emptyState.test.tsx
@@ -11,6 +11,17 @@ describe("EmptyState", () => {
       toJSON(render(<EmptyState heading="Heading">Body content</EmptyState>))
     ).toMatchSnapshot();
   });
+  it("appearance='error'", () => {
+    expect(
+      toJSON(
+        render(
+          <EmptyState heading="Heading" appearance="error">
+            Body content
+          </EmptyState>
+        )
+      )
+    ).toMatchSnapshot();
+  });
   it("renders with primary and secondary actions", () => {
     expect(
       toJSON(


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

## Testing

1. Look at the new story to preview `appearance="error"`

2. Test the width update in Kommander:
- `npm run dist`, then copy result to `kommander/kommander/frontend/node_modules/@dcos/ui-kit/dist/`
- Look at some Kommander screens that show the `EmptyState` component

The EmptyState card width should max out at 450px unless there is a `CodeSnippet` inside - then the width should max out at the parent's width. Resizing the viewport to <450px should also resize the `EmptyState` card to a narrower width.

## Trade-offs

I'm not sure whether or not we'll add other variations to the `appearance` prop

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

Demo of width updates: https://share.getcloudapp.com/jkuZjGBo

`appearance="error"`
<img width="1678" alt="Screen Shot 2020-09-09 at 6 08 39 PM" src="https://user-images.githubusercontent.com/2313998/92659997-86129580-f2c7-11ea-8983-b8af7b98c016.png">


## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
