### PR TITLE
Update tabs and add story controls

### DIFF
--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -34,11 +34,12 @@ injectGlobal`
   cursor: pointer;
   font-weight: ${fontWeightMedium};
   color: ${themeTextColorPrimary};
+
   &:after{
     content: "";
     position: absolute;
     background: ${themeBrandPrimary};
-    display:none;
+    display: none;
   }
 }
 
@@ -80,66 +81,62 @@ export interface TabsProps {
   direction?: TabDirection;
 }
 
-class Tabs extends React.PureComponent<TabsProps, {}> {
-  public render() {
-    const {
-      children,
-      selectedIndex,
-      onSelect,
-      direction = defaultTabDirection
-    } = this.props;
+const Tabs = ({
+  children,
+  selectedIndex,
+  onSelect,
+  direction = defaultTabDirection
+}: TabsProps) => {
+  const { tabs, tabsContent } = React.Children.toArray(children)
+    .filter(item => React.isValidElement<TabItemProps>(item))
+    .reduce<{
+      tabs: React.ReactNodeArray;
+      tabsContent: React.ReactNodeArray;
+    }>(
+      (acc, item) => {
+        const { tabs = [], tabsContent = [] } = acc;
+        const { children } = item.props;
+        const key = item.key ? item.key : undefined;
+        const childrenWithKeys = React.Children.toArray(children).map(child =>
+          React.isValidElement<TabTitle>(child)
+            ? React.cloneElement(child, { key })
+            : child
+        );
 
-    const { tabs, tabsContent } = React.Children.toArray(children)
-      .filter(item => React.isValidElement<TabItemProps>(item))
-      .reduce<{
-        tabs: React.ReactNodeArray;
-        tabsContent: React.ReactNodeArray;
-      }>(
-        (acc, item) => {
-          const { tabs = [], tabsContent = [] } = acc;
-          const { children } = item.props;
-          const key = item.key ? item.key : undefined;
-          const childrenWithKeys = React.Children.toArray(children).map(child =>
-            React.isValidElement<TabTitle>(child)
-              ? React.cloneElement(child, { key })
-              : child
-          );
-
-          const title = childrenWithKeys.find(
-            child =>
-              React.isValidElement<TabTitle>(child) && child.type === TabTitle
-          );
-          const tabChildren = childrenWithKeys.filter(
-            child => !(React.isValidElement(child) && child.type === TabTitle)
-          );
-          return {
-            tabs: [...tabs, title],
-            tabsContent: [
-              ...tabsContent,
-              ...(tabChildren.length
-                ? [<TabPanel key={key}>{tabChildren}</TabPanel>]
-                : [])
-            ]
-          };
-        },
-        { tabs: [], tabsContent: [] }
-      );
-
-    return (
-      <ReactTabs
-        className={cx("react-tabs", {
-          [fullHeightTabs]: Boolean(tabsContent.length),
-          [getTabLayout(direction)]: Boolean(direction)
-        })}
-        selectedIndex={selectedIndex}
-        onSelect={onSelect}
-        data-cy="tabs"
-      >
-        <TabList>{tabs}</TabList>
-        {tabsContent}
-      </ReactTabs>
+        const title = childrenWithKeys.find(
+          child =>
+            React.isValidElement<TabTitle>(child) && child.type === TabTitle
+        );
+        const tabChildren = childrenWithKeys.filter(
+          child => !(React.isValidElement(child) && child.type === TabTitle)
+        );
+        return {
+          tabs: [...tabs, title],
+          tabsContent: [
+            ...tabsContent,
+            ...(tabChildren.length
+              ? [<TabPanel key={key}>{tabChildren}</TabPanel>]
+              : [])
+          ]
+        };
+      },
+      { tabs: [], tabsContent: [] }
     );
-  }
-}
 
-export default Tabs;
+  return (
+    <ReactTabs
+      className={cx("react-tabs", {
+        [fullHeightTabs]: Boolean(tabsContent.length),
+        [getTabLayout(direction)]: Boolean(direction)
+      })}
+      selectedIndex={selectedIndex}
+      onSelect={onSelect}
+      data-cy="tabs"
+    >
+      <TabList>{tabs}</TabList>
+      {tabsContent}
+    </ReactTabs>
+  );
+};
+
+export default React.memo(Tabs);

--- a/packages/tabs/stories/Tabs.stories.tsx
+++ b/packages/tabs/stories/Tabs.stories.tsx
@@ -1,49 +1,62 @@
 import * as React from "react";
 import { TabTitle, Tabs, TabItem } from "../index";
-import { TabDirection } from "../components/Tabs";
+import { TabsProps } from "../components/Tabs";
+import { Story, Meta } from "@storybook/react";
 
-class Example extends React.Component<
-  { direction?: TabDirection },
-  Partial<{ selectedIndex: number }>
-> {
-  state = { selectedIndex: 0 };
-  handleSelect = selectedIndex => {
-    this.setState({ selectedIndex });
-  };
-  render() {
-    const { selectedIndex } = this.state;
-    return (
-      <Tabs
-        selectedIndex={selectedIndex}
-        onSelect={this.handleSelect}
-        direction={this.props.direction}
-      >
-        <TabItem>
-          <TabTitle>Tab 1 Name</TabTitle>
-          <div>First tab Content</div>
-        </TabItem>
-        <TabItem>
-          <TabTitle>Tab 2 Name</TabTitle>
-          Second Tab Content
-        </TabItem>
-      </Tabs>
-    );
-  }
-}
+const TabsStory = ({ direction }: TabsProps) => {
+  const [selectedIndex, setSelectedIndex] = React.useState(0);
+
+  return (
+    <Tabs
+      selectedIndex={selectedIndex}
+      onSelect={setSelectedIndex}
+      direction={direction}
+    >
+      <TabItem>
+        <TabTitle>Tab 1</TabTitle>
+        Tab content.
+      </TabItem>
+      <TabItem>
+        <TabTitle>Tab 2</TabTitle>
+        Tab content.
+      </TabItem>
+    </Tabs>
+  );
+};
 
 export default {
   title: "Navigation/Tabs",
   component: Tabs,
-  subcomponents: { Tabs, TabTitle, TabItem }
-};
+  subcomponents: { Tabs, TabTitle, TabItem },
+  argTypes: {
+    direction: {
+      options: ["horiz", "vert"],
+      control: { type: "radio" }
+    },
+    onSelect: {
+      table: {
+        disable: true
+      }
+    },
+    selectedIndex: {
+      table: {
+        disable: true
+      }
+    }
+  }
+} as Meta;
 
-export const Default = () => <Example />;
+const Template: Story<TabsProps> = args => <TabsStory {...args} />;
 
-export const Vertical = () => <Example direction="vert" />;
+export const Default = Template.bind({});
+Default.args = { direction: "horiz" };
 
-export const Responsive = () => (
+export const Responsive = args => (
   <>
-    <p>Resize your viewport width to see the tab direction change</p>
-    <Example direction={{ medium: "vert" }} />
+    <p>Resize the viewport width to see the tab direction change 👇</p>
+    <TabsStory direction={{ medium: "vert" }} {...args} />
   </>
 );
+Responsive.args = {
+  direction: { medium: "vert" }
+};

--- a/packages/tabs/style.ts
+++ b/packages/tabs/style.ts
@@ -15,7 +15,7 @@ const spacingSizeConfig: { [key: string]: SpaceSizes } = {
   inset: "l",
   tabPanel: "xl",
   tabList: "s",
-  betweenTabs: "m",
+  betweenTabs: "l",
   withinTab: "s"
 };
 

--- a/packages/tabs/tests/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/tabs/tests/__snapshots__/Tabs.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Tabs renders default 1`] = `
 <div
-  class="react-tabs css-pjouvl"
+  class="react-tabs css-14ccmid"
   data-cy="tabs"
   data-tabs="true"
 >
@@ -53,7 +53,7 @@ exports[`Tabs renders default 1`] = `
 
 exports[`Tabs renders vertically 1`] = `
 <div
-  class="react-tabs css-14zcokl"
+  class="react-tabs css-628men"
   data-cy="tabs"
   data-tabs="true"
 >


### PR DESCRIPTION
Closes D2IQ-62145

Updates:
- The spacing between tabs has been increased from 16px -> 24px. This aligns with the Spacing Standards in the Design System https://mesosphere.invisionapp.com/console/Kommander-GA-cknny74gbi6ql01y3t8vc22o0/cknny9h71i8fy01y3z0z129of/play
- While I was in there I decided to give the component an update to a FC, functionality remains the same after testing within Storybook.
- The Story has been updated to the new template format, there is now the option to use controls to change the direction prop.

<!-- See Checklist for PR creators below. -->

## Testing

Test the Tabs Story. 📖 
<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
#### Example of how this will appear in Kommander 

##### Before:
<img width="334" alt="Screen Shot 2021-11-08 at 7 05 58 AM" src="https://user-images.githubusercontent.com/34781875/140782129-e11392b7-89e5-4013-8187-ac3bac62a607.png">


##### After:
<img width="331" alt="Screen Shot 2021-11-08 at 7 05 45 AM" src="https://user-images.githubusercontent.com/34781875/140781483-e68cab33-8561-46bc-b502-07dfbc0ad973.png">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
