### PR TITLE
fix: use `display: none` to hide closed expendable items

### DIFF
--- a/packages/expandable/components/Expandable.tsx
+++ b/packages/expandable/components/Expandable.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { cx } from "emotion";
-import { visuallyHidden } from "../../shared/styles/styleUtils";
+import { display } from "../../shared/styles/styleUtils";
 import { toggler } from "../style";
 import { ResetButton } from "../../button";
 import { Icon } from "../../icon";
@@ -72,7 +72,7 @@ const Expandable: React.FC<ExpandableProps> = ({
           <FlexItem>{label}</FlexItem>
         </Flex>
       </ResetButton>
-      <div className={cx({ [visuallyHidden]: !open })} aria-hidden={!open}>
+      <div className={cx({ [display("none")]: !open })} aria-hidden={!open}>
         {children}
       </div>
     </div>

--- a/packages/fullscreenView/components/FullscrenView.tsx
+++ b/packages/fullscreenView/components/FullscrenView.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cx } from "emotion";
+// TODO: This component contains `willReceiveProps`
 import Delegate from "react-delegate-component";
 import { ButtonProps } from "../../button/components/ButtonBase";
 import { flex, padding, flexItem } from "../../shared/styles/styleUtils";


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

We tried to use a more accessible form of hiding elements but that doesn't work out as easy as thought with our current integration tests. 
For the ease of implementation I decided to bring `display: none` back for now to be able to finish: https://jira.d2iq.com/browse/D2IQ-65002

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
