### PR TITLE
D2IQ-74165: add default maxWidth to tooltips

### DIFF
--- a/packages/clicktocopybutton/tests/__snapshots__/ClickToCopyButton.test.tsx.snap
+++ b/packages/clicktocopybutton/tests/__snapshots__/ClickToCopyButton.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`ClickToCopyButton renders default 1`] = `
                 <TooltipContent
                   id="copyTooltip1"
                   isOpen={false}
+                  maxWidth={300}
                 >
                   Copied to clipboard
                 </TooltipContent>
@@ -237,6 +238,7 @@ exports[`ClickToCopyButton renders with custom children 1`] = `
                 <TooltipContent
                   id="copyTooltip2"
                   isOpen={false}
+                  maxWidth={300}
                 >
                   Copied to clipboard
                 </TooltipContent>

--- a/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
+++ b/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
@@ -437,6 +437,7 @@ exports[`CodeSnippet renders with copy button 1`] = `
                                 <TooltipContent
                                   id="copyTooltip1"
                                   isOpen={false}
+                                  maxWidth={300}
                                 >
                                   Copied to clipboard
                                 </TooltipContent>

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -1163,6 +1163,7 @@ exports[`Table v2 rendering renders default 1`] = `
                               <TooltipContent
                                 id="colTooltip1-tooltip"
                                 isOpen={false}
+                                maxWidth={300}
                               >
                                 test
                               </TooltipContent>
@@ -5050,6 +5051,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                               <TooltipContent
                                 id="colTooltip2-tooltip"
                                 isOpen={false}
+                                maxWidth={300}
                               >
                                 test
                               </TooltipContent>

--- a/packages/tooltip/components/Tooltip.tsx
+++ b/packages/tooltip/components/Tooltip.tsx
@@ -8,7 +8,7 @@ import { getFirstFocusableChildNode } from "../../utilities/getFocusableChildNod
 export interface BaseTooltipProps {
   children: React.ReactNode | string;
   id: string;
-  maxWidth?: number;
+  maxWidth?: number | null;
   minWidth?: number;
 }
 export interface TooltipProps extends BaseTooltipProps {
@@ -31,7 +31,7 @@ const Tooltip = ({
   children,
   disablePortal,
   id,
-  maxWidth,
+  maxWidth = 300,
   minWidth,
   onClose,
   isOpen: isOpenProp = false,

--- a/packages/tooltip/components/TooltipContent.tsx
+++ b/packages/tooltip/components/TooltipContent.tsx
@@ -37,7 +37,7 @@ class TooltipContent extends React.PureComponent<TooltipContentProps, {}> {
           role="tooltip"
           style={{
             minWidth,
-            maxWidth
+            maxWidth: maxWidth || undefined
           }}
           data-cy="tooltipContent"
         >

--- a/packages/tooltip/stories/Tooltip.stories.tsx
+++ b/packages/tooltip/stories/Tooltip.stories.tsx
@@ -72,6 +72,12 @@ storiesOf("Overlays|Tooltip", module)
       </Tooltip>
     );
   })
+  .add("default max width", () => (
+    <Tooltip trigger="if not provided, maxWidth defaults to 300" id="maxWidth">
+      since my content is wider than 300px, it will wrap so that tooltip does
+      not exceed a width of 300px by default
+    </Tooltip>
+  ))
   .add("min or max width", () => (
     <React.Fragment>
       <div style={{ marginBottom: "1em" }}>
@@ -88,6 +94,16 @@ storiesOf("Overlays|Tooltip", module)
         content
       </Tooltip>
     </React.Fragment>
+  ))
+  .add("content width", () => (
+    <Tooltip
+      trigger="if maxWidth is null, tooltip width will expand to fit content"
+      id="maxWidth"
+      maxWidth={null}
+    >
+      sometimes I may want my tooltip to take up as much width as the content
+      needs without having the default maxWidth
+    </Tooltip>
   ))
   .add("suppress toggle", () => (
     <Tooltip trigger="hover me" id="suppress" isOpen={true} suppress={true}>

--- a/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Tooltip renders 1`] = `
         <TooltipContent
           id="renders"
           isOpen={false}
+          maxWidth={300}
         >
           content
         </TooltipContent>
@@ -86,6 +87,7 @@ exports[`Tooltip renders open tooltip 1`] = `
         <TooltipContent
           id="opened"
           isOpen={true}
+          maxWidth={300}
         >
           content
         </TooltipContent>
@@ -162,6 +164,7 @@ exports[`Tooltip renders open tooltip 1`] = `
                         data-cy="tooltipContent"
                         id="opened"
                         role="tooltip"
+                        style="max-width: 300px;"
                       >
                         content
                       </div>
@@ -220,6 +223,7 @@ exports[`Tooltip renders open tooltip 1`] = `
                         data-cy="tooltipContent"
                         id="opened"
                         role="tooltip"
+                        style="max-width: 300px;"
                       >
                         content
                       </div>
@@ -243,6 +247,7 @@ exports[`Tooltip renders open tooltip 1`] = `
                   <TooltipContent
                     id="opened"
                     isOpen={true}
+                    maxWidth={300}
                   >
                     <div
                       aria-hidden={false}
@@ -252,7 +257,7 @@ exports[`Tooltip renders open tooltip 1`] = `
                       role="tooltip"
                       style={
                         Object {
-                          "maxWidth": undefined,
+                          "maxWidth": 300,
                           "minWidth": undefined,
                         }
                       }
@@ -324,6 +329,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
         <TooltipContent
           id="customDir"
           isOpen={true}
+          maxWidth={300}
         >
           content
         </TooltipContent>
@@ -398,6 +404,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
                         data-cy="tooltipContent"
                         id="opened"
                         role="tooltip"
+                        style="max-width: 300px;"
                       >
                         content
                       </div>
@@ -416,6 +423,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
                         data-cy="tooltipContent"
                         id="customDir"
                         role="tooltip"
+                        style="max-width: 300px;"
                       >
                         content
                       </div>
@@ -474,6 +482,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
                         data-cy="tooltipContent"
                         id="customDir"
                         role="tooltip"
+                        style="max-width: 300px;"
                       >
                         content
                       </div>
@@ -497,6 +506,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
                   <TooltipContent
                     id="customDir"
                     isOpen={true}
+                    maxWidth={300}
                   >
                     <div
                       aria-hidden={false}
@@ -506,7 +516,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
                       role="tooltip"
                       style={
                         Object {
-                          "maxWidth": undefined,
+                          "maxWidth": 300,
                           "minWidth": undefined,
                         }
                       }


### PR DESCRIPTION
- Add maxWidth for tooltips
- Add option for user to override default maxWidth to fit width to content by setting maxWidth to null (not sure if I'm 100% happy with that)

Closes D2IQ-74165

## Testing

- Check out tooltip stories

## Trade-offs

This is I guess kind of a breaking change but should it _really_ be a breaking change? Let me know.

## Dependencies

## Screenshots
