### PR TITLE
fix: controlled FieldList row deletion

### DIFF
--- a/packages/formStructure/components/FieldList.tsx
+++ b/packages/formStructure/components/FieldList.tsx
@@ -91,6 +91,10 @@ const FieldListRow: React.FC<FieldListRowProps> = React.memo(
       }
     };
 
+    const handleRowClick = () => {
+      fieldListContext?.removeListItem(rowIndex);
+    };
+
     return (
       <div className={getFieldRowGrid(columns, iconSizes[REMOVE_ICON_SIZE])}>
         {columns.map((col, i) => {
@@ -126,7 +130,7 @@ const FieldListRow: React.FC<FieldListRowProps> = React.memo(
         {/* this wrapper div is needed to fix a vertical centering bug in Firefox with <button> elements that are children of display: grid */}
         <div>
           <ResetButton
-            onClick={fieldListContext?.removeListItem(rowIndex)}
+            onClick={handleRowClick}
             disabled={isRowDisabled(rowIndex, disabledRows)}
             onKeyUp={addEmptyRow}
             data-cy="fieldList-removeButton"

--- a/packages/formStructure/components/FieldListContext.tsx
+++ b/packages/formStructure/components/FieldListContext.tsx
@@ -10,7 +10,7 @@ type FieldListContext = {
     rowId?: string | number,
     itemToAdd?: Record<string, any>
   ) => void;
-  removeListItem: (rowIndex: number) => () => void;
+  removeListItem: (rowIndex: number) => void;
 };
 
 export const Context = React.createContext<FieldListContext | null>(null);
@@ -46,12 +46,11 @@ export const FieldListProvider: React.FC<FieldListProviderProps> = ({
 
   const removeListItem = (rowIndex: number) => {
     if (onRemoveItem) {
-      return onRemoveItem(rowIndex);
+      const handleRemove = onRemoveItem(rowIndex);
+      handleRemove();
     }
 
-    return () => {
-      setData(data.filter((_, i) => rowIndex !== i));
-    };
+    setData(data.filter((_, i) => rowIndex !== i));
   };
 
   return (


### PR DESCRIPTION
It seemed as though the onRemoveItem was never actually being called
based on the way that it was written, because the useEffect would not
fire, thus you'd end up with rendering issues. By tweaking a bit how
this function is called in the context, it appears to fix the issue.

I don't know why this callback function was written with the additional
closure, but I preserved it to maintain backwards compatibility.

Addresses D2IQ-77909

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
