### PR TITLE
BreadcrumbItem Component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,6 +18,15 @@ module.exports = {
   addons: [
     "@storybook/addon-knobs",
     "@storybook/addon-essentials",
-    "@storybook/addon-a11y"
+    "@storybook/addon-a11y",
+    {
+      name: "@storybook/addon-docs",
+      options: {
+        configureJSX: true,
+        babelOptions: {},
+        sourceLoaderOptions: null,
+        transcludeMarkdown: true
+      }
+    }
   ]
 };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ info
 
 After this there is a web server started at the address http://localhost:6006 which is hosting storybook. This is our documentation from the local repository. Anything you change will reflect there directly.
 
-After you're happy with your channges, create a commit by using `git commit` or using [git cz](http://commitizen.github.io/cz-cli/).
+After you're happy with your changes, create a commit by using `git commit` or using [git cz](http://commitizen.github.io/cz-cli/).
 
 Finally, push and create a pull request 🎉
 
@@ -83,13 +83,13 @@ When a new component is being created, work with the design team to document des
 #### Consider the Following Before Adding a New Component
 
 **Is it likely this component be used in more than 1 app?**
-For example, a component for a card that may contain any content would be a good candidate for ui-kit. A card that specifically renders data specific to an object in an napp is not.
+For example, a component for a card that may contain any content would be a good candidate for ui-kit. A card that specifically renders data specific to an object in an app is not.
 
 **Does it fit in with a "theme" of other components in the UI Kit?**
-For example, if we have a toast and an inline alert box, a page banner would make sense to exist in the ui-kit
+For example, if we have a toast and an inline alert box, a page banner would make sense to exist in the ui-kit.
 
 **Is the effort that goes into building and maintaining it as a reusable component worth the payoff?**
-For example, Table and it's related components are complex components to properly maintain, but it's such a heavily used pattern in our apps, that it's worth the effort
+For example, Table and it's related components are complex components to properly maintain, but it's such a heavily used pattern in our apps, that it's worth the effort.
 
 **Will side effects of adding this component help us move the design system forward?**
 For example, adding a toast component forces us to think about visual indication of alert status (error, success, warning, etc.), z-index stacking context, accessibility guidelines, and how we animate a piece of UI in and out of the viewport.
@@ -176,7 +176,7 @@ We can't assume how our customers use their computer. We need to consider human 
 | ----------------------------- | -------------------------- |
 | - Use a mouse                 | - Keyboard support         |
 | - See low-contrast text       | - Highly readable text     |
-| - See a screen at all         | - Screenreader support     |
+| - See a screen at all         | - Screen reader support    |
 | - Hear sounds                 | - Captions and transcripts |
 | - Understand complex language | - Plain language           |
 
@@ -184,7 +184,7 @@ Accessibility and universal design are huge topics. If you want to learn more, [
 
 #### Configuration Objects
 
-Please consider using configuration objects as they will provide the user a lot of value by
+Please consider using configuration objects as they will provide the user a lot of value by:
 
 - consistency
 - less typing needed
@@ -253,9 +253,9 @@ We are supporting the conventional commit types as follows:
 
 ### JIRA Integration
 
-`semantic-release-jira` plugin automaticallly can update your Mesosphere JIRA issues labels with UI-Kit release version, if you add it as footer to your commit message.
+`semantic-release-jira` plugin automatically can update your Mesosphere JIRA issues labels with UI-Kit release version, if you add it as footer to your commit message.
 
-You can use `Updates`, `Closes` or `Resolves` statements (they all have the same effect tho) and add multiple JIRAs by seprarating them by comma.
+You can use `Updates`, `Closes` or `Resolves` statements (they all have the same effect tho) and add multiple JIRAs by separating them by comma.
 
 Examples Commit message:
 
@@ -265,7 +265,7 @@ fix(Table): fix lorem so that it enables foo
 this commit body message describes the commit
 
 BREAKING CHANGE
-Before this fix foo wasnt enabled at all, behavior changes from <old> to <new>
+Before this fix foo wasn't enabled at all, behavior changes from <old> to <new>
 
 Closes DCOS_OSS-12345, Closes DCOS-23456
 ```

--- a/packages/breadcrumb/components/BreadcrumbItem.tsx
+++ b/packages/breadcrumb/components/BreadcrumbItem.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { IconShapes } from "../../icon/components/Icon";
+import ResetLink from "../../link/components/ResetLink";
+import IconPropAdapter from "../../icon/components/IconPropAdapter";
+import { Flex, FlexItem } from "../../styleUtils/layout";
+
+interface BreadcrumbItemProps {
+  icon?: IconShapes | React.ReactElement<HTMLElement>;
+  url?: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+const BreadcrumbItem = ({
+  icon,
+  url,
+  onClick,
+  children
+}: BreadcrumbItemProps) => {
+  const content =
+    url || onClick ? (
+      <ResetLink url={url} onClick={onClick}>
+        {children}
+      </ResetLink>
+    ) : (
+      <span>{children}</span>
+    );
+
+  return icon ? (
+    <Flex align="center" gutterSize="m">
+      <FlexItem flex="shrink">
+        <IconPropAdapter icon={icon} size="s" color="inherit" />
+      </FlexItem>
+      <FlexItem>{content}</FlexItem>
+    </Flex>
+  ) : (
+    content
+  );
+};
+
+export default BreadcrumbItem;

--- a/packages/breadcrumb/index.ts
+++ b/packages/breadcrumb/index.ts
@@ -1,1 +1,2 @@
 export { default as Breadcrumb } from "./components/Breadcrumb";
+export { default as BreadcrumbItem } from "./components/BreadcrumbItem";

--- a/packages/breadcrumb/stories/Breadcrumb.stories.tsx
+++ b/packages/breadcrumb/stories/Breadcrumb.stories.tsx
@@ -1,23 +1,38 @@
 import * as React from "react";
 
-import { Breadcrumb } from "../index";
+import { Breadcrumb, BreadcrumbItem } from "../index";
+
+import { action } from "@storybook/addon-actions";
+import { ProductIcons } from "../../icons/dist/product-icons-enum";
 
 export default {
   title: "Navigation/Breadcrumb",
-  component: Breadcrumb
+  component: Breadcrumb,
+  subcomponents: { BreadcrumbItem }
 };
 
 export const Default = () => (
   <Breadcrumb>
     <span>One</span>
-    <span>
-      T<em>wo</em>
-    </span>
+    <span>Two</span>
   </Breadcrumb>
 );
 
-export const TopLevelBreadcrumb = () => (
+export const WithBreadcrumbItems = () => (
   <Breadcrumb>
-    <span>One</span>
+    <BreadcrumbItem
+      icon={ProductIcons.Gear}
+      onClick={action("clicked breadcrumb item one")}
+    >
+      One
+    </BreadcrumbItem>
+    <BreadcrumbItem onClick={action("clicked breadcrumb item two")}>
+      Two
+    </BreadcrumbItem>
+    <BreadcrumbItem onClick={action("clicked breadcrumb item three")}>
+      Three
+    </BreadcrumbItem>
   </Breadcrumb>
 );
+
+WithBreadcrumbItems.storyName = "With BreadcrumbItem";

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -22,7 +22,7 @@ export {
   AccordionItemTitleInteractive
 } from "./accordion";
 export { Badge, BadgeButton, ColorCodedBadge } from "./badge";
-export { Breadcrumb } from "./breadcrumb";
+export { Breadcrumb, BreadcrumbItem } from "./breadcrumb";
 export {
   PrimaryButton,
   SecondaryButton,


### PR DESCRIPTION
The `BreadcrumbItem` component can be utilized to reduce common formatting utilizing FlexItems, frequently used within Kommander UI `Breadcrumb` component usage. 

`BreadcrumbItem` offers the option of an icon, url, onClick functionality, and children. All with formatted style to align with common usage. 

I have reduced the Stories to simply display the previous without and with `BreadcrumbItem`, for the sake of reducing our story files any additional examples are probably superfluous here. 

Changes to `main.js` are to ensure stories display their code examples in the Docs tab. 

I have also corrected some spelling/grammar errors in the contributing documentation while reading through for info on adding a new component. 

Closes D2IQ-65928

<!-- See Checklist for PR creators below. -->

## Testing

Run Storybook and view BreadcrumbItem story. 
<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [x] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
