### PR TITLE
D2IQ-73430 feat: slidetoggle

### DIFF
--- a/packages/index.ts
+++ b/packages/index.ts
@@ -134,6 +134,7 @@ export { UIKitThemeProvider } from "./themes";
 export { UIKitProvider } from "./uiKitProvider";
 export { CodeSnippet } from "./codesnippet";
 export { ClickToCopyButton } from "./clicktocopybutton";
+export { SlideToggle } from "./slideToggle";
 
 // Style utility components
 export {

--- a/packages/slideToggle/README.md
+++ b/packages/slideToggle/README.md
@@ -1,0 +1,3 @@
+# SlideToggle
+
+SlideToggles are used to toggle something on or off.

--- a/packages/slideToggle/components/SlideToggle.tsx
+++ b/packages/slideToggle/components/SlideToggle.tsx
@@ -1,0 +1,201 @@
+import * as React from "react";
+import { cx } from "emotion";
+import {
+  flex,
+  flexItem,
+  visuallyHidden,
+  display,
+  tintContent,
+  tintContentSecondary,
+  vAlignChildren
+} from "../../shared/styles/styleUtils";
+
+import {
+  themeError,
+  themeSuccess,
+  themeBgPrimary
+} from "../../design-tokens/build/js/designTokens";
+import { InputAppearance } from "../../shared/types/inputAppearance";
+import FormFieldWrapper from "../../shared/components/FormFieldWrapper";
+import { SystemIcons } from "../../icons/dist/system-icons-enum";
+import { Icon } from "../../icon";
+import {
+  checkContainer,
+  toggle,
+  toggleRound,
+  toggleContainer,
+  toggleInputApperances,
+  toggleInputLabel,
+  toggleInputFeedbackText
+} from "../style";
+
+export interface SlideToggleProps extends React.HTMLProps<HTMLInputElement> {
+  /**
+   * Sets the current appearance of the input component. This defaults to InputAppearance.Standard, but supports `InputAppearance.Error` & `InputAppearance.Success` appearances as well.
+   */
+  appearance?: InputAppearance;
+  /**
+   * Whether or not the input is checked
+   */
+  checked?: boolean;
+  /**
+   * Unique identifier used for the input element
+   */
+  id: string;
+  /**
+   * The text or node content that appears next to the input
+   */
+  inputLabel: React.ReactNode | string;
+  /**
+   * Defaults to `true`, but can be set to `false` to visibly hide the content passed to `inputLabel`. The `inputLabel` should still be set even when hidden for accessibility support.
+   */
+  showInputLabel?: boolean;
+  /**
+   * The value being toggled
+   */
+  value?: string;
+  /**
+   * How the text content vertically aligns with the input
+   */
+  vertAlign?: "center" | "top";
+  /**
+   * hintContent is text or a ReactNode that is displayed directly under the input with additional information about the expected input.
+   */
+  hintContent?: React.ReactNode;
+  /**
+   * Sets the contents for validation errors. This will be displayed below the input element. Errors are only visible when the `TextInput` appearance is also set to `TextInputAppearance.Error`.
+   */
+  errors?: React.ReactNode[];
+}
+
+const SlideToggle: React.FC<React.PropsWithRef<SlideToggleProps>> = props => {
+  const {
+    appearance,
+    children,
+    disabled,
+    hintContent,
+    id,
+    inputLabel,
+    showInputLabel,
+    vertAlign,
+    checked,
+    value,
+    errors,
+    onBlur,
+    onFocus,
+    ...other
+  } = props;
+  const inputType = "SlideToggle";
+  const inputDataCy = [
+    `${inputType}-input`,
+    ...(checked ? [`${inputType}-input.checked`] : []),
+    ...(appearance && appearance !== InputAppearance.Standard
+      ? [`${inputType}-input.${appearance}`]
+      : [])
+  ].join(" ");
+  const parentDataCy = [
+    `${inputType}`,
+    ...(checked ? [`${inputType}.checked`] : []),
+    ...(appearance && appearance !== InputAppearance.Standard
+      ? [`${inputType}.${appearance}`]
+      : [])
+  ].join(" ");
+  const [hasFocus, setHasFocus] = React.useState<boolean>(false);
+  const handleFocus = e => {
+    setHasFocus(true);
+
+    onFocus?.(e);
+  };
+
+  const handleBlur = e => {
+    setHasFocus(false);
+
+    onBlur?.(e);
+  };
+
+  return (
+    <FormFieldWrapper id={id} errors={errors} hintContent={hintContent}>
+      {({ getValidationErrors, isValid, describedByIds, getHintContent }) => (
+        <div className={vAlignChildren} data-cy={parentDataCy}>
+          <label
+            className={cx(
+              flex({
+                align: vertAlign === "top" ? "flex-start" : "center"
+              }),
+              display("inline-flex")
+            )}
+            htmlFor={id}
+          >
+            <div className={cx(flexItem("shrink"), display("inherit"))}>
+              <>
+                <div className={cx(toggleContainer)}>
+                  {/* tslint:disable react-a11y-role-has-required-aria-props */}
+                  <input
+                    type={inputType}
+                    id={id}
+                    className={visuallyHidden}
+                    checked={checked}
+                    disabled={disabled}
+                    value={value}
+                    aria-invalid={!isValid}
+                    aria-describedby={describedByIds}
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
+                    data-cy={inputDataCy}
+                    {...other}
+                  />
+                  <div
+                    className={cx(toggle, toggleRound, {
+                      [toggleInputApperances[`${appearance}-focus`]]: hasFocus,
+                      [toggleInputApperances[`${appearance}-active`]]: checked,
+                      [toggleInputApperances["focus-active"]]:
+                        checked && hasFocus,
+                      [toggleInputApperances.disabled]: disabled,
+                      [toggleInputApperances["disabled-active"]]:
+                        disabled && checked
+                    })}
+                  >
+                    {checked && (
+                      <span className={checkContainer}>
+                        <Icon
+                          shape={SystemIcons.Check}
+                          size="xxs"
+                          color={themeBgPrimary}
+                        />
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </>
+            </div>
+            <div
+              className={cx(flexItem("grow"), toggleInputLabel, {
+                [visuallyHidden]: !showInputLabel,
+                [tintContent(themeError)]: appearance === InputAppearance.Error,
+                [tintContent(themeSuccess)]:
+                  appearance === InputAppearance.Success,
+                [tintContentSecondary]: disabled
+              })}
+            >
+              {inputLabel}
+            </div>
+          </label>
+          {(getHintContent || getValidationErrors) && (
+            <div className={toggleInputFeedbackText}>
+              {getHintContent}
+              {appearance === InputAppearance.Error && getValidationErrors}
+            </div>
+          )}
+        </div>
+      )}
+    </FormFieldWrapper>
+  );
+};
+
+SlideToggle.defaultProps = {
+  appearance: InputAppearance.Standard,
+  showInputLabel: true,
+  vertAlign: "center"
+};
+
+export default SlideToggle;

--- a/packages/slideToggle/index.ts
+++ b/packages/slideToggle/index.ts
@@ -1,0 +1,1 @@
+export { default as SlideToggle } from "./components/SlideToggle";

--- a/packages/slideToggle/stories/SlideToggle.stories.tsx
+++ b/packages/slideToggle/stories/SlideToggle.stories.tsx
@@ -1,0 +1,130 @@
+import * as React from "react";
+import SlideToggle from "../components/SlideToggle";
+import { GridList, Text } from "../..";
+import { InputAppearance } from "../../shared/types/inputAppearance";
+
+export const Primary = () => {
+  const [checked, setChecked] = React.useState(false);
+  const handleClick = () => {
+    setChecked(!checked);
+  };
+  return (
+    <SlideToggle
+      id="toggle"
+      inputLabel="Normal toggle"
+      value="unchecked"
+      checked={checked}
+      onClick={handleClick}
+    />
+  );
+};
+
+export const Appearances = () => {
+  return (
+    <GridList columnCount={3}>
+      <Text>Standard</Text>
+      <SlideToggle
+        id="std-unchecked"
+        inputLabel="Unchecked"
+        value="unchecked"
+        checked={false}
+      />
+      <SlideToggle
+        id="std-checked"
+        inputLabel="Checked"
+        value="unchecked"
+        checked={true}
+      />
+      <Text>Error</Text>
+      <SlideToggle
+        id="err-unchecked"
+        appearance={InputAppearance.Error}
+        inputLabel="Unchecked"
+        value="unchecked"
+        checked={false}
+      />
+      <SlideToggle
+        id="err-checked"
+        appearance={InputAppearance.Error}
+        inputLabel="Checked"
+        value="unchecked"
+        checked={true}
+      />
+      <Text>Success</Text>
+      <SlideToggle
+        id="err-unchecked"
+        appearance={InputAppearance.Success}
+        inputLabel="Unchecked"
+        value="unchecked"
+        checked={false}
+      />
+      <SlideToggle
+        id="err-checked"
+        appearance={InputAppearance.Success}
+        inputLabel="Checked"
+        value="unchecked"
+        checked={true}
+      />
+      <Text>Disabled</Text>
+      <SlideToggle
+        id="dis-unchecked"
+        disabled={true}
+        inputLabel="Unchecked"
+        value="unchecked"
+        checked={false}
+      />
+      <SlideToggle
+        id="dis-checked"
+        disabled={true}
+        inputLabel="Checked"
+        value="unchecked"
+        checked={true}
+      />
+    </GridList>
+  );
+};
+
+export const HintText = () => {
+  const [checked, setChecked] = React.useState(false);
+  const handleClick = () => {
+    setChecked(!checked);
+  };
+  return (
+    <SlideToggle
+      id="toggle"
+      inputLabel="toggle w/ hint text"
+      hintContent="This is some hint text."
+      value="unchecked"
+      checked={checked}
+      onClick={handleClick}
+    />
+  );
+};
+
+export const Errors = () => (
+  <SlideToggle
+    id="toggle"
+    appearance={InputAppearance.Error}
+    inputLabel="toggle with errors"
+    value="unchecked"
+    checked={true}
+    errors={["this is an error.", "this is another."]}
+  />
+);
+
+export const HintTextAndErrors = () => (
+  <SlideToggle
+    id="toggle"
+    appearance={InputAppearance.Error}
+    inputLabel="toggle with errors"
+    hintContent="This is some hint text."
+    value="unchecked"
+    checked={true}
+    errors={["this is an error.", "this is another."]}
+  />
+);
+
+export default {
+  title: "Forms|SlideToggle",
+  component: SlideToggle
+};

--- a/packages/slideToggle/style.ts
+++ b/packages/slideToggle/style.ts
@@ -1,0 +1,172 @@
+import { css } from "emotion";
+import {
+  spaceL,
+  spaceS,
+  themeBorder,
+  themeBgDisabled,
+  themeBgPrimary,
+  themeBrandPrimary,
+  themeError,
+  themeSuccess,
+  themeTextColorDisabled,
+  white
+} from "../design-tokens/build/js/designTokens";
+
+const toggleInputHeight = 14;
+const toggleInputWidth = toggleInputHeight * 2;
+const toggleRoundBorder = 1;
+const toggleRoundSize = toggleInputHeight - toggleRoundBorder * 2;
+
+export const toggleInputLabel = css`
+  padding-left: ${spaceS};
+`;
+
+export const toggleInputFeedbackText = css`
+  padding-left: ${toggleInputWidth + parseInt(spaceS, 10)}px;
+`;
+
+export const toggleInputApperances = {
+  disabled: css`
+    border: solid;
+    border-width: ${toggleRoundBorder}px;
+    border-color: ${themeBgDisabled};
+    background-color: ${themeBgDisabled};
+
+    &:before {
+      border: solid;
+      border-color: ${themeBgDisabled};
+      border-width: ${toggleRoundBorder}px;
+    }
+  `,
+  "standard-focus": css`
+    border: solid;
+    border-width: ${toggleRoundBorder}px;
+    border-color: ${themeBrandPrimary};
+
+    &:before {
+      border: solid;
+      border-color: ${themeBrandPrimary};
+      border-width: ${toggleRoundBorder}px;
+    }
+  `,
+  "standard-active": css`
+    border: solid;
+    border-color: ${themeBrandPrimary};
+    border-width: ${toggleRoundBorder}px;
+    background-color: ${themeBrandPrimary};
+
+    &:before {
+      border: solid;
+      border-color: ${themeBrandPrimary};
+      border-width: ${toggleRoundBorder}px;
+      transform: translateX(${toggleInputHeight + toggleRoundBorder}px);
+    }
+  `,
+  "error-active": css`
+    border: solid;
+    border-color: ${themeBrandPrimary};
+    border-width: ${toggleRoundBorder}px;
+    background-color: ${themeBrandPrimary};
+
+    &:before {
+      border: solid;
+      border-color: ${themeBrandPrimary};
+      border-width: ${toggleRoundBorder}px;
+      transform: translateX(${toggleInputHeight + toggleRoundBorder}px);
+    }
+  `,
+  "success-active": css`
+    border: solid;
+    border-color: ${themeBrandPrimary};
+    border-width: ${toggleRoundBorder}px;
+    background-color: ${themeBrandPrimary};
+
+    &:before {
+      border: solid;
+      border-color: ${themeBrandPrimary};
+      border-width: ${toggleRoundBorder}px;
+      transform: translateX(${toggleInputHeight + toggleRoundBorder}px);
+    }
+  `,
+  "error-focus": css`
+    border: solid;
+    border-width: ${toggleRoundBorder}px;
+    border-color: ${themeError};
+
+    &:before {
+      border: solid;
+      border-width: ${toggleRoundBorder}px;
+      border-color: ${themeError};
+    }
+  `,
+  "success-focus": css`
+    border: solid;
+    border-width: ${toggleRoundBorder}px;
+    border-color: ${themeSuccess};
+
+    &:before {
+      border: solid;
+      border-width: ${toggleRoundBorder}px;
+      border-color: ${themeSuccess};
+    }
+  `,
+  "disabled-active": css`
+    border: solid;
+    border-width: ${toggleRoundBorder}px;
+    border-color: ${themeTextColorDisabled};
+    background-color: ${themeTextColorDisabled};
+
+    &:before {
+      border: solid;
+      border-width: ${toggleRoundBorder}px;
+      border-color: ${themeTextColorDisabled};
+    }
+  `,
+  "focus-active": css``
+};
+
+export const toggleContainer = css`
+  height: ${toggleInputHeight}px;
+  position: relative;
+  width: ${toggleInputWidth}px;
+`;
+
+export const toggle = css`
+  background-color: ${themeBgPrimary};
+  border: solid;
+  border-width: ${toggleRoundBorder}px;
+  border-color: ${themeBorder};
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: 250ms;
+
+  &:before {
+    background-color: ${white};
+    border: solid;
+    border-color: ${themeBorder};
+    border-width: ${toggleRoundBorder}px;
+    bottom: ${-toggleRoundBorder}px;
+    content: "";
+    height: ${toggleRoundSize}px;
+    left: ${-toggleRoundBorder}px;
+    position: absolute;
+    transition: 250ms;
+    width: ${toggleRoundSize}px;
+  }
+`;
+export const toggleRound = css`
+  border-radius: ${spaceL};
+  &:before {
+    border-radius: 50%;
+  }
+`;
+
+export const checkContainer = css`
+  position: absolute;
+  left: ${toggleRoundBorder * 2}px;
+  bottom: ${-toggleRoundBorder * 2}px;
+`;


### PR DESCRIPTION
Added a new toggle component `SlideToggle` this is basically a checkbox
styled to be a slider with a check when checked.

I initially tried to implement this extending the ToggleComponent like
the CheckboxInput and RadioInputs do, but the styles were different
enough that I needed to make this its own component.

- Closes D2IQ-73430

<!-- See Checklist for PR creators below. -->

## Testing

Open story and try it out.

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

![image](https://user-images.githubusercontent.com/1972968/105555582-4de87e00-5ccf-11eb-980b-147c6963c116.png)


## Checklist for PR creator

- [x] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
