### PR TITLE
feat: title attr on truncated Text

### DIFF
--- a/packages/styleUtils/typography/components/Text.tsx
+++ b/packages/styleUtils/typography/components/Text.tsx
@@ -34,6 +34,12 @@ const Text = (props: TextProps) => {
     "data-cy": dataCy
   } = props;
   const TextTag = tag || defaultTag;
+  let title: string | undefined;
+
+  // if truncated, show title attr with complete text
+  if (wrap === "truncate" && typeof children === "string") {
+    title = children;
+  }
 
   return (
     <TextTag
@@ -55,6 +61,7 @@ const Text = (props: TextProps) => {
         }
       )}
       data-cy={dataCy}
+      title={title}
     >
       {children}
     </TextTag>

--- a/packages/styleUtils/typography/stories/text.stories.tsx
+++ b/packages/styleUtils/typography/stories/text.stories.tsx
@@ -133,4 +133,9 @@ storiesOf("Typography|Text", module)
   ))
   .add("custom HTML tag", () => (
     <Text tag="span">{`This text is in a <span> tag`}</Text>
+  ))
+  .add("nested HTML tag", () => (
+    <Text>
+      <span>{`This text is in a <span> tag passed as a child`}</span>
+    </Text>
   ));

--- a/packages/styleUtils/typography/tests/__snapshots__/typographyComponents.test.tsx.snap
+++ b/packages/styleUtils/typography/tests/__snapshots__/typographyComponents.test.tsx.snap
@@ -176,6 +176,7 @@ exports[`Typography Text renders all wrap variants 1`] = `
 <p
   className="rmTextMargins emotion-0"
   data-cy="text"
+  title="content"
 >
   content
 </p>

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -2156,6 +2156,7 @@ exports[`Table v2 rendering renders default 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -2549,6 +2550,7 @@ exports[`Table v2 rendering renders default 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -2942,6 +2944,7 @@ exports[`Table v2 rendering renders default 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -3335,6 +3338,7 @@ exports[`Table v2 rendering renders default 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -3728,6 +3732,7 @@ exports[`Table v2 rendering renders default 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -6044,6 +6049,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -6437,6 +6443,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -6830,6 +6837,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -7223,6 +7231,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>
@@ -7616,6 +7625,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
               <div
                 className="rmTextMargins emotion-43"
                 data-cy="text"
+                title="No data is available."
               >
                 No data is available.
               </div>


### PR DESCRIPTION
When a user sends the wrap prop with the arg of truncate, in the case
that the child is a string, output the child as the title HTML attribute
so that the user and screen readers will get the string in its entirety.

Closes D2IQ-77202

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
