### PR TITLE
feat: add block display override to icon

### DIFF
--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -3,3 +3,4 @@
 Icons can live within other components, such as buttons. They should take on the text color of that component.
 Icons have a default color, but can be styled with any color.
 Icons have a default size, but can be resized to any of the predetermined icon sizes from our design tokens.
+The Icon svg defaults to `display: inline` but can be set to `display: block` with the `block` property.

--- a/packages/icon/components/Icon.tsx
+++ b/packages/icon/components/Icon.tsx
@@ -5,7 +5,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { ProductIcons } from "../../icons/dist/product-icons-enum";
 import { IconSize } from "../../shared/types/iconSize";
 import { iconSizes } from "../../shared/styles/styleUtils/layout/iconSizes";
-import { icon } from "../style";
+import { icon, blockIcon } from "../style";
 
 const DEFAULT_ICON_SIZE: IconSize = "s";
 
@@ -21,6 +21,8 @@ export interface IconProps {
   size?: IconSize;
   /** human-readable selector used for writing tests */
   ["data-cy"]?: string;
+  /** Sets display to block if true */
+  block?: boolean;
 }
 
 const Icon: React.FC<IconProps> = ({
@@ -28,7 +30,8 @@ const Icon: React.FC<IconProps> = ({
   size = DEFAULT_ICON_SIZE,
   shape,
   ariaLabel,
-  "data-cy": dataCy
+  "data-cy": dataCy,
+  block
 }) => {
   const svgColor = color || "currentColor";
   const iconSize = iconSizes[size];
@@ -41,7 +44,7 @@ const Icon: React.FC<IconProps> = ({
       viewBox={`0 0 ${parseInt(iconSize, 10)} ${parseInt(iconSize, 10)}`}
       role="img"
       aria-label={ariaLabel || `${shape} icon`}
-      className={cx(icon, tintSVG(svgColor))}
+      className={cx(icon, tintSVG(svgColor), block ? blockIcon : "")}
       data-cy={["icon", dataCy].filter(Boolean).join(" ")}
     >
       <use xlinkHref={`#${shape}`} />

--- a/packages/icon/style.ts
+++ b/packages/icon/style.ts
@@ -7,3 +7,7 @@ export const icon = css`
     pointer-events: none;
   }
 `;
+
+export const blockIcon = css`
+  display: block;
+`;

--- a/packages/icon/tests/Icon.test.tsx
+++ b/packages/icon/tests/Icon.test.tsx
@@ -25,4 +25,9 @@ describe("Icon", () => {
 
     expect(toJson(component)).toMatchSnapshot();
   });
+  it("renders display block", () => {
+    const component = shallow(<Icon shape={SystemIcons.ArrowDown} block />);
+
+    expect(toJson(component)).toMatchSnapshot();
+  });
 });

--- a/packages/icon/tests/__snapshots__/Icon.test.tsx.snap
+++ b/packages/icon/tests/__snapshots__/Icon.test.tsx.snap
@@ -26,6 +26,33 @@ exports[`Icon renders 1`] = `
 </svg>
 `;
 
+exports[`Icon renders display block 1`] = `
+.emotion-0 {
+  vertical-align: middle;
+  fill: currentColor;
+  display: block;
+}
+
+.emotion-0 use {
+  pointer-events: none;
+}
+
+<svg
+  aria-label="system-arrow-down icon"
+  className="emotion-0"
+  data-cy="icon"
+  height={24}
+  preserveAspectRatio="xMinYMin meet"
+  role="img"
+  viewBox="0 0 24 24"
+  width={24}
+>
+  <use
+    xlinkHref="#system-arrow-down"
+  />
+</svg>
+`;
+
 exports[`Icon renders with defaults 1`] = `
 .emotion-0 {
   vertical-align: middle;


### PR DESCRIPTION
Added a `block` flag to the Icon props to allow changing the svg from the
default `display: inline` to `display: block` this will allow an icon to
use `margin: auto` inside flex. This is useful when displaying an icon
next to text and we want them to be aligned.

I did not change the default since it would break the rendering for
other components.

I initially set `block` as a default prop set to false, but this then
broke every snapshot. Instead I just made it an optional prop.

Alternative to a block flag we could of made a display prop the defaults
to inline and can be set to any valid display CSS value. I'm not opposed
to this but didn't need it now.

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
