### PR TITLE
Fix for Flexbox spacing issues with Emotion 11 updates

### DIFF
--- a/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
+++ b/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
@@ -52,9 +52,14 @@ exports[`CodeSnippet renders default 1`] = `
   width: auto;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (column-gap: 1px) {
   .emotion-3>*:not(:last-child) {
     padding-right: 0;
+  }
+}
+
+@supports not (row-gap: 1px) {
+  .emotion-3>*:not(:last-child) {
     padding-bottom: 0;
   }
 }
@@ -185,9 +190,8 @@ exports[`CodeSnippet renders with copy button 1`] = `
   padding: 16px;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (row-gap: 1px) {
   .emotion-3>*:not(:last-child) {
-    padding-right: 0;
     padding-bottom: 0;
   }
 }
@@ -222,6 +226,12 @@ exports[`CodeSnippet renders with copy button 1`] = `
 
 .emotion-3>div {
   width: auto;
+}
+
+@supports not (column-gap: 1px) {
+  .emotion-3>*:not(:last-child) {
+    padding-right: 0;
+  }
 }
 
 .emotion-4 {

--- a/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
+++ b/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
@@ -74,9 +74,14 @@ exports[`Sidebar renders 1`] = `
   width: auto;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (column-gap: 1px) {
   .emotion-2>*:not(:last-child) {
     padding-right: 0;
+  }
+}
+
+@supports not (row-gap: 1px) {
+  .emotion-2>*:not(:last-child) {
     padding-bottom: 0;
   }
 }

--- a/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`MessagePanel renders with primary and secondary actions 1`] = `
         Body content
       </div>
       <div
-        class="css-mofsq3"
+        class="css-jtsifh"
         data-cy="flex"
       >
         <div

--- a/packages/messagePanel/tests/__snapshots__/messagePanelWithGraphic.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanelWithGraphic.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`MessagePanelWithGraphic renders with primary and secondary actions 1`] 
     </div>
   </div>
   <div
-    class="css-mofsq3"
+    class="css-jtsifh"
     data-cy="flex"
   >
     <div

--- a/packages/promo/__snapshots__/promos.test.tsx.snap
+++ b/packages/promo/__snapshots__/promos.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Promos renders PromoBanner 1`] = `
       </div>
     </button>
     <div
-      class="css-npch7t"
+      class="css-1qfp4eg"
       data-cy="flex"
     >
       <div
@@ -62,7 +62,7 @@ exports[`Promos renders PromoBanner 1`] = `
             Some promo details
           </div>
           <div
-            class="css-dfgl6y"
+            class="css-1z0oasc"
             data-cy="flex"
           >
             <div
@@ -177,7 +177,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
       </div>
     </button>
     <div
-      class="css-npch7t"
+      class="css-1qfp4eg"
       data-cy="flex"
     >
       <div
@@ -206,7 +206,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
             Some promo details
           </div>
           <div
-            class="css-dfgl6y"
+            class="css-1z0oasc"
             data-cy="flex"
           >
             <div
@@ -321,7 +321,7 @@ exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
       </div>
     </button>
     <div
-      class="css-npch7t"
+      class="css-1qfp4eg"
       data-cy="flex"
     >
       <div
@@ -350,7 +350,7 @@ exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
             Some promo details
           </div>
           <div
-            class="css-dfgl6y"
+            class="css-1z0oasc"
             data-cy="flex"
           >
             <div
@@ -472,7 +472,7 @@ exports[`Promos renders PromoInline 1`] = `
           </div>
         </button>
         <div
-          class="css-npch7t"
+          class="css-1qfp4eg"
           data-cy="flex"
         >
           <div
@@ -501,7 +501,7 @@ exports[`Promos renders PromoInline 1`] = `
                 Some promo details
               </div>
               <div
-                class="css-dfgl6y"
+                class="css-1z0oasc"
                 data-cy="flex"
               >
                 <div

--- a/packages/shared/styles/styleUtils/layout/flexbox.ts
+++ b/packages/shared/styles/styleUtils/layout/flexbox.ts
@@ -73,7 +73,7 @@ const getGutterPaddingValues = (responsivePaddingConfig, gutterSize) => {
     }, {});
 
   // override gutter values that need to be set to "none"
-  const overideGutters = spacingSize => ({
+  const overrideGutters = spacingSize => ({
     ...gutterSize,
     ...breakpointsToRemovePadding(spacingSize)
   });
@@ -81,8 +81,8 @@ const getGutterPaddingValues = (responsivePaddingConfig, gutterSize) => {
   // remove any properties for breakpoints that did not have a responsive `direction` prop
   Object.keys(responsivePaddingConfig).forEach(
     key =>
-      (paddingValues[key] = (key in overideGutters(responsivePaddingConfig)
-        ? overideGutters(responsivePaddingConfig)
+      (paddingValues[key] = (key in overrideGutters(responsivePaddingConfig)
+        ? overrideGutters(responsivePaddingConfig)
         : responsivePaddingConfig)[key])
   );
 
@@ -132,12 +132,12 @@ export const applyFlexItemGutters = (direction, gutterSize) => {
     return;
   }
 
-  const rowGuttter = getResponsiveColumnStyles(direction, gutterSize, "none");
+  const rowGutter = getResponsiveColumnStyles(direction, gutterSize, "none");
   const columnGutter = getResponsiveColumnStyles(direction, "none", gutterSize);
   const rowGap =
-    typeof rowGuttter === "object"
-      ? getGutterPaddingValues(rowGuttter, gutterSize)
-      : rowGuttter;
+    typeof rowGutter === "object"
+      ? getGutterPaddingValues(rowGutter, gutterSize)
+      : rowGutter;
   const columnGap =
     typeof columnGutter === "object"
       ? getGutterPaddingValues(columnGutter, gutterSize)
@@ -147,9 +147,15 @@ export const applyFlexItemGutters = (direction, gutterSize) => {
     ${getResponsiveSpacingStyle("column-gap", columnGap)};
     ${getResponsiveSpacingStyle("row-gap", rowGap)};
 
-    @supports (column-gap: 1px) and (row-gap: 1px) {
+    // If column-gap or row-gap are not supported by the browser utilize padding for spacing
+    @supports not (column-gap: 1px) {
       > *:not(:last-child) {
         ${getResponsiveSpacingStyle("padding-right", columnGap)};
+      }
+    }
+
+    @supports not (row-gap: 1px) {
+      > *:not(:last-child) {
         ${getResponsiveSpacingStyle("padding-bottom", rowGap)};
       }
     }

--- a/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
+++ b/packages/styleUtils/layout/flexbox/stories/flex.stories.tsx
@@ -7,6 +7,7 @@ import FlexItem from "../components/FlexItem";
 import styled from "@emotion/styled";
 import { SpaceSize } from "../../../../shared/styles/styleUtils/modifiers/modifierUtils";
 import { css } from "@emotion/css";
+import { DangerButton, SecondaryButton } from "../../../../button";
 
 const DemoChild = styled("div")`
   background-color: white;
@@ -393,5 +394,16 @@ export const Wrap = () => {
         </SpacingBox>
       </div>
     </div>
+  );
+};
+
+export const WithButtons = () => {
+  return (
+    <SpacingBox spacingSize="m">
+      <Flex gutterSize="s" align="center">
+        <DangerButton>Delete License</DangerButton>
+        <SecondaryButton>Go to Support Portal</SecondaryButton>
+      </Flex>
+    </SpacingBox>
   );
 };

--- a/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
+++ b/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
@@ -33,9 +33,14 @@ exports[`Flex renders default 1`] = `
   width: auto;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (column-gap: 1px) {
   .emotion-0>*:not(:last-child) {
     padding-right: 0;
+  }
+}
+
+@supports not (row-gap: 1px) {
+  .emotion-0>*:not(:last-child) {
     padding-bottom: 0;
   }
 }
@@ -90,9 +95,14 @@ exports[`Flex renders with all props 1`] = `
   width: 100%;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (column-gap: 1px) {
   .emotion-0>*:not(:last-child) {
     padding-right: 0;
+  }
+}
+
+@supports not (row-gap: 1px) {
+  .emotion-0>*:not(:last-child) {
     padding-bottom: 24px;
   }
 }
@@ -115,12 +125,12 @@ exports[`Flex renders with all props 1`] = `
 `;
 
 exports[`Flex renders with responsive props 1`] = `
-@media (min-width: 0) {
+@media (min-width: 900px) {
   .emotion-0 {
-    -webkit-box-pack: start;
-    -ms-flex-pack: start;
-    -webkit-justify-content: flex-start;
-    justify-content: flex-start;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
   }
 }
 
@@ -190,19 +200,19 @@ exports[`Flex renders with responsive props 1`] = `
 
 @media (min-width: 0) {
   .emotion-0 {
+    -webkit-box-pack: start;
+    -ms-flex-pack: start;
+    -webkit-justify-content: flex-start;
+    justify-content: flex-start;
+  }
+}
+
+@media (min-width: 0) {
+  .emotion-0 {
     -webkit-align-items: flex-start;
     -webkit-box-align: flex-start;
     -ms-flex-align: flex-start;
     align-items: flex-start;
-  }
-}
-
-@media (min-width: 900px) {
-  .emotion-0 {
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
   }
 }
 
@@ -244,7 +254,7 @@ exports[`Flex renders with responsive props 1`] = `
   }
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (column-gap: 1px) {
   @media (min-width: 0) {
     .emotion-0>*:not(:last-child) {
       padding-right: 0;
@@ -256,7 +266,9 @@ exports[`Flex renders with responsive props 1`] = `
       padding-right: 16px;
     }
   }
+}
 
+@supports not (row-gap: 1px) {
   @media (min-width: 0) {
     .emotion-0>*:not(:last-child) {
       padding-bottom: 12px;

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -450,7 +450,7 @@ exports[`Table v2 rendering renders default 1`] = `
                 wrap="nowrap"
               >
                 <div
-                  className="css-1tn66z7"
+                  className="css-mxutz3"
                   data-cy="flex"
                 >
                   <FlexItem
@@ -3740,7 +3740,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                 wrap="nowrap"
               >
                 <div
-                  className="css-1tn66z7"
+                  className="css-mxutz3"
                   data-cy="flex"
                 >
                   <FlexItem

--- a/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
@@ -140,9 +140,8 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
   justify-content: center;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (row-gap: 1px) {
   .emotion-4>*:not(:last-child) {
-    padding-right: 4px;
     padding-bottom: 0;
   }
 }
@@ -177,6 +176,12 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
 
 .emotion-4>div {
   width: auto;
+}
+
+@supports not (column-gap: 1px) {
+  .emotion-4>*:not(:last-child) {
+    padding-right: 4px;
+  }
 }
 
 .emotion-5 {
@@ -902,9 +907,8 @@ exports[`TextInputWithBadges renders with badges 1`] = `
   justify-content: center;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (row-gap: 1px) {
   .emotion-4>*:not(:last-child) {
-    padding-right: 4px;
     padding-bottom: 0;
   }
 }
@@ -939,6 +943,12 @@ exports[`TextInputWithBadges renders with badges 1`] = `
 
 .emotion-4>div {
   width: auto;
+}
+
+@supports not (column-gap: 1px) {
+  .emotion-4>*:not(:last-child) {
+    padding-right: 4px;
+  }
 }
 
 .emotion-5 {

--- a/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
+++ b/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ToggleBoxGroup renders default 1`] = `
+@supports not (row-gap: 1px) {
+  .emotion-0>*:not(:last-child) {
+    padding-bottom: 0;
+  }
+}
+
 .emotion-0 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -33,14 +39,17 @@ exports[`ToggleBoxGroup renders default 1`] = `
   width: auto;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (column-gap: 1px) {
   .emotion-0>*:not(:last-child) {
     padding-right: 16px;
-    padding-bottom: 0;
   }
 }
 
 .emotion-1>* {
+  height: 100%;
+}
+
+.emotion-2>* {
   height: 100%;
 }
 
@@ -55,10 +64,6 @@ exports[`ToggleBoxGroup renders default 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
-}
-
-.emotion-2>* {
-  height: 100%;
 }
 
 .emotion-3 {
@@ -358,6 +363,12 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
   font-weight: 500;
 }
 
+@supports not (row-gap: 1px) {
+  .emotion-2>*:not(:last-child) {
+    padding-bottom: 0;
+  }
+}
+
 .emotion-2 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -390,18 +401,13 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
   width: auto;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (column-gap: 1px) {
   .emotion-2>*:not(:last-child) {
     padding-right: 16px;
-    padding-bottom: 0;
   }
 }
 
 .emotion-3>* {
-  height: 100%;
-}
-
-.emotion-4>* {
   height: 100%;
 }
 
@@ -416,6 +422,10 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
+}
+
+.emotion-4>* {
+  height: 100%;
 }
 
 .emotion-5 {
@@ -710,10 +720,6 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
 `;
 
 exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
-.emotion-0>div {
-  width: auto;
-}
-
 .emotion-0 {
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -742,14 +748,27 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
   row-gap: 0;
 }
 
-@supports (column-gap: 1px) and (row-gap: 1px) {
+.emotion-0>div {
+  width: auto;
+}
+
+@supports not (column-gap: 1px) {
   .emotion-0>*:not(:last-child) {
     padding-right: 16px;
+  }
+}
+
+@supports not (row-gap: 1px) {
+  .emotion-0>*:not(:last-child) {
     padding-bottom: 0;
   }
 }
 
 .emotion-1>* {
+  height: 100%;
+}
+
+.emotion-2>* {
   height: 100%;
 }
 
@@ -764,10 +783,6 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
-}
-
-.emotion-2>* {
-  height: 100%;
 }
 
 .emotion-3 {
@@ -1089,10 +1104,15 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
 `;
 
 exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
-@supports (column-gap: 1px) and (row-gap: 1px) {
+@supports not (row-gap: 1px) {
+  .emotion-0>*:not(:last-child) {
+    padding-bottom: 48px;
+  }
+}
+
+@supports not (column-gap: 1px) {
   .emotion-0>*:not(:last-child) {
     padding-right: 0;
-    padding-bottom: 48px;
   }
 }
 
@@ -1169,10 +1189,6 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
   height: 100%;
 }
 
-.emotion-6>div {
-  height: 100%;
-}
-
 .emotion-6:hover,
 .emotion-6:focus,
 .emotion-6:focus-within {
@@ -1182,6 +1198,10 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
 
 .emotion-6:active {
   box-shadow: 0 0 0 2px var(--themeBrandPrimary, #7D58FF);
+}
+
+.emotion-6>div {
+  height: 100%;
 }
 
 .emotion-6 {


### PR DESCRIPTION
This issue was unearthed with the Emotion 11 updates. There were a few places in Kommander UI on Emotion 11 that displayed slightly off spacing, due to the padding-right and padding-bottom being added in the `Flex` component. 

It is possible that the `@support` feature query was not actually being applied until everything became updated. The feature query should be used to apply padding when the browser does not support `row-gap` or `column-gap`. According to [caniuse](https://caniuse.com/?search=column-gap) it's mostly applicable for IE and common browser versions prior to ~2017. We may decide to remove this feature query in the future if it is confirmed that we no longer need to support IE. 

[More info on how Feature Query works.](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports)


## Testing

View Flexbox story 'With Buttons', which gives a sandbox replicating the issue and fix. 

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots


Seen in Kommander UI. 👇

<img width="1353" alt="Screen Shot 2021-09-24 at 11 11 55 AM" src="https://user-images.githubusercontent.com/34781875/134711137-da1f94c1-d427-44fe-955c-8b16fc144882.png">


Before:

<img width="586" alt="Screen Shot 2021-09-23 at 3 36 28 PM" src="https://user-images.githubusercontent.com/34781875/134711156-16de646d-b0d0-41be-8b04-d527a4937626.png">



After:

<img width="647" alt="Screen Shot 2021-09-23 at 3 36 56 PM" src="https://user-images.githubusercontent.com/34781875/134711097-ac898080-fd9c-4b56-88a4-217d62fc1747.png">
<!-- See Checklist for PR creators below. -->
<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
