### PR TITLE
fix: for console errors found in kommander

### DIFF
--- a/packages/textInput/components/TextInputWithBadges.tsx
+++ b/packages/textInput/components/TextInputWithBadges.tsx
@@ -77,6 +77,7 @@ export class TextInputWithBadges extends TextInputWithIcon<
       onBadgeChange,
       downshiftReset,
       addBadgeOnBlur,
+      badgeAppearance,
       ...inputProps
     } = baseProps as TextInputWithBadgesProps;
     inputProps.onKeyDown = this.handleKeyDown;
@@ -97,7 +98,8 @@ export class TextInputWithBadges extends TextInputWithIcon<
 
   protected getInputContent() {
     const inputAppearance = this.getInputAppearance();
-    const { badgeAppearance = "primary" } = this.props;
+    const { hintContent, badgeAppearance = "primary" } = this.props;
+
     return (
       <FormFieldWrapper
         // TODO: figure out how to get rid of this non-null assertion
@@ -105,10 +107,10 @@ export class TextInputWithBadges extends TextInputWithIcon<
         // it would be possible for `this.props.id` to be undefined
         id={this.props.id!}
         errors={this.props.errors}
-        hintContent={this.props.hintContent}
+        hintContent={hintContent}
       >
         {({ getValidationErrors, getHintContent, isValid, describedByIds }) => (
-          <React.Fragment>
+          <>
             <div
               className={cx(
                 flex({ wrap: "wrap" }),
@@ -119,33 +121,35 @@ export class TextInputWithBadges extends TextInputWithIcon<
             >
               {this.getIconStartContent()}
               {this.props.badges &&
-                this.props.badges.map(badge => (
-                  <span
-                    className={badgeInputContents}
-                    key={`${badge.value}-badgeWrapper`}
-                  >
-                    <Badge appearance={badgeAppearance}>
-                      <Flex align="center" gutterSize="xxs">
-                        <FlexItem>
-                          <div className={cx(textTruncate, badgeText)}>
-                            {typeof badge.label === "string"
-                              ? badge.label.replace(/\s/g, "\u00a0")
-                              : badge.label}
-                          </div>
-                        </FlexItem>
-                        <FlexItem flex="shrink">
-                          <Clickable
-                            action={this.onBadgeClose.bind(this, badge)}
-                          >
-                            <span>
-                              <Icon shape={SystemIcons.Close} size="xxs" />
-                            </span>
-                          </Clickable>
-                        </FlexItem>
-                      </Flex>
-                    </Badge>
-                  </span>
-                ))}
+                this.props.badges.map(badge => {
+                  return (
+                    <span
+                      className={badgeInputContents}
+                      key={`${badge.value}-badgeWrapper`}
+                    >
+                      <Badge appearance={badgeAppearance}>
+                        <Flex align="center" gutterSize="xxs">
+                          <FlexItem>
+                            <div className={cx(textTruncate, badgeText)}>
+                              {typeof badge.label === "string"
+                                ? badge.label.replace(/\s/g, "\u00a0")
+                                : badge.label}
+                            </div>
+                          </FlexItem>
+                          <FlexItem flex="shrink">
+                            <Clickable
+                              action={this.onBadgeClose.bind(this, badge)}
+                            >
+                              <span>
+                                <Icon shape={SystemIcons.Close} size="xxs" />
+                              </span>
+                            </Clickable>
+                          </FlexItem>
+                        </Flex>
+                      </Badge>
+                    </span>
+                  );
+                })}
               {this.getInputElement(
                 [badgeInput, badgeInputContents, flexItem("grow")],
                 isValid,
@@ -155,7 +159,7 @@ export class TextInputWithBadges extends TextInputWithIcon<
             </div>
             {getHintContent}
             {getValidationErrors}
-          </React.Fragment>
+          </>
         )}
       </FormFieldWrapper>
     );
@@ -173,11 +177,11 @@ export class TextInputWithBadges extends TextInputWithIcon<
   }
 
   private handleTagAdd(tagToAdd: BadgeDatum) {
-    const { onBadgeChange, badges = [] } = this.props;
+    const { onBadgeChange, badges = [], downshiftReset } = this.props;
     const badgeValues = badges.map(badge => badge.value);
 
-    if (this.props.downshiftReset) {
-      this.props.downshiftReset();
+    if (downshiftReset) {
+      downshiftReset();
     }
 
     if (

--- a/packages/toaster/components/Toaster.tsx
+++ b/packages/toaster/components/Toaster.tsx
@@ -42,7 +42,7 @@ class Toaster extends React.PureComponent<ToasterProps, { toasts: Toast[] }> {
     this.restartTimeouts();
   }
 
-  public componentWillReceiveProps(props: ToasterProps) {
+  public UNSAFE_componentWillReceiveProps(props: ToasterProps) {
     const children = React.Children.toArray(props.children);
     const childIds = children.map(toast => toast.props.id);
     const currentIds = this.state.toasts.map(toast => toast.props.id);

--- a/packages/toaster/tests/Toaster.test.tsx
+++ b/packages/toaster/tests/Toaster.test.tsx
@@ -101,7 +101,7 @@ describe("Toaster", () => {
     const instance = component.find(Toaster).instance() as Toaster;
 
     expect(instance.state.toasts.length).toEqual(1);
-    instance.componentWillReceiveProps(newProps);
+    instance.UNSAFE_componentWillReceiveProps(newProps);
     expect(instance.state.toasts.length).toEqual(2);
   });
 });


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

Many of these errors were due to the pass-through props on the `TextInputWithBadges`.

I would like to fix the lifecycle methods more so when we are able to have time to incrementally update and convert UI Kit components. 

## Testing

Check console errors while Storybook is running.

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
