### PR TITLE
D2IQ-65928: add BreadcrumbItem component

### DIFF
--- a/packages/breadcrumb/components/BreadcrumbItem.tsx
+++ b/packages/breadcrumb/components/BreadcrumbItem.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { IconShapes } from "../../icon/components/Icon";
+import ResetLink from "../../link/components/ResetLink";
+import IconPropAdapter from "../../icon/components/IconPropAdapter";
+import { Flex, FlexItem } from "../../styleUtils/layout";
+
+interface BreadcrumbItemProps {
+  url?: string;
+  onClick?: () => void;
+  icon?: IconShapes | React.ReactElement<HTMLElement>;
+  children: React.ReactNode;
+}
+const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
+  icon,
+  url,
+  onClick,
+  children
+}) => {
+  const content =
+    url || onClick ? (
+      <ResetLink url={url} onClick={onClick}>
+        {children}
+      </ResetLink>
+    ) : (
+      <span>{children}</span>
+    );
+
+  return icon ? (
+    <Flex align="center" gutterSize="m">
+      <FlexItem flex="shrink">
+        <IconPropAdapter icon={icon} size="s" color="inherit" />
+      </FlexItem>
+      <FlexItem>{content}</FlexItem>
+    </Flex>
+  ) : (
+    content
+  );
+};
+
+export default BreadcrumbItem;

--- a/packages/breadcrumb/index.ts
+++ b/packages/breadcrumb/index.ts
@@ -1,1 +1,2 @@
 export { default as Breadcrumb } from "./components/Breadcrumb";
+export { default as BreadcrumbItem } from "./components/BreadcrumbItem";

--- a/packages/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -2,9 +2,11 @@ import * as React from "react";
 import { storiesOf } from "@storybook/react";
 import { withReadme } from "storybook-readme";
 
-import { Breadcrumb } from "../index";
+import { Breadcrumb, BreadcrumbItem } from "../index";
 
 import readme from "../README.md";
+import { action } from "@storybook/addon-actions";
+import { ProductIcons } from "../../icons/dist/product-icons-enum";
 
 storiesOf("Navigation|Breadcrumb", module)
   .addParameters({
@@ -23,5 +25,30 @@ storiesOf("Navigation|Breadcrumb", module)
   .add("at top-level", () => (
     <Breadcrumb>
       <span>One</span>
+    </Breadcrumb>
+  ))
+  .add("using BreadcrumbItems", () => (
+    <Breadcrumb>
+      <BreadcrumbItem>One</BreadcrumbItem>
+      <BreadcrumbItem>Two</BreadcrumbItem>
+      <BreadcrumbItem>
+        <span style={{ color: "blue" }}>Three</span>
+      </BreadcrumbItem>
+    </Breadcrumb>
+  ))
+  .add("with click handler", () => (
+    <Breadcrumb>
+      <BreadcrumbItem onClick={action("clicked breadcrumb item one")}>
+        One
+      </BreadcrumbItem>
+      <BreadcrumbItem onClick={action("clicked breadcrumb item two")}>
+        Two
+      </BreadcrumbItem>
+    </Breadcrumb>
+  ))
+  .add("with icon", () => (
+    <Breadcrumb>
+      <BreadcrumbItem icon={ProductIcons.Gear}>One</BreadcrumbItem>
+      <BreadcrumbItem>Two</BreadcrumbItem>
     </Breadcrumb>
   ));

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -22,7 +22,7 @@ export {
   AccordionItemTitleInteractive
 } from "./accordion";
 export { Badge, BadgeButton, ColorCodedBadge } from "./badge";
-export { Breadcrumb } from "./breadcrumb";
+export { Breadcrumb, BreadcrumbItem } from "./breadcrumb";
 export {
   PrimaryButton,
   SecondaryButton,


### PR DESCRIPTION
The BreadcrumbItem component takes care of common formatting boilerplate in breadcrumbs. You can specify an optional icon (by shape or by component), url, and/or onClick handler in addition to the breadcrumb content.

Closes D2IQ-65928

## Testing

- See Breadcrumb stories 

## Trade-offs

## Dependencies

## Screenshots
