### PR TITLE
D2IQ-72667: Pagination component

### DIFF
--- a/packages/index.ts
+++ b/packages/index.ts
@@ -89,6 +89,7 @@ export {
   FullscreenModal
 } from "./modal";
 export { PageHeader, PageHeaderBody, PageHeaderTabs } from "./pageheader";
+export { Pagination, PaginationContainer, usePageChange } from "./pagination";
 export { Popover } from "./popover";
 export { ProgressBar } from "./progressbar";
 export { PromoBanner, PromoInline } from "./promo";

--- a/packages/pagination/Pagination.tsx
+++ b/packages/pagination/Pagination.tsx
@@ -1,0 +1,276 @@
+import * as React from "react";
+import Delegate from "react-delegate-component";
+import { useId } from "react-id-generator";
+import { cx } from "emotion";
+import { Flex, FlexItem } from "../styleUtils/layout";
+import { Icon } from "../icon";
+import { ResetButton } from "../button";
+import { ResetLink } from "../link";
+import { SelectInput } from "../selectInput";
+import { SystemIcons } from "../icons/dist/system-icons-enum";
+import { TextInput } from "../textInput";
+import { themeBgDisabled } from "../design-tokens/build/js/designTokens";
+import { ExpandedLinkProps } from "../link/types";
+import { defaultInputWidth } from "./style";
+import { border, display, margin, padding } from "../shared/styles/styleUtils";
+
+interface PaginationProps {
+  /** Prop used to control which page the user is currently navigated to */
+  activePage?: number;
+  /** The default page the user starts on before the user navigates using the text input or the prev/next buttons. For use when the component is uncontrolled. */
+  initialActivePage?: number;
+  /** The label used to describe the items being paginated through */
+  itemsLabel?: string;
+  /** Prop used to control how many items are shown per page */
+  pageLength?: number;
+  /** The default number of items shown per page before the user selects a new number from the dropdown. For use when the component is uncontrolled. */
+  initialPageLength?: number;
+  /** The link used for the "next page" button */
+  nextUrl?: string;
+  /** A callback for when the user clicks the prev/next buttons or changes the selected option for how many items are shown per page */
+  onChange?: (newPage: number, newPageLength: number) => void;
+  /** The link used for the "previous page" button */
+  prevUrl?: string;
+  /** Whether to show the menu to set how many items are shown per page */
+  showPageLengthMenu?: boolean;
+  /** The total number of items on all pages */
+  totalItems?: number;
+  /** The total number of pages */
+  totalPages?: number;
+}
+
+const DEFAULT_PAGE_LENGTHS = [10, 30, 50, 100];
+const LARGE_PAGE_LENGTHS = [10, 30, 50, 100, 200];
+export const INITIAL_PAGE_LENGTH = DEFAULT_PAGE_LENGTHS[1];
+const LARGE_PAGE_LENGTH_THRESHOLD = 500;
+const DEFAULT_ITEMS_LABEL = "Items";
+
+export const getItemCountString = (
+  activePage: number,
+  itemsLabel: string,
+  pageLength: number,
+  totalItems?: number
+) => {
+  const startItemIndex = (activePage - 1) * pageLength + 1;
+  const endItemIndex = totalItems
+    ? Math.min(activePage * pageLength, totalItems)
+    : activePage * pageLength;
+  const itemRange = `${startItemIndex}–${endItemIndex}`;
+  const totalItemsLabel = totalItems ? `${totalItems} ${itemsLabel}` : "";
+
+  if (!Boolean(totalItemsLabel)) {
+    return itemRange;
+  }
+
+  return `${itemRange} of ${totalItemsLabel}`;
+};
+
+const getItemCountClassName = (showPageLengthMenu?: boolean) => {
+  if (showPageLengthMenu) {
+    return cx(border("horiz"), padding("horiz"), margin("horiz"));
+  }
+
+  return cx(border("right"), padding("right"), margin("right"));
+};
+
+const NavButton: React.FC<Partial<
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+> &
+  Partial<ExpandedLinkProps> & { direction: "prev" | "next" }> = ({
+  direction,
+  disabled,
+  url,
+  ...other
+}) => {
+  delete other.children;
+
+  const ariaLabel = direction === "prev" ? "previous page" : "next page";
+  const children = (
+    <Icon
+      shape={
+        direction === "prev" ? SystemIcons.CaretLeft : SystemIcons.CaretRight
+      }
+      color={disabled ? themeBgDisabled : "inherit"}
+    />
+  );
+
+  return (
+    <Delegate
+      to={url ? ResetLink : ResetButton}
+      props={
+        url
+          ? {
+              ["aria-label"]: ariaLabel,
+              children,
+              url: disabled ? url : undefined,
+              ...(disabled ? { ariaDisabled: "true" } : {}),
+              ...other
+            }
+          : { ["aria-label"]: ariaLabel, children, disabled, ...other }
+      }
+    />
+  );
+};
+
+const Pagination: React.FC<PaginationProps> = ({
+  activePage: activePageProp,
+  initialActivePage = 1,
+  itemsLabel = DEFAULT_ITEMS_LABEL,
+  pageLength: pageLengthProp,
+  initialPageLength = INITIAL_PAGE_LENGTH,
+  nextUrl,
+  onChange,
+  prevUrl,
+  showPageLengthMenu,
+  totalItems,
+  totalPages: totalPagesProp
+}) => {
+  const [pageLengthMenuId] = useId(1, "pageLengthMenu");
+  const [activePageState, setActivePageState] = React.useState<number>(
+    initialActivePage
+  );
+  const [pageInputVal, setPageInputVal] = React.useState<number>(
+    initialActivePage
+  );
+  const [pageLengthState, setPageLengthState] = React.useState<number>(
+    initialPageLength
+  );
+
+  const activePage = activePageProp || activePageState;
+  const pageLength = pageLengthProp || pageLengthState;
+  const isTotalPagesCalculable = Boolean(totalItems && pageLength);
+  const calculatedTotalPages =
+    isTotalPagesCalculable && totalItems
+      ? Math.ceil(totalItems / pageLength)
+      : undefined;
+  const totalPages =
+    !totalPagesProp && isTotalPagesCalculable
+      ? calculatedTotalPages
+      : totalPagesProp;
+  const pageLengthOptions = (totalItems &&
+  totalItems >= LARGE_PAGE_LENGTH_THRESHOLD
+    ? LARGE_PAGE_LENGTHS
+    : DEFAULT_PAGE_LENGTHS
+  ).map(option => {
+    return {
+      label: option.toString(),
+      value: option.toString()
+    };
+  });
+
+  if (calculatedTotalPages && totalPages !== calculatedTotalPages) {
+    console.warn(
+      `The 'totalPages' prop is set to ${totalPagesProp}, but this doesn't add up with these props: \n totalItems: ${totalItems} \n pageLength: ${pageLength} \n\n the expected 'totalPages' value is ${calculatedTotalPages}`
+    );
+  }
+
+  const onPageChange = (newPage: number) => {
+    if (!activePageProp) {
+      setActivePageState(newPage);
+    }
+
+    if (onChange) {
+      onChange(newPage, pageLength);
+    }
+  };
+  const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPageInputVal(parseInt(e.currentTarget.value, 10));
+  };
+  const handlePageLengthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newPageLength = parseInt(e.currentTarget.value, 10);
+    if (!pageLengthProp) {
+      setPageLengthState(newPageLength);
+      setActivePageState(1);
+    }
+
+    if (onChange) {
+      onChange(activePage, newPageLength);
+    }
+  };
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    onPageChange(pageInputVal);
+  };
+  const handlePrevClick = () => {
+    onPageChange(activePage - 1);
+  };
+  const handleNextClick = () => {
+    onPageChange(activePage + 1);
+  };
+
+  React.useEffect(() => {
+    setPageInputVal(activePage);
+  }, [activePage, pageLength]);
+
+  return (
+    <Flex align="center">
+      {showPageLengthMenu && (
+        <Flex align="center" gutterSize="xs">
+          <FlexItem flex="shrink">
+            <span aria-hidden="true" tabIndex={-1}>
+              {itemsLabel} per page
+            </span>
+          </FlexItem>
+          <FlexItem flex="shrink">
+            <SelectInput
+              showInputLabel={false}
+              id={pageLengthMenuId}
+              inputLabel={`${itemsLabel} per page`}
+              onChange={handlePageLengthChange}
+              options={pageLengthOptions}
+              value={pageLength}
+            />
+          </FlexItem>
+        </Flex>
+      )}
+      <div className={getItemCountClassName(showPageLengthMenu)}>
+        {getItemCountString(activePage, itemsLabel, pageLength, totalItems)}
+      </div>
+      <Flex align="center" gutterSize="s">
+        <FlexItem flex="shrink">
+          <NavButton
+            direction="prev"
+            url={prevUrl}
+            onClick={handlePrevClick}
+            disabled={activePage === 1}
+          />
+        </FlexItem>
+        <FlexItem flex="shrink">
+          <form
+            onSubmit={handleSubmit}
+            className={cx(display("inline-block"), {
+              [defaultInputWidth]: !Boolean(totalPages)
+            })}
+          >
+            <TextInput
+              type="number"
+              label="Page number"
+              showInputLabel={false}
+              value={pageInputVal}
+              onChange={handlePageInputChange}
+              min={1}
+              max={totalPages}
+            />
+          </form>
+          {Boolean(totalPages) && ` / ${totalPages}`}
+        </FlexItem>
+        <FlexItem flex="shrink">
+          <NavButton
+            direction="next"
+            url={nextUrl}
+            onClick={handleNextClick}
+            disabled={Boolean(totalPages && activePage === totalPages)}
+          />
+        </FlexItem>
+      </Flex>
+    </Flex>
+  );
+};
+
+Pagination.defaultProps = {
+  initialActivePage: 1,
+  initialPageLength: INITIAL_PAGE_LENGTH,
+  itemsLabel: DEFAULT_ITEMS_LABEL
+};
+
+export default Pagination;

--- a/packages/pagination/PaginationContainer.tsx
+++ b/packages/pagination/PaginationContainer.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { FlexboxProperties } from "../shared/styles/styleUtils/layout/flexbox";
+import { Flex, FlexItem } from "../styleUtils/layout";
+import Pagination from "./Pagination";
+
+const PaginationContainer: React.FC<{
+  vertAlignChildren?: FlexboxProperties["align"];
+}> = ({ children, vertAlignChildren }) => {
+  const paginationComponent = React.Children.toArray(children).find(
+    child => React.isValidElement(child) && child.type === Pagination
+  );
+  const additionalChildren = React.Children.toArray(children).filter(
+    child => React.isValidElement(child) && child.type !== Pagination
+  );
+
+  return (
+    <Flex align={vertAlignChildren} justify="flex-end" wrap="wrap">
+      {Boolean(additionalChildren.length) && (
+        <FlexItem>{additionalChildren}</FlexItem>
+      )}
+      <FlexItem flex="shrink">{paginationComponent}</FlexItem>
+    </Flex>
+  );
+};
+
+PaginationContainer.defaultProps = {
+  vertAlignChildren: "center"
+};
+
+export default PaginationContainer;

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -2,14 +2,24 @@
 
 A `Pagination` component may be used to navigate through a large colletion of items that is divided into multiple pages.
 
+## Usage
+
+Use the Pagination component when 1 or more of the following criteria are met:
+
+- A collection has greater than 30 items
+- Screen real estate is tight and it would be helpful to show the list a few items at a time
+- List objects are expensive to query and it would improve performance to split the queries up into paged results
+
+### Customizing item count per page
+
+Show the page length selection menu when 1 or more of the following criteria are met:
+
+- there are more than 200 items
+- it would be helpful to filter and sort on a larger batch of items
+- it would be helpful to let the user only show 10 items at a time so they can focus on dense data
+
+Do not show the page length selection menu if querying >30 items will have a negative on performance that would degrade the user experience.
+
 ## Layout
 
 The `Pagination` component should be right-aligned with the list of items it is paging through.
-
-## [WIP] Customizing item count per page
-
-TODO: Work with design team to spec how we use the "items per page" dropdown menu
-
----
-
-These usage docs are incomplete. More info about pagination UX is needed from the design team.

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -1,0 +1,15 @@
+# Pagination
+
+A `Pagination` component may be used to navigate through a large colletion of items that is divided into multiple pages.
+
+## Layout
+
+The `Pagination` component should be right-aligned with the list of items it is paging through.
+
+## [WIP] Customizing item count per page
+
+TODO: Work with design team to spec how we use the "items per page" dropdown menu
+
+---
+
+These usage docs are incomplete. More info about pagination UX is needed from the design team.

--- a/packages/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/packages/pagination/__snapshots__/pagination.test.tsx.snap
@@ -1,0 +1,518 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination rendering renders default 1`] = `
+.emotion-0 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-right-style: solid;
+  padding-right: 16px;
+  margin-right: 16px;
+}
+
+.emotion-1 {
+  display: inline-block;
+  max-width: 80px;
+}
+
+<Flex
+  align="center"
+  direction="row"
+  gutterSize="none"
+  justify="flex-start"
+  wrap="nowrap"
+>
+  <div
+    className="emotion-0"
+  >
+    61–80
+  </div>
+  <Flex
+    align="center"
+    direction="row"
+    gutterSize="s"
+    justify="flex-start"
+    wrap="nowrap"
+  >
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="prev"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <form
+        className="emotion-1"
+        onSubmit={[Function]}
+      >
+        <TextInput
+          appearance="standard"
+          label="Page number"
+          min={1}
+          onChange={[Function]}
+          showInputLabel={false}
+          type="number"
+          value={4}
+        />
+      </form>
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="next"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+  </Flex>
+</Flex>
+`;
+
+exports[`Pagination rendering renders prev and next buttons as links 1`] = `
+.emotion-0 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-right-style: solid;
+  padding-right: 16px;
+  margin-right: 16px;
+}
+
+.emotion-1 {
+  display: inline-block;
+  max-width: 80px;
+}
+
+<Flex
+  align="center"
+  direction="row"
+  gutterSize="none"
+  justify="flex-start"
+  wrap="nowrap"
+>
+  <div
+    className="emotion-0"
+  >
+    61–80
+  </div>
+  <Flex
+    align="center"
+    direction="row"
+    gutterSize="s"
+    justify="flex-start"
+    wrap="nowrap"
+  >
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="prev"
+        disabled={false}
+        onClick={[Function]}
+        url="prev"
+      />
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <form
+        className="emotion-1"
+        onSubmit={[Function]}
+      >
+        <TextInput
+          appearance="standard"
+          label="Page number"
+          min={1}
+          onChange={[Function]}
+          showInputLabel={false}
+          type="number"
+          value={4}
+        />
+      </form>
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="next"
+        disabled={false}
+        onClick={[Function]}
+        url="next"
+      />
+    </FlexItem>
+  </Flex>
+</Flex>
+`;
+
+exports[`Pagination rendering renders w/ custom item label 1`] = `
+.emotion-0 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-right-style: solid;
+  padding-right: 16px;
+  margin-right: 16px;
+}
+
+.emotion-1 {
+  display: inline-block;
+  max-width: 80px;
+}
+
+<Flex
+  align="center"
+  direction="row"
+  gutterSize="none"
+  justify="flex-start"
+  wrap="nowrap"
+>
+  <div
+    className="emotion-0"
+  >
+    61–80
+  </div>
+  <Flex
+    align="center"
+    direction="row"
+    gutterSize="s"
+    justify="flex-start"
+    wrap="nowrap"
+  >
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="prev"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <form
+        className="emotion-1"
+        onSubmit={[Function]}
+      >
+        <TextInput
+          appearance="standard"
+          label="Page number"
+          min={1}
+          onChange={[Function]}
+          showInputLabel={false}
+          type="number"
+          value={4}
+        />
+      </form>
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="next"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+  </Flex>
+</Flex>
+`;
+
+exports[`Pagination rendering renders w/ page length menu 1`] = `
+.emotion-1 {
+  display: inline-block;
+  max-width: 80px;
+}
+
+.emotion-0 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-left-style: solid;
+  border-right-style: solid;
+  padding-left: 16px;
+  padding-right: 16px;
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+<Flex
+  align="center"
+  direction="row"
+  gutterSize="none"
+  justify="flex-start"
+  wrap="nowrap"
+>
+  <Flex
+    align="center"
+    direction="row"
+    gutterSize="xs"
+    justify="flex-start"
+    wrap="nowrap"
+  >
+    <FlexItem
+      flex="shrink"
+    >
+      <span
+        aria-hidden="true"
+        tabIndex={-1}
+      >
+        Items
+         per page
+      </span>
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <SelectInput
+        appearance="standard"
+        id="pageLengthMenu6"
+        inputLabel="Items per page"
+        onChange={[Function]}
+        options={
+          Array [
+            Object {
+              "label": "10",
+              "value": "10",
+            },
+            Object {
+              "label": "30",
+              "value": "30",
+            },
+            Object {
+              "label": "50",
+              "value": "50",
+            },
+            Object {
+              "label": "100",
+              "value": "100",
+            },
+          ]
+        }
+        showInputLabel={false}
+        value={100}
+      />
+    </FlexItem>
+  </Flex>
+  <div
+    className="emotion-0"
+  >
+    301–400
+  </div>
+  <Flex
+    align="center"
+    direction="row"
+    gutterSize="s"
+    justify="flex-start"
+    wrap="nowrap"
+  >
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="prev"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <form
+        className="emotion-1"
+        onSubmit={[Function]}
+      >
+        <TextInput
+          appearance="standard"
+          label="Page number"
+          min={1}
+          onChange={[Function]}
+          showInputLabel={false}
+          type="number"
+          value={4}
+        />
+      </form>
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="next"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+  </Flex>
+</Flex>
+`;
+
+exports[`Pagination rendering renders w/ totalItems set 1`] = `
+.emotion-0 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-right-style: solid;
+  padding-right: 16px;
+  margin-right: 16px;
+}
+
+.emotion-1 {
+  display: inline-block;
+}
+
+<Flex
+  align="center"
+  direction="row"
+  gutterSize="none"
+  justify="flex-start"
+  wrap="nowrap"
+>
+  <div
+    className="emotion-0"
+  >
+    61–80 of 200 Items
+  </div>
+  <Flex
+    align="center"
+    direction="row"
+    gutterSize="s"
+    justify="flex-start"
+    wrap="nowrap"
+  >
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="prev"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <form
+        className="emotion-1"
+        onSubmit={[Function]}
+      >
+        <TextInput
+          appearance="standard"
+          label="Page number"
+          max={10}
+          min={1}
+          onChange={[Function]}
+          showInputLabel={false}
+          type="number"
+          value={4}
+        />
+      </form>
+       / 10
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="next"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+  </Flex>
+</Flex>
+`;
+
+exports[`Pagination rendering renders w/ totalPages, pageLength, and totalItems set 1`] = `
+.emotion-0 {
+  border-width: 1px;
+  border-color: var(--themeBorder,#DADDE2);
+  border-right-style: solid;
+  padding-right: 16px;
+  margin-right: 16px;
+}
+
+.emotion-1 {
+  display: inline-block;
+}
+
+<Flex
+  align="center"
+  direction="row"
+  gutterSize="none"
+  justify="flex-start"
+  wrap="nowrap"
+>
+  <div
+    className="emotion-0"
+  >
+    31–40 of 200 Items
+  </div>
+  <Flex
+    align="center"
+    direction="row"
+    gutterSize="s"
+    justify="flex-start"
+    wrap="nowrap"
+  >
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="prev"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <form
+        className="emotion-1"
+        onSubmit={[Function]}
+      >
+        <TextInput
+          appearance="standard"
+          label="Page number"
+          max={20}
+          min={1}
+          onChange={[Function]}
+          showInputLabel={false}
+          type="number"
+          value={4}
+        />
+      </form>
+       / 20
+    </FlexItem>
+    <FlexItem
+      flex="shrink"
+    >
+      <NavButton
+        direction="next"
+        disabled={false}
+        onClick={[Function]}
+      />
+    </FlexItem>
+  </Flex>
+</Flex>
+`;
+
+exports[`Pagination rendering renders wrapped in a PaginationContainer 1`] = `
+<Flex
+  align="flex-end"
+  direction="row"
+  gutterSize="none"
+  justify="flex-end"
+  wrap="wrap"
+>
+  <FlexItem
+    flex="shrink"
+  >
+    <Pagination
+      initialActivePage={4}
+      initialPageLength={20}
+      itemsLabel="Items"
+      key=".0"
+    />
+  </FlexItem>
+</Flex>
+`;

--- a/packages/pagination/index.ts
+++ b/packages/pagination/index.ts
@@ -1,0 +1,3 @@
+export { default as PaginationContainer } from "./PaginationContainer";
+export { default as Pagination } from "./Pagination";
+export { default as usePageChange } from "./usePageChange";

--- a/packages/pagination/pagination.stories.tsx
+++ b/packages/pagination/pagination.stories.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import * as faker from "faker";
+import { storiesOf } from "@storybook/react";
+import { withReadme } from "storybook-readme";
+import Pagination from "./Pagination";
+import PaginationContainer from "./PaginationContainer";
+import { BorderedList } from "../list";
+import usePageChange from "./usePageChange";
+
+const readme = require("./README.md");
+
+const initialData = Array.from(
+  { length: 200 },
+  () => faker.helpers.createCard().username
+);
+
+storiesOf("Navigation|Pagination", module)
+  .addDecorator(withReadme([readme]))
+  .add("default", () => (
+    <PaginationContainer>
+      <Pagination totalItems={200} />
+    </PaginationContainer>
+  ))
+  .add("example w/ paged list (controlled component)", () => {
+    const ControlledPaginationWrapper: React.FC<{
+      children: (renderProps: {
+        activePage: number;
+        pageLength: number;
+        itemEndIndex: number;
+        itemStartIndex: number;
+        onChange: (newPage, newPageLength) => void;
+      }) => React.ReactElement;
+    }> = ({ children }) => {
+      return children(usePageChange());
+    };
+    return (
+      <ControlledPaginationWrapper>
+        {({
+          activePage,
+          itemEndIndex,
+          itemStartIndex,
+          pageLength,
+          onChange
+        }) => (
+          <>
+            <BorderedList tag="ul">
+              {initialData.slice(itemStartIndex, itemEndIndex).map(name => (
+                <li>{name}</li>
+              ))}
+            </BorderedList>
+            <PaginationContainer>
+              <Pagination
+                activePage={activePage}
+                onChange={onChange}
+                pageLength={pageLength}
+                showPageLengthMenu={true}
+                totalItems={200}
+              />
+            </PaginationContainer>
+          </>
+        )}
+      </ControlledPaginationWrapper>
+    );
+  })
+  .add("start on a page > 1", () => (
+    <PaginationContainer>
+      <Pagination initialActivePage={3} totalItems={200} />
+    </PaginationContainer>
+  ))
+  .add("prev and next buttons as links", () => (
+    <PaginationContainer>
+      <Pagination
+        prevUrl="#page-1"
+        nextUrl="#page-3"
+        initialActivePage={2}
+        totalItems={200}
+      />
+    </PaginationContainer>
+  ))
+  .add("w/ a menu for items per page", () => (
+    <>
+      <PaginationContainer>
+        <div>With default page length menu opts</div>
+        <Pagination showPageLengthMenu={true} totalItems={200} />
+      </PaginationContainer>
+      <br />
+      <PaginationContainer>
+        <div>With large page length menu opts</div>
+        <Pagination showPageLengthMenu={true} totalItems={500} />
+      </PaginationContainer>
+    </>
+  ))
+  .add("w/ custom item label", () => (
+    <PaginationContainer>
+      <Pagination itemsLabel="clusters" totalItems={200} />
+    </PaginationContainer>
+  ))
+  .add("w/ sibling elements in PaginationContainer", () => (
+    <PaginationContainer>
+      <div>I'm another child of PaginationContainer</div>
+      <Pagination totalItems={200} />
+    </PaginationContainer>
+  ))
+  .add("only totalPages set", () => (
+    <PaginationContainer>
+      <Pagination totalPages={5} />
+    </PaginationContainer>
+  ))
+  .add("w/o totalItems set", () => (
+    <PaginationContainer>
+      <Pagination />
+    </PaginationContainer>
+  ))
+  .add("w/o PaginationContainer", () => <Pagination totalItems={200} />);

--- a/packages/pagination/pagination.test.tsx
+++ b/packages/pagination/pagination.test.tsx
@@ -1,0 +1,179 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import serializer from "jest-emotion";
+import toJson from "enzyme-to-json";
+
+import Pagination, { getItemCountString } from "./Pagination";
+import PaginationContainer from "./PaginationContainer";
+
+expect.addSnapshotSerializer(serializer);
+
+describe("Pagination", () => {
+  describe("rendering", () => {
+    it("renders default", () => {
+      const component = shallow(
+        <Pagination initialActivePage={4} initialPageLength={20} />
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it("renders wrapped in a PaginationContainer", () => {
+      const component = shallow(
+        <PaginationContainer vertAlignChildren="flex-end">
+          <Pagination initialActivePage={4} initialPageLength={20} />
+        </PaginationContainer>
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it("renders w/ custom item label", () => {
+      const component = shallow(
+        <Pagination
+          itemsLabel="things"
+          initialActivePage={4}
+          initialPageLength={20}
+        />
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it("renders w/ totalItems set", () => {
+      const component = shallow(
+        <Pagination
+          totalItems={200}
+          initialActivePage={4}
+          initialPageLength={20}
+        />
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it("renders w/ totalPages, pageLength, and totalItems set", () => {
+      const component = shallow(
+        <Pagination
+          totalPages={20}
+          pageLength={10}
+          totalItems={200}
+          initialActivePage={4}
+          initialPageLength={20}
+        />
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it("renders prev and next buttons as links", () => {
+      const component = shallow(
+        <Pagination
+          prevUrl="prev"
+          nextUrl="next"
+          initialActivePage={4}
+          initialPageLength={20}
+        />
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+
+    it("renders w/ page length menu", () => {
+      const component = shallow(
+        <Pagination
+          showPageLengthMenu={true}
+          initialPageLength={100}
+          initialActivePage={4}
+        />
+      );
+
+      expect(toJson(component)).toMatchSnapshot();
+    });
+  });
+
+  describe("getItemCountString", () => {
+    it("returns {start}-{end} of {total} if all params are passed", () => {
+      expect(getItemCountString(2, "items", 20, 60)).toEqual(
+        "21–40 of 60 items"
+      );
+    });
+
+    it("returns {start}-{end} if totalItems param isn't passed", () => {
+      expect(getItemCountString(2, "items", 20)).toEqual("21–40");
+    });
+  });
+
+  describe("page navigation functionality", () => {
+    it("increments number input value when 'next' button is clicked", () => {
+      const component = mount(
+        <Pagination
+          showPageLengthMenu={true}
+          initialPageLength={100}
+          initialActivePage={4}
+        />
+      );
+
+      expect(component.find("input").prop("value")).toEqual(4);
+      component.find("button[aria-label='next page']").simulate("click");
+      expect(component.find("input").prop("value")).toEqual(5);
+    });
+
+    it("decrements number input value when 'prev' button is clicked", () => {
+      const component = mount(<Pagination initialActivePage={4} />);
+
+      expect(component.find("input").prop("value")).toEqual(4);
+      component.find("button[aria-label='previous page']").simulate("click");
+      expect(component.find("input").prop("value")).toEqual(3);
+    });
+
+    it("disables the next button when the user is on the last page", () => {
+      const component = mount(
+        <Pagination initialActivePage={5} totalPages={5} />
+      );
+
+      expect(
+        component.find("button[aria-label='next page']").prop("disabled")
+      ).toEqual(true);
+    });
+
+    it("disables the prev button when the user is on the first page", () => {
+      const component = mount(<Pagination initialActivePage={1} />);
+
+      expect(
+        component.find("button[aria-label='previous page']").prop("disabled")
+      ).toEqual(true);
+    });
+
+    it("calls onChange prop when page length menu is changed", () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Pagination
+          showPageLengthMenu={true}
+          initialActivePage={4}
+          onChange={onChange}
+        />
+      );
+
+      expect(onChange).not.toHaveBeenCalled();
+      component.find("select").simulate("change");
+      expect(onChange).toHaveBeenCalledWith(4, 30);
+    });
+
+    it("calls onChange prop when page text input is changed and submitted", () => {
+      const onChange = jest.fn();
+      const component = mount(
+        <Pagination
+          showPageLengthMenu={true}
+          initialActivePage={4}
+          onChange={onChange}
+        />
+      );
+
+      expect(onChange).not.toHaveBeenCalled();
+      component.find("input").simulate("change");
+      component.find("form").simulate("submit");
+      expect(onChange).toHaveBeenCalledWith(4, 30);
+    });
+  });
+});

--- a/packages/pagination/style.ts
+++ b/packages/pagination/style.ts
@@ -1,0 +1,6 @@
+import { css } from "emotion";
+
+// 80px is approximately enough room for 3 digits and the number input controls
+export const defaultInputWidth = css`
+  max-width: 80px;
+`;

--- a/packages/pagination/usePageChange.ts
+++ b/packages/pagination/usePageChange.ts
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { INITIAL_PAGE_LENGTH } from "./Pagination";
+
+const usePageChange = (): {
+  activePage: number;
+  itemEndIndex: number;
+  itemStartIndex: number;
+  pageLength: number;
+  onChange: (newPage: number, newPageLength: number) => void;
+} => {
+  const [activePage, setActivePage] = React.useState<number>(1);
+  const [pageLength, setPageLength] = React.useState<number>(
+    INITIAL_PAGE_LENGTH
+  );
+
+  const onChange = (newPage, newPageLength) => {
+    setActivePage(newPage);
+    setPageLength(newPageLength);
+
+    if (pageLength !== newPageLength) {
+      setActivePage(1);
+    }
+  };
+
+  const itemStartIndex = (activePage - 1) * pageLength;
+  const itemEndIndex = itemStartIndex + pageLength - 1;
+
+  return {
+    activePage,
+    itemEndIndex,
+    itemStartIndex,
+    pageLength,
+    onChange
+  };
+};
+
+export default usePageChange;

--- a/packages/textInput/components/TextInput.tsx
+++ b/packages/textInput/components/TextInput.tsx
@@ -7,12 +7,8 @@ import {
   getInputAppearanceStyle,
   inputContainer
 } from "../../shared/styles/formStyles";
-import {
-  flex,
-  flexItem,
-  inputReset,
-  padding
-} from "../../shared/styles/styleUtils";
+import { inputReset, padding } from "../../shared/styles/styleUtils";
+import { flex, flexItem } from "../../shared/styles/styleUtils/layout/flexbox";
 import { InputAppearance } from "../../shared/types/inputAppearance";
 import { renderLabel } from "../../utilities/label";
 
@@ -93,7 +89,7 @@ export class TextInput<P extends TextInputProps> extends React.Component<P> {
       >
         {({ getValidationErrors, getHintContent, isValid, describedByIds }) => (
           <div>
-            <div className={cx(flex())}>
+            <div className={flex()}>
               {this.getInputElement(
                 [
                   padding("horiz", "m"),


### PR DESCRIPTION
Closes D2IQ-72667

<!-- See Checklist for PR creators below. -->

## Testing

Play with the Pagination stories in Storybook and make sure they match up with the Invision mock.

## Trade-offs

Maybe we should create a "ControlledPagination" component so we don't have props that look too similar:
- `initialActivePage`(for uncontrolled) and `activePage` (for controlled)
- `initialPageLength` (for uncontrolled) and `pageLength` (for controlled)

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
<img width="1094" alt="Screen Shot 2020-10-27 at 8 46 00 PM" src="https://user-images.githubusercontent.com/2313998/97377118-9d1c3f80-1895-11eb-8ebd-c0a10f0962aa.png">
<img width="1096" alt="Screen Shot 2020-10-27 at 8 46 18 PM" src="https://user-images.githubusercontent.com/2313998/97377119-9db4d600-1895-11eb-8f46-3de4674668c2.png">


## Checklist for PR creator

- [x] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
