### PR TITLE
fix: show story source

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,10 +9,10 @@ require("../packages/shared/styles/global").injectStorybookResetCss();
 addDecorator(iconDecorator);
 addDecorator(withKnobs);
 addDecorator(withA11y);
-addDecorator(addReadme);
 addDecorator(
   withInfo({
     inline: true,
-    source: false
+    source: true
   })
 );
+addDecorator(addReadme);


### PR DESCRIPTION
This change enables story source to show in storybook and fixes incorrect prop types tables.

## Testing

- `npm start` and make sure you can see story source and that prop tables show correct props

## Trade-offs

- For some reason storybook-readme is wiping out the syntax highlighting on source blocks 🤔 
- We should switch from addon-info to addon-docs
- There is some kind of wrapper around sources with these weird invisible SVGs. I do not know why
<img width="1391" alt="Screen Shot 2021-01-22 at 6 29 11 PM" src="https://user-images.githubusercontent.com/19582796/105566531-8d1fca80-5ce1-11eb-9628-16080ae791db.png">


## Dependencies

## Screenshots

**Before**
<img width="1470" alt="Screen Shot 2021-01-22 at 6 28 31 PM" src="https://user-images.githubusercontent.com/19582796/105566495-5fd31c80-5ce1-11eb-921c-94134ac9063f.png">

**After**
<img width="1391" alt="Screen Shot 2021-01-22 at 6 29 11 PM" src="https://user-images.githubusercontent.com/19582796/105566502-682b5780-5ce1-11eb-927a-1d926a2df4c5.png">
<img width="1390" alt="Screen Shot 2021-01-22 at 6 29 19 PM" src="https://user-images.githubusercontent.com/19582796/105566509-6bbede80-5ce1-11eb-8cf7-90b958093913.png">

