### PR TITLE
D2IQ-69910: eliminates indentation of wrapping FlexItems when Flex has gutterSize set

### DIFF
--- a/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
+++ b/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
@@ -42,15 +42,20 @@ exports[`CodeSnippet renders default 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 0;
+  column-gap: 0;
+  row-gap: 0;
 }
 
 .emotion-3 > div {
   width: auto;
 }
 
-.emotion-3 > *:not(:first-child) {
-  padding-left: 0;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-3 > *:not(:last-child) {
+    padding-right: 0;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-2 {
@@ -205,15 +210,20 @@ exports[`CodeSnippet renders with copy button 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 0;
+  column-gap: 0;
+  row-gap: 0;
 }
 
 .emotion-7 > div {
   width: auto;
 }
 
-.emotion-7 > *:not(:first-child) {
-  padding-left: 0;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-7 > *:not(:last-child) {
+    padding-right: 0;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-2 {

--- a/packages/emptyState/tests/__snapshots__/emptyState.test.tsx.snap
+++ b/packages/emptyState/tests/__snapshots__/emptyState.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`EmptyState renders with primary and secondary actions 1`] = `
         Body content
       </div>
       <div
-        class="css-1m9h7kz"
+        class="css-mofsq3"
         data-cy="flex"
       >
         <div

--- a/packages/emptyState/tests/__snapshots__/emptyStateWithGraphic.test.tsx.snap
+++ b/packages/emptyState/tests/__snapshots__/emptyStateWithGraphic.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`EmptyStateWithGraphic renders with primary and secondary actions 1`] = 
     </div>
   </div>
   <div
-    class="css-1m9h7kz"
+    class="css-mofsq3"
     data-cy="flex"
   >
     <div

--- a/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
+++ b/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
@@ -64,15 +64,20 @@ exports[`Sidebar renders 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 0;
+  column-gap: 0;
+  row-gap: 0;
 }
 
 .emotion-3 > div {
   width: auto;
 }
 
-.emotion-3 > *:not(:first-child) {
-  padding-left: 0;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-3 > *:not(:last-child) {
+    padding-right: 0;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-1 {

--- a/packages/promo/__snapshots__/promos.test.tsx.snap
+++ b/packages/promo/__snapshots__/promos.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Promos renders PromoBanner 1`] = `
       </div>
     </button>
     <div
-      class="css-138vlob"
+      class="css-10l8rda"
       data-cy="flex"
     >
       <div
@@ -62,7 +62,7 @@ exports[`Promos renders PromoBanner 1`] = `
             Some promo details
           </div>
           <div
-            class="css-1yaruh1"
+            class="css-dfgl6y"
             data-cy="flex"
           >
             <div
@@ -177,7 +177,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
       </div>
     </button>
     <div
-      class="css-138vlob"
+      class="css-10l8rda"
       data-cy="flex"
     >
       <div
@@ -206,7 +206,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
             Some promo details
           </div>
           <div
-            class="css-1yaruh1"
+            class="css-dfgl6y"
             data-cy="flex"
           >
             <div
@@ -321,7 +321,7 @@ exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
       </div>
     </button>
     <div
-      class="css-138vlob"
+      class="css-10l8rda"
       data-cy="flex"
     >
       <div
@@ -350,7 +350,7 @@ exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
             Some promo details
           </div>
           <div
-            class="css-1yaruh1"
+            class="css-dfgl6y"
             data-cy="flex"
           >
             <div
@@ -472,7 +472,7 @@ exports[`Promos renders PromoInline 1`] = `
           </div>
         </button>
         <div
-          class="css-138vlob"
+          class="css-10l8rda"
           data-cy="flex"
         >
           <div
@@ -501,7 +501,7 @@ exports[`Promos renders PromoInline 1`] = `
                 Some promo details
               </div>
               <div
-                class="css-1yaruh1"
+                class="css-dfgl6y"
                 data-cy="flex"
               >
                 <div

--- a/packages/shared/styles/styleUtils/layout/flexbox.ts
+++ b/packages/shared/styles/styleUtils/layout/flexbox.ts
@@ -132,29 +132,26 @@ export const applyFlexItemGutters = (direction, gutterSize) => {
     return;
   }
 
-  const columnPaddingTop = getResponsiveColumnStyles(
-    direction,
-    gutterSize,
-    "none"
-  );
-  const columnPaddingLeft = getResponsiveColumnStyles(
-    direction,
-    "none",
-    gutterSize
-  );
-  const paddingTop =
-    typeof columnPaddingTop === "object"
-      ? getGutterPaddingValues(columnPaddingTop, gutterSize)
-      : columnPaddingTop;
-  const paddingLeft =
-    typeof columnPaddingLeft === "object"
-      ? getGutterPaddingValues(columnPaddingLeft, gutterSize)
-      : columnPaddingLeft;
+  const rowGuttter = getResponsiveColumnStyles(direction, gutterSize, "none");
+  const columnGutter = getResponsiveColumnStyles(direction, "none", gutterSize);
+  const rowGap =
+    typeof rowGuttter === "object"
+      ? getGutterPaddingValues(rowGuttter, gutterSize)
+      : rowGuttter;
+  const columnGap =
+    typeof columnGutter === "object"
+      ? getGutterPaddingValues(columnGutter, gutterSize)
+      : columnGutter;
 
   return css`
-    > *:not(:first-child) {
-      ${getResponsiveSpacingStyle("padding-left", paddingLeft)};
-      ${getResponsiveSpacingStyle("padding-top", paddingTop)};
+    ${getResponsiveSpacingStyle("column-gap", columnGap)};
+    ${getResponsiveSpacingStyle("row-gap", rowGap)};
+
+    @supports (column-gap: 1px) and (row-gap: 1px) {
+      > *:not(:last-child) {
+        ${getResponsiveSpacingStyle("padding-right", columnGap)};
+        ${getResponsiveSpacingStyle("padding-bottom", rowGap)};
+      }
     }
   `;
 };

--- a/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
+++ b/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
@@ -2,20 +2,16 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { withKnobs, select } from "@storybook/addon-knobs";
 import { withReadme } from "storybook-readme";
+import { themeBgSecondary } from "../../../../design-tokens/build/js/designTokens";
+import { SpacingBox } from "../../../modifiers";
 import Flex from "../components/Flex";
 import FlexItem from "../components/FlexItem";
 import styled from "@emotion/styled";
 import { SpaceSize } from "../../../../shared/styles/styleUtils/modifiers/modifierUtils";
+import { css } from "emotion";
 
 const readme = require("../README.md");
 
-const SampleContainer = styled("div")`
-  background-color: #f5f5f5;
-
-  > * {
-    height: 80px;
-  }
-`;
 const DemoChild = styled("div")`
   background-color: white;
   border: 1px solid rgba(0, 0, 0, 0.1);
@@ -29,7 +25,7 @@ storiesOf("Layout|Flex", module)
   .addDecorator(withReadme([readme]))
   .addDecorator(withKnobs)
   .add("default", () => (
-    <SampleContainer>
+    <SpacingBox spacingSize="m" bgColor={themeBgSecondary}>
       <Flex>
         <FlexItem>
           <DemoChild>1</DemoChild>
@@ -44,7 +40,7 @@ storiesOf("Layout|Flex", module)
           <DemoChild>4</DemoChild>
         </FlexItem>
       </Flex>
-    </SampleContainer>
+    </SpacingBox>
   ))
   .add("align", () => {
     const alignments = {
@@ -58,7 +54,15 @@ storiesOf("Layout|Flex", module)
     return (
       <div>
         <p>Use the Knobs panel to change the alignment of the flex items</p>
-        <SampleContainer>
+        <SpacingBox
+          spacingSize="m"
+          bgColor={themeBgSecondary}
+          className={css`
+            > * {
+              min-height: 100px;
+            }
+          `}
+        >
           <Flex align={align}>
             <FlexItem>
               <DemoChild>1</DemoChild>
@@ -73,14 +77,22 @@ storiesOf("Layout|Flex", module)
               <DemoChild>4</DemoChild>
             </FlexItem>
           </Flex>
-        </SampleContainer>
+        </SpacingBox>
       </div>
     );
   })
   .add("responsive align", () => (
     <div>
       <p>Change the width of your viewport to see the alignment change</p>
-      <SampleContainer>
+      <SpacingBox
+        spacingSize="m"
+        bgColor={themeBgSecondary}
+        className={css`
+          > * {
+            min-height: 100px;
+          }
+        `}
+      >
         <Flex
           align={{
             default: "flex-start",
@@ -100,7 +112,7 @@ storiesOf("Layout|Flex", module)
             <DemoChild>4</DemoChild>
           </FlexItem>
         </Flex>
-      </SampleContainer>
+      </SpacingBox>
     </div>
   ))
   .add("directions", () => {
@@ -118,7 +130,7 @@ storiesOf("Layout|Flex", module)
           Use the Knobs panel to change the direction the flex items get layed
           out
         </p>
-        <SampleContainer>
+        <SpacingBox spacingSize="m" bgColor={themeBgSecondary}>
           <Flex direction={direction as React.CSSProperties["flexDirection"]}>
             <FlexItem>
               <DemoChild>1</DemoChild>
@@ -133,7 +145,7 @@ storiesOf("Layout|Flex", module)
               <DemoChild>4</DemoChild>
             </FlexItem>
           </Flex>
-        </SampleContainer>
+        </SpacingBox>
       </div>
     );
   })
@@ -273,7 +285,7 @@ storiesOf("Layout|Flex", module)
           Use the Knobs panel to change the justification alignment of the flex
           items
         </p>
-        <SampleContainer>
+        <SpacingBox spacingSize="m" bgColor={themeBgSecondary}>
           <Flex justify={justify as React.CSSProperties["justifyContent"]}>
             <FlexItem flex="shrink">
               <DemoChild>1</DemoChild>
@@ -288,7 +300,7 @@ storiesOf("Layout|Flex", module)
               <DemoChild>4</DemoChild>
             </FlexItem>
           </Flex>
-        </SampleContainer>
+        </SpacingBox>
       </div>
     );
   })
@@ -298,7 +310,7 @@ storiesOf("Layout|Flex", module)
         Change the width of your viewport to see the justification alignment
         change
       </p>
-      <SampleContainer>
+      <SpacingBox spacingSize="m" bgColor={themeBgSecondary}>
         <Flex
           justify={{
             default: "flex-start",
@@ -318,7 +330,7 @@ storiesOf("Layout|Flex", module)
             <DemoChild>4</DemoChild>
           </FlexItem>
         </Flex>
-      </SampleContainer>
+      </SpacingBox>
     </div>
   ))
   .add("wrap", () => {
@@ -333,8 +345,8 @@ storiesOf("Layout|Flex", module)
       <div>
         <p>Use the Knobs panel to change the style of wrapping</p>
         <div style={{ maxWidth: "800px", width: "100%" }}>
-          <SampleContainer>
-            <Flex wrap={wrap as React.CSSProperties["flexWrap"]}>
+          <SpacingBox spacingSize="m" bgColor={themeBgSecondary}>
+            <Flex wrap={wrap as React.CSSProperties["flexWrap"]} gutterSize="m">
               <FlexItem flex="shrink">
                 <DemoChild>Flex child 1</DemoChild>
               </FlexItem>
@@ -372,7 +384,7 @@ storiesOf("Layout|Flex", module)
                 <DemoChild>Flex child 12</DemoChild>
               </FlexItem>
             </Flex>
-          </SampleContainer>
+          </SpacingBox>
         </div>
       </div>
     );

--- a/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
+++ b/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
@@ -23,15 +23,20 @@ exports[`Flex renders default 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 0;
+  column-gap: 0;
+  row-gap: 0;
 }
 
 .emotion-0 > div {
   width: auto;
 }
 
-.emotion-0 > *:not(:first-child) {
-  padding-left: 0;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-0 > *:not(:last-child) {
+    padding-right: 0;
+    padding-bottom: 0;
+  }
 }
 
 <div
@@ -74,15 +79,20 @@ exports[`Flex renders with all props 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 0;
+  column-gap: 0;
+  row-gap: 24px;
 }
 
 .emotion-0 > div {
   width: 100%;
 }
 
-.emotion-0 > *:not(:first-child) {
-  padding-left: 0;
-  padding-top: 24px;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-0 > *:not(:last-child) {
+    padding-right: 0;
+    padding-bottom: 24px;
+  }
 }
 
 <div
@@ -205,27 +215,55 @@ exports[`Flex renders with responsive props 1`] = `
 }
 
 @media (min-width:0) {
-  .emotion-0 > *:not(:first-child) {
-    padding-left: 0;
+  .emotion-0 {
+    -webkit-column-gap: 0;
+    column-gap: 0;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-0 > *:not(:first-child) {
-    padding-left: 16px;
+  .emotion-0 {
+    -webkit-column-gap: 16px;
+    column-gap: 16px;
   }
 }
 
 @media (min-width:0) {
-  .emotion-0 > *:not(:first-child) {
-    padding-top: 12px;
+  .emotion-0 {
+    row-gap: 12px;
   }
 }
 
 @media (min-width:900px) {
-  .emotion-0 > *:not(:first-child) {
-    padding-top: 0;
+  .emotion-0 {
+    row-gap: 0;
   }
+}
+
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+@media (min-width:0) {
+    .emotion-0 > *:not(:last-child) {
+      padding-right: 0;
+    }
+}
+
+@media (min-width:900px) {
+    .emotion-0 > *:not(:last-child) {
+      padding-right: 16px;
+    }
+}
+
+@media (min-width:0) {
+    .emotion-0 > *:not(:last-child) {
+      padding-bottom: 12px;
+    }
+}
+
+@media (min-width:900px) {
+    .emotion-0 > *:not(:last-child) {
+      padding-bottom: 0;
+    }
+}
 }
 
 <div

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -285,6 +285,9 @@ exports[`Table v2 rendering renders default 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+  row-gap: 0;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -296,9 +299,11 @@ exports[`Table v2 rendering renders default 1`] = `
   width: auto;
 }
 
-.emotion-9 > *:not(:first-child) {
-  padding-left: 4px;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-9 > *:not(:last-child) {
+    padding-right: 4px;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-6 {
@@ -4187,6 +4192,9 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+  row-gap: 0;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -4198,9 +4206,11 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
   width: auto;
 }
 
-.emotion-9 > *:not(:first-child) {
-  padding-left: 4px;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-9 > *:not(:last-child) {
+    padding-right: 4px;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-6 {

--- a/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
@@ -218,15 +218,20 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+  row-gap: 0;
 }
 
 .emotion-6 > div {
   width: auto;
 }
 
-.emotion-6 > *:not(:first-child) {
-  padding-left: 4px;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-6 > *:not(:last-child) {
+    padding-right: 4px;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-2 {
@@ -972,15 +977,20 @@ exports[`TextInputWithBadges renders with badges 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 4px;
+  column-gap: 4px;
+  row-gap: 0;
 }
 
 .emotion-6 > div {
   width: auto;
 }
 
-.emotion-6 > *:not(:first-child) {
-  padding-left: 4px;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-6 > *:not(:last-child) {
+    padding-right: 4px;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-2 {

--- a/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
+++ b/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
@@ -44,15 +44,20 @@ exports[`ToggleBoxGroup renders default 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  row-gap: 0;
 }
 
 .emotion-21 > div {
   width: auto;
 }
 
-.emotion-21 > *:not(:first-child) {
-  padding-left: 16px;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-21 > *:not(:last-child) {
+    padding-right: 16px;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-5 {
@@ -387,15 +392,20 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  row-gap: 0;
 }
 
 .emotion-22 > div {
   width: auto;
 }
 
-.emotion-22 > *:not(:first-child) {
-  padding-left: 16px;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-22 > *:not(:last-child) {
+    padding-right: 16px;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-6 {
@@ -743,15 +753,20 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 16px;
+  column-gap: 16px;
+  row-gap: 0;
 }
 
 .emotion-21 > div {
   width: auto;
 }
 
-.emotion-21 > *:not(:first-child) {
-  padding-left: 16px;
-  padding-top: 0;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-21 > *:not(:last-child) {
+    padding-right: 16px;
+    padding-bottom: 0;
+  }
 }
 
 .emotion-5 {
@@ -1164,15 +1179,20 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
   display: -ms-flexbox;
   display: flex;
   min-height: 0;
+  -webkit-column-gap: 0;
+  column-gap: 0;
+  row-gap: 48px;
 }
 
 .emotion-21 > div {
   width: 100%;
 }
 
-.emotion-21 > *:not(:first-child) {
-  padding-left: 0;
-  padding-top: 48px;
+@supports (-webkit-column-gap:1px) and (row-gap:1px) or (column-gap:1px) and (row-gap:1px) {
+  .emotion-21 > *:not(:last-child) {
+    padding-right: 0;
+    padding-bottom: 48px;
+  }
 }
 
 <ToggleBoxGroup


### PR DESCRIPTION
Closes D2IQ-69910

<!-- See Checklist for PR creators below. -->

## Testing

Confirm there is no indentation of rows when `<Flex>` has `wrap="wrap"` and `gutterSize` props set.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
Before:
<img width="1093" alt="Screen Shot 2020-10-19 at 9 49 55 AM" src="https://user-images.githubusercontent.com/2313998/96462560-b1a46c00-11f3-11eb-95a2-1b3076e3c3c2.png">

After:
<img width="1096" alt="Screen Shot 2020-10-19 at 10 00 44 AM" src="https://user-images.githubusercontent.com/2313998/96462561-b23d0280-11f3-11eb-8c5d-a69749c3afbe.png">


## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
