### PR TITLE
Fix ConfigurationMap styles

### DIFF
--- a/packages/configurationmap/components/ConfigurationMapLabel.tsx
+++ b/packages/configurationmap/components/ConfigurationMapLabel.tsx
@@ -1,18 +1,20 @@
 import * as React from "react";
+import { cx } from "emotion";
 import { breakWord, textWeight, padding } from "../../shared/styles/styleUtils";
 import { configurationMapLabel } from "../style";
-import styled from "@emotion/styled";
 
-const ConfigurationMapLabel = styled("dt")`
-  ${configurationMapLabel};
-  ${padding("right", "s")};
-  ${textWeight("medium")};
-  ${breakWord};
-  overflow: hidden;
-`;
-
-export default ({ children }) => (
-  <ConfigurationMapLabel data-cy="configurationMapLabel">
+const ConfigurationMapLabel: React.FC = ({ children }) => (
+  <div
+    className={cx(
+      configurationMapLabel,
+      padding("right", "s"),
+      textWeight("medium"),
+      breakWord
+    )}
+    data-cy="configurationMapLabel"
+  >
     {children}
-  </ConfigurationMapLabel>
+  </div>
 );
+
+export default ConfigurationMapLabel;

--- a/packages/configurationmap/components/ConfigurationMapRow.tsx
+++ b/packages/configurationmap/components/ConfigurationMapRow.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import styled from "@emotion/styled";
+import { cx } from "emotion";
 import { configurationMapRow, showActionOnHoverStyle } from "../style";
 import { flex, padding, border } from "../../shared/styles/styleUtils";
 
@@ -8,19 +8,19 @@ interface ConfigurationMapRowProps {
   onlyShowActionOnHover?: boolean;
 }
 
-const ConfigurationMapRow = styled("div")<ConfigurationMapRowProps>`
-  ${props => showActionOnHoverStyle(props.onlyShowActionOnHover)};
-  ${configurationMapRow};
-  ${border("bottom")};
-  ${flex()};
-  ${padding("vert", "xs")};
-`;
-
-export default (props: ConfigurationMapRowProps) => (
-  <ConfigurationMapRow
-    onlyShowActionOnHover={props.onlyShowActionOnHover}
+const ConfigurationMapRow: React.FC<ConfigurationMapRowProps> = props => (
+  <div
+    className={cx(
+      { [showActionOnHoverStyle]: props.onlyShowActionOnHover },
+      configurationMapRow,
+      border("bottom"),
+      flex(),
+      padding("vert", "xs")
+    )}
     data-cy="configurationMapRow"
   >
     {props.children}
-  </ConfigurationMapRow>
+  </div>
 );
+
+export default ConfigurationMapRow;

--- a/packages/configurationmap/components/ConfigurationMapSection.tsx
+++ b/packages/configurationmap/components/ConfigurationMapSection.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
-import styled from "@emotion/styled";
+import { cx } from "emotion";
 import { margin } from "../../shared/styles/styleUtils";
 import { dlReset } from "../../shared/styles/styleUtils/resets/definitionListReset";
 
-const ConfigurationMapSection = styled("dl")`
-  ${dlReset};
-  ${margin("bottom", "l")};
-`;
-
-export default ({ children }) => (
-  <ConfigurationMapSection data-cy="configurationMapSection">
+const ConfigurationMapSection = ({ children }) => (
+  <div
+    className={cx(dlReset, margin("bottom", "l"))}
+    data-cy="configurationMapSection"
+  >
     {children}
-  </ConfigurationMapSection>
+  </div>
 );
+
+export default ConfigurationMapSection;

--- a/packages/configurationmap/components/ConfigurationMapValue.tsx
+++ b/packages/configurationmap/components/ConfigurationMapValue.tsx
@@ -1,16 +1,15 @@
 import * as React from "react";
-import styled from "@emotion/styled";
+import { cx } from "emotion";
 import { flexItem, breakWord } from "../../shared/styles/styleUtils";
 import { ddReset } from "../../shared/styles/styleUtils/resets/definitionListReset";
 
-const ConfigurationMapValue = styled("dd")`
-  ${ddReset};
-  ${flexItem("grow")};
-  ${breakWord};
-`;
-
-export default ({ children }) => (
-  <ConfigurationMapValue data-cy="configurationMapValue">
+const ConfigurationMapValue = ({ children }) => (
+  <div
+    className={cx(ddReset, flexItem("grow"), breakWord)}
+    data-cy="configurationMapValue"
+  >
     {children}
-  </ConfigurationMapValue>
+  </div>
 );
+
+export default ConfigurationMapValue;

--- a/packages/configurationmap/style.ts
+++ b/packages/configurationmap/style.ts
@@ -17,6 +17,7 @@ export const configurationMapHeadingStyle = css`
 
 export const configurationMapLabel = css`
   flex-basis: 15em;
+  overflow: hidden;
 
   &,
   & > * {
@@ -25,16 +26,12 @@ export const configurationMapLabel = css`
   }
 `;
 
-export const showActionOnHoverStyle = (onlyShowActionOnHover?: boolean) => {
-  if (onlyShowActionOnHover) {
-    return css`
-      .${rowActionStaticClassname} {
-        ${visuallyHidden};
-      }
-
-      &:hover .${rowActionStaticClassname} {
-        ${undoVisuallyHidden};
-      }
-    `;
+export const showActionOnHoverStyle = css`
+  .${rowActionStaticClassname} {
+    ${visuallyHidden};
   }
-};
+
+  &:hover .${rowActionStaticClassname} {
+    ${undoVisuallyHidden};
+  }
+`;

--- a/packages/configurationmap/tests/ConfigurationMap.test.tsx
+++ b/packages/configurationmap/tests/ConfigurationMap.test.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import serializer from "jest-emotion";
+import { render, mount } from "enzyme";
+import toJSON from "enzyme-to-json";
 
 import {
   ConfigurationMap,
@@ -10,8 +13,8 @@ import {
   ConfigurationMapValueWithDefault,
   ConfigurationMapRowAction
 } from "../";
-import { render, mount } from "enzyme";
-import toJSON from "enzyme-to-json";
+
+expect.addSnapshotSerializer(serializer);
 
 describe("ConfigurationMap", () => {
   it("renders default", () => {

--- a/packages/configurationmap/tests/HashMap.test.tsx
+++ b/packages/configurationmap/tests/HashMap.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
+import serializer from "jest-emotion";
 import { render, shallow } from "enzyme";
 import toJSON from "enzyme-to-json";
 import { HashMap } from "../";
+
+expect.addSnapshotSerializer(serializer);
 
 describe("HashMap", () => {
   it("renders default", () => {

--- a/packages/configurationmap/tests/__snapshots__/ConfigurationMap.test.tsx.snap
+++ b/packages/configurationmap/tests/__snapshots__/ConfigurationMap.test.tsx.snap
@@ -1,98 +1,339 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfigurationMap renders default 1`] = `
+.emotion-9 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-2 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-2:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
+}
+
+.emotion-0 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-0,
+.emotion-0 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
 <div
   data-cy="configurationMap"
 >
-  <dl
-    class="css-n7t6tv"
+  <div
+    class="emotion-9"
     data-cy="configurationMapSection"
   >
     <div
-      class="css-azki39"
+      class="emotion-2"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         Name
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         Jane Doe
-      </dd>
+      </div>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-2"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         Role
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         UX Designer
-      </dd>
+      </div>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-2"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         City
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         San Francisco
-      </dd>
+      </div>
     </div>
-  </dl>
+  </div>
 </div>
 `;
 
 exports[`ConfigurationMap renders with actions 1`] = `
+.emotion-15 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-0 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-0,
+.emotion-0 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-4 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-4 .static_configurationMapRowAction {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  position: absolute;
+  overflow: hidden;
+  margin: -1px;
+  padding: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.emotion-4:hover .static_configurationMapRowAction {
+  -webkit-clip: initial;
+  clip: initial;
+  position: static;
+  overflow: visible;
+  margin: 0;
+  width: auto;
+  height: auto;
+}
+
+.emotion-4:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-4 > div {
+  width: auto;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: initial;
+}
+
+.emotion-2 {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  text-align: inherit;
+  color: var(--themeTextColorInteractive,#7D58FF);
+  fill: var(--themeTextColorInteractive,#7D58FF);
+  cursor: pointer;
+  display: inline-block;
+  outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.emotion-2::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+.emotion-2:hover {
+  color: #704fe5;
+  fill: #704fe5;
+}
+
+.emotion-2:active {
+  color: #6446cc;
+  fill: #6446cc;
+}
+
+.emotion-2[href],
+.emotion-2[href]:visited {
+  color: var(--themeTextColorInteractive,#7D58FF);
+  fill: var(--themeTextColorInteractive,#7D58FF);
+}
+
 <div
   data-cy="configurationMap"
 >
-  <dl
-    class="css-n7t6tv"
+  <div
+    class="emotion-15"
     data-cy="configurationMapSection"
   >
     <div
-      class="css-f05u7u"
+      class="emotion-4"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         Name
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         Jane Doe
-      </dd>
+      </div>
       <span
-        class="static_configurationMapRowAction css-48ylac"
+        class="static_configurationMapRowAction emotion-3"
         data-cy="configrationMapRowAction"
       >
         <button
-          class="css-8g34zf"
+          class="emotion-2"
           data-cy="secondaryButton"
           tabindex="0"
           type="button"
@@ -106,27 +347,27 @@ exports[`ConfigurationMap renders with actions 1`] = `
       </span>
     </div>
     <div
-      class="css-f05u7u"
+      class="emotion-4"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         Role
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         UX Designer
-      </dd>
+      </div>
       <span
-        class="static_configurationMapRowAction css-48ylac"
+        class="static_configurationMapRowAction emotion-3"
         data-cy="configrationMapRowAction"
       >
         <button
-          class="css-8g34zf"
+          class="emotion-2"
           data-cy="secondaryButton"
           tabindex="0"
           type="button"
@@ -140,27 +381,27 @@ exports[`ConfigurationMap renders with actions 1`] = `
       </span>
     </div>
     <div
-      class="css-f05u7u"
+      class="emotion-4"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         City
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         San Francisco
-      </dd>
+      </div>
       <span
-        class="static_configurationMapRowAction css-48ylac"
+        class="static_configurationMapRowAction emotion-3"
         data-cy="configrationMapRowAction"
       >
         <button
-          class="css-8g34zf"
+          class="emotion-2"
           data-cy="secondaryButton"
           tabindex="0"
           type="button"
@@ -173,143 +414,324 @@ exports[`ConfigurationMap renders with actions 1`] = `
         </button>
       </span>
     </div>
-  </dl>
+  </div>
 </div>
 `;
 
 exports[`ConfigurationMap renders with default value 1`] = `
+.emotion-9 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-2 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-2:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
+}
+
+.emotion-0 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-0,
+.emotion-0 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
 <div
   data-cy="configurationMap"
 >
-  <dl
-    class="css-n7t6tv"
+  <div
+    class="emotion-9"
     data-cy="configurationMapSection"
   >
     <div
-      class="css-azki39"
+      class="emotion-2"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         Name
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         Jane Doe
-      </dd>
+      </div>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-2"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         Role
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         —
-      </dd>
+      </div>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-2"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-0"
         data-cy="configurationMapLabel"
       >
         City
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-1"
         data-cy="configurationMapValue"
       >
         —
-      </dd>
+      </div>
     </div>
-  </dl>
+  </div>
 </div>
 `;
 
 exports[`ConfigurationMap renders with headline 1`] = `
+.emotion-11 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-4 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-4:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-4 > div {
+  width: auto;
+}
+
+.emotion-2 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-2,
+.emotion-2 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-3 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin: 1em 0;
+  padding-bottom: 8px;
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+}
+
+.emotion-0 {
+  line-height: 1.4;
+  font-weight: 500;
+  font-size: 24px;
+  color: var(--themeTextColorPrimary,#1B2029);
+  fill: var(--themeTextColorPrimary,#1B2029);
+  text-align: inherit;
+}
+
 <div
   data-cy="configurationMap"
 >
-  <dl
-    class="css-n7t6tv"
+  <div
+    class="emotion-11"
     data-cy="configurationMapSection"
   >
     <div
-      class="css-4p29as"
+      class="emotion-1"
       data-cy="configurationMapHeading"
     >
       <h1
-        class="rmTextMargins css-ipvdfg"
+        class="rmTextMargins emotion-0"
         data-cy="headingText1"
       >
         Jane Doe Info
       </h1>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-4"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-2"
         data-cy="configurationMapLabel"
       >
         Name
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-3"
         data-cy="configurationMapValue"
       >
         Jane Doe
-      </dd>
+      </div>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-4"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-2"
         data-cy="configurationMapLabel"
       >
         Role
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-3"
         data-cy="configurationMapValue"
       >
         UX Designer
-      </dd>
+      </div>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-4"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-2"
         data-cy="configurationMapLabel"
       >
         City
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-3"
         data-cy="configurationMapValue"
       >
         San Francisco
-      </dd>
+      </div>
     </div>
-  </dl>
+  </div>
 </div>
 `;

--- a/packages/configurationmap/tests/__snapshots__/HashMap.test.tsx.snap
+++ b/packages/configurationmap/tests/__snapshots__/HashMap.test.tsx.snap
@@ -1,178 +1,705 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HashMap renders array value 1`] = `
-<dl
-  class="css-n7t6tv"
+.emotion-3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-2 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-2:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
+}
+
+.emotion-0 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-0,
+.emotion-0 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+<div
+  class="emotion-3"
   data-cy="configurationMapSection"
 >
   <div
-    class="css-azki39"
+    class="emotion-2"
     data-cy="configurationMapRow"
   >
-    <dt
-      class="css-rs2f7e"
+    <div
+      class="emotion-0"
       data-cy="configurationMapLabel"
     >
       foo
-    </dt>
-    <dd
-      class="css-gvvllw"
+    </div>
+    <div
+      class="emotion-1"
       data-cy="configurationMapValue"
     >
       foo, bar, baz
-    </dd>
+    </div>
   </div>
-</dl>
+</div>
 `;
 
 exports[`HashMap renders boolean value 1`] = `
-<dl
-  class="css-n7t6tv"
+.emotion-3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-2 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-2:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
+}
+
+.emotion-0 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-0,
+.emotion-0 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+<div
+  class="emotion-3"
   data-cy="configurationMapSection"
 >
   <div
-    class="css-azki39"
+    class="emotion-2"
     data-cy="configurationMapRow"
   >
-    <dt
-      class="css-rs2f7e"
+    <div
+      class="emotion-0"
       data-cy="configurationMapLabel"
     >
       foo
-    </dt>
-    <dd
-      class="css-gvvllw"
+    </div>
+    <div
+      class="emotion-1"
       data-cy="configurationMapValue"
     >
       true
-    </dd>
+    </div>
   </div>
-</dl>
+</div>
 `;
 
 exports[`HashMap renders default 1`] = `
-<dl
-  class="css-n7t6tv"
+.emotion-3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-2 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-2:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
+}
+
+.emotion-0 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-0,
+.emotion-0 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+<div
+  class="emotion-3"
   data-cy="configurationMapSection"
 >
   <div
-    class="css-azki39"
+    class="emotion-2"
     data-cy="configurationMapRow"
   >
-    <dt
-      class="css-rs2f7e"
+    <div
+      class="emotion-0"
       data-cy="configurationMapLabel"
     >
       foo
-    </dt>
-    <dd
-      class="css-gvvllw"
+    </div>
+    <div
+      class="emotion-1"
       data-cy="configurationMapValue"
     >
       bar
-    </dd>
+    </div>
   </div>
-</dl>
+</div>
 `;
 
 exports[`HashMap renders empty value 1`] = `
-<dl
-  class="css-n7t6tv"
+.emotion-3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-2 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-2:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-2 > div {
+  width: auto;
+}
+
+.emotion-0 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-0,
+.emotion-0 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+<div
+  class="emotion-3"
   data-cy="configurationMapSection"
 >
   <div
-    class="css-azki39"
+    class="emotion-2"
     data-cy="configurationMapRow"
   >
-    <dt
-      class="css-rs2f7e"
+    <div
+      class="emotion-0"
       data-cy="configurationMapLabel"
     >
       foo
-    </dt>
-    <dd
-      class="css-gvvllw"
+    </div>
+    <div
+      class="emotion-1"
       data-cy="configurationMapValue"
     >
       empty
-    </dd>
+    </div>
   </div>
-</dl>
+</div>
 `;
 
 exports[`HashMap renders with a headline 1`] = `
-<dl
-  class="css-n7t6tv"
+.emotion-5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-4 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-4:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-4 > div {
+  width: auto;
+}
+
+.emotion-2 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-2,
+.emotion-2 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-3 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin: 1em 0;
+  padding-bottom: 8px;
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+}
+
+.emotion-0 {
+  line-height: 1.4;
+  font-weight: 500;
+  font-size: 24px;
+  color: var(--themeTextColorPrimary,#1B2029);
+  fill: var(--themeTextColorPrimary,#1B2029);
+  text-align: inherit;
+}
+
+<div
+  class="emotion-5"
   data-cy="configurationMapSection"
 >
   <div
-    class="css-4p29as"
+    class="emotion-1"
     data-cy="configurationMapHeading"
   >
     <h1
-      class="rmTextMargins css-ipvdfg"
+      class="rmTextMargins emotion-0"
       data-cy="headingText1"
     >
       baz
     </h1>
   </div>
   <div
-    class="css-azki39"
+    class="emotion-4"
     data-cy="configurationMapRow"
   >
-    <dt
-      class="css-rs2f7e"
+    <div
+      class="emotion-2"
       data-cy="configurationMapLabel"
     >
       foo
-    </dt>
-    <dd
-      class="css-gvvllw"
+    </div>
+    <div
+      class="emotion-3"
       data-cy="configurationMapValue"
     >
       bar
-    </dd>
+    </div>
   </div>
-</dl>
+</div>
 `;
 
 exports[`HashMap renders with nested object hash 1`] = `
-<dl
-  class="css-n7t6tv"
+.emotion-5 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-bottom: 24px;
+}
+
+.emotion-4 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+  -webkit-align-items: flex;
+  -webkit-box-align: flex;
+  -ms-flex-align: flex;
+  align-items: flex;
+  height: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: nowrap;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.emotion-4:last-of-type {
+  border-bottom-width: 0;
+}
+
+.emotion-4 > div {
+  width: auto;
+}
+
+.emotion-2 {
+  -webkit-flex-basis: 15em;
+  -ms-flex-preferred-size: 15em;
+  flex-basis: 15em;
+  overflow: hidden;
+  padding-right: 12px;
+  font-weight: 500;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-2,
+.emotion-2 > * {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
+
+.emotion-3 {
+  margin-left: 0;
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+  word-wrap: break-word;
+}
+
+.emotion-1 {
+  margin: 1em 0;
+  padding-bottom: 8px;
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-bottom-style: solid;
+}
+
+.emotion-0 {
+  line-height: 1.33;
+  line-height: 1.4;
+  font-weight: 500;
+  font-size: 18px;
+  color: var(--themeTextColorPrimary,#1B2029);
+  fill: var(--themeTextColorPrimary,#1B2029);
+  text-align: inherit;
+}
+
+<div
+  class="emotion-5"
   data-cy="configurationMapSection"
 >
-  <dl
-    class="css-n7t6tv"
+  <div
+    class="emotion-5"
     data-cy="configurationMapSection"
   >
     <div
-      class="css-4p29as"
+      class="emotion-1"
       data-cy="configurationMapHeading"
     >
       <h2
-        class="rmTextMargins css-1jlnqz6"
+        class="rmTextMargins emotion-0"
         data-cy="headingText2"
       >
         foo
       </h2>
     </div>
     <div
-      class="css-azki39"
+      class="emotion-4"
       data-cy="configurationMapRow"
     >
-      <dt
-        class="css-rs2f7e"
+      <div
+        class="emotion-2"
         data-cy="configurationMapLabel"
       >
         bar
-      </dt>
-      <dd
-        class="css-gvvllw"
+      </div>
+      <div
+        class="emotion-3"
         data-cy="configurationMapValue"
       >
         baz
-      </dd>
+      </div>
     </div>
-  </dl>
-</dl>
+  </div>
+</div>
 `;

--- a/packages/table_deprecated/components/Table.tsx
+++ b/packages/table_deprecated/components/Table.tsx
@@ -165,8 +165,6 @@ const ContentCell = styled<
   }};
 `;
 
-// const ContentCell = props => <div {...props} />;
-
 export class Table<T> extends React.PureComponent<TableProps, TableState> {
   public multiGridRef: {
     recomputeGridSize?: any;

--- a/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
+++ b/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Typeahead renders 1`] = `
+.emotion-0 {
+  display: block;
+  padding-top: 0;
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
 .emotion-2 {
   -webkit-align-items: flex;
   -webkit-box-align: flex;
@@ -27,14 +35,6 @@ exports[`Typeahead renders 1`] = `
 
 .emotion-2 > div {
   width: auto;
-}
-
-.emotion-0 {
-  display: block;
-  padding-top: 0;
-  margin-top: 0;
-  margin-bottom: 4px;
-  font-weight: 500;
 }
 
 .emotion-1 {
@@ -315,6 +315,14 @@ exports[`Typeahead renders 1`] = `
 `;
 
 exports[`Typeahead renders a menu with a max height 1`] = `
+.emotion-0 {
+  display: block;
+  padding-top: 0;
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
 .emotion-2 {
   -webkit-align-items: flex;
   -webkit-box-align: flex;
@@ -341,14 +349,6 @@ exports[`Typeahead renders a menu with a max height 1`] = `
 
 .emotion-2 > div {
   width: auto;
-}
-
-.emotion-0 {
-  display: block;
-  padding-top: 0;
-  margin-top: 0;
-  margin-bottom: 4px;
-  font-weight: 500;
 }
 
 .emotion-1 {


### PR DESCRIPTION
The styles broke with the emotion 10 upgrade, and I missed it because we weren't putting styles in the snapshots.

## Testing

Confirm that ConfigurationMap components look right

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

Before:
![Screen Shot 2020-10-15 at 4 45 00 PM](https://user-images.githubusercontent.com/2313998/96184097-f7b4b380-0f05-11eb-82af-8395a8158c1b.png)

After:
![Screen Shot 2020-10-15 at 2 44 16 PM](https://user-images.githubusercontent.com/2313998/96184094-f71c1d00-0f05-11eb-9aa8-8887658a23de.png)


## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
