### PR TITLE
feat: new promo banner background gradient

### DIFF
--- a/packages/promo/__snapshots__/promos.test.tsx.snap
+++ b/packages/promo/__snapshots__/promos.test.tsx.snap
@@ -290,7 +290,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
 
 exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
 <div
-  class="css-cht2m7"
+  class="css-dhevp"
   data-cy="spacingBox"
 >
   <div

--- a/packages/promo/components/PromoBanner.tsx
+++ b/packages/promo/components/PromoBanner.tsx
@@ -12,7 +12,7 @@ interface PromoBannerProps extends PromoProps {
 
 const darkGradientStyles: GradientStyle[] = ["purple"];
 
-const PromoBanner: React.StatelessComponent<PromoBannerProps> = ({
+const PromoBanner: React.FunctionComponent<PromoBannerProps> = ({
   bgColor = "",
   gradientStyle,
   isDarkBackground,

--- a/packages/promo/style.ts
+++ b/packages/promo/style.ts
@@ -1,7 +1,9 @@
 import { css } from "emotion";
 import { GradientColors, GradientStyle } from "./types";
 import {
+  blueLighten3,
   blueLighten4,
+  blueLighten5,
   spaceS,
   textBlockWidth,
   themeBgSecondary,
@@ -42,17 +44,30 @@ export const graphicContainer = css`
 
 export const gradientStyles: Record<GradientStyle, GradientColors> = {
   lightBlue: [themeBgSecondary, blueLighten4],
+  oceanBlue: [blueLighten5, blueLighten4, blueLighten3],
   // these colors are not in ui-kit, but this is what was spec'd by the design team
   purple: ["#440099", "#36007A"]
 };
 
-export const getBackgroundGradient = (gradientStyle?: GradientStyle) =>
-  gradientStyle
-    ? css`
-        background-image: linear-gradient(
-          90deg,
-          ${gradientStyles[gradientStyle][0]} 0%,
-          ${gradientStyles[gradientStyle][1]} 100%
-        );
-      `
-    : "";
+export const getBackgroundGradient = (gradientStyle?: GradientStyle) => {
+  if (!gradientStyle) {
+    return "";
+  }
+
+  const stops = gradientStyles[gradientStyle];
+
+  if (gradientStyle === "oceanBlue") {
+    return css`
+      background-image: linear-gradient(
+        90deg,
+        ${stops[0]} 0%,
+        ${stops[1]} 60.84%,
+        ${stops[2]} 100%
+      );
+    `;
+  }
+
+  return css`
+    background-image: linear-gradient(90deg, ${stops[0]} 0%, ${stops[1]} 100%);
+  `;
+};

--- a/packages/promo/style.ts
+++ b/packages/promo/style.ts
@@ -61,7 +61,7 @@ export const getBackgroundGradient = (gradientStyle?: GradientStyle) => {
       background-image: linear-gradient(
         90deg,
         ${stops[0]} 0%,
-        ${stops[1]} 60.84%,
+        ${stops[1]} 45%,
         ${stops[2]} 100%
       );
     `;

--- a/packages/promo/types.ts
+++ b/packages/promo/types.ts
@@ -21,6 +21,6 @@ export interface PromoProps {
   ["data-cy"]?: string;
 }
 
-export type GradientStyle = "lightBlue" | "purple";
-export type GradientColors = [string, string];
+export type GradientStyle = "lightBlue" | "purple" | "oceanBlue";
+export type GradientColors = [string, string, string?];
 export type PromoBackgroundColor = "themeBgSecondary" | "purpleLighten5";


### PR DESCRIPTION
Introducing a new oceanBlue version of the background gradient for the
PromoBanner, which has a specific implementation with three stops.

I considered an alternative of allowing this component to take a custom background color.

Closes D2IQ-77630

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

Have asked design to give me colors that are already in our design system rather than these three custom colors, so I will wait on them to merge this in, but the implementation can be reviewed.

## Screenshots

![Screen Shot 2021-08-09 at 5 05 14 PM](https://user-images.githubusercontent.com/815936/128780806-04543bc8-00a9-43a1-9bea-0ede258fb951.png)



## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
