### PR TITLE
fix: add second generic to FieldListColumnProps definition

### DIFF
--- a/packages/formStructure/components/FieldListColumn.tsx
+++ b/packages/formStructure/components/FieldListColumn.tsx
@@ -5,13 +5,13 @@ type DefaultProps = Pick<TextInputProps, "key" | "id" | "inputLabel">;
 
 type Value<T> = T;
 
-interface RenderProps<T> {
+interface RenderProps<T, E> {
   /** Whether field is disabled */
   disabled?: boolean;
   /** The data to populate a the field */
   fieldData: Record<string, any>;
   /** The callback for when an input value is changed */
-  onChange?: (e: React.FormEvent<HTMLInputElement>) => void;
+  onChange?: (e: E) => void;
   /** The index of the row of the current field */
   rowIndex: number;
   /** Boilerplate props to pass that are passed to a field component to support screenreaders. The `inputLabel` prop is specific to ui-kit's form components. If you're using form components that are not from ui-kit, you'll have to manually use this object to create a visually hidden `<label>` element, and ensure the `<label>`'s `for` attribute matches the corresponding `<input>`'s ID property. */
@@ -27,9 +27,12 @@ export interface FieldListColumnWidthProps {
   maxWidth?: number | string;
   key: React.Key;
 }
-export interface FieldListColumnProps<T = string> {
+export interface FieldListColumnProps<
+  T = string,
+  E = React.FormEvent<HTMLInputElement>
+> {
   /** Returns a function with render props as an argument. Storybook does not currently have a way to document render props, so you'll have to view the source of the `FieldListColumn` component to read the documentation. */
-  children: (renderProps: RenderProps<T>) => React.ReactNode;
+  children: (renderProps: RenderProps<T, E>) => React.ReactNode;
   /** The header that labels the column */
   header: React.ReactNode;
   /** The path where the column fields' value exists in the object passed to `FieldList` component's `data` prop */
@@ -38,10 +41,13 @@ export interface FieldListColumnProps<T = string> {
   onChange?: (rowIndex: number, pathToValue: string) => (e) => void;
 }
 
-export const FieldListColumn: <T = string>(
-  props: FieldListColumnProps<T> & FieldListColumnWidthProps
+export const FieldListColumn: <
+  T = string,
+  E = React.FormEvent<HTMLInputElement>
+>(
+  props: FieldListColumnProps<T, E> & FieldListColumnWidthProps
 ) => React.ReactElement<
-  FieldListColumnProps<T> & FieldListColumnWidthProps
+  FieldListColumnProps<T, E> & FieldListColumnWidthProps
 > = () => <React.Fragment />;
 
 export const FieldListColumnSeparator: React.SFC<FieldListColumnWidthProps> = () => (


### PR DESCRIPTION
The FieldList and FieldListColumn components allow consumers to define any type of onChange handler for their field columns, and even allow configuring the `value` type via generic. Currently we are not able to fully take advantage of this `value` flexibility because the render props `onChange` handler assumes that the event will be an InputElement form event. To allow use with different types of inputs (like selects) and different types of form controls that don't use form events at all (like TextInputWithBadges), a second generic is added to the column definition.

## Testing

Should work as usual

## Trade-offs

## Dependencies

## Screenshots
