### PR TITLE
revert dropdown menu sticky section changes

### DIFF
--- a/packages/dropdownMenu/components/DropdownMenu.tsx
+++ b/packages/dropdownMenu/components/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { css, cx } from "@emotion/css";
+import { cx } from "@emotion/css";
 import Downshift, { ControllerStateAndHelpers } from "downshift";
 import { Dropdownable } from "../../dropdownable";
 import { border, buttonReset, display } from "../../shared/styles/styleUtils";
@@ -8,10 +8,6 @@ import PopoverListItem from "../../popover/components/PopoverListItem";
 import { DropdownSectionProps } from "./DropdownSection";
 import { DropdownMenuItemProps } from "./DropdownMenuItem";
 import { Direction } from "../../dropdownable/components/Dropdownable";
-import {
-  spaceM,
-  themeBgPrimary
-} from "../../design-tokens/build/js/designTokens";
 
 export interface DropdownMenuProps {
   /**
@@ -85,39 +81,6 @@ const DropdownMenu: React.SFC<DropdownMenuProps> = props => {
     }
   };
 
-  const stickyFooter = css`
-    background-color: ${themeBgPrimary};
-    position: sticky;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding: 2px 0;
-    width: 100%;
-
-    &::before {
-      content: " ";
-      top: -17px;
-      width: inherit;
-      height: ${spaceM};
-      position: absolute;
-      background: linear-gradient(transparent, ${themeBgPrimary});
-    }
-  `;
-
-  const SectionWrapper = ({ children, footer = false, sectionIndex }) => {
-    return (
-      <div
-        key={`dropdown-${sectionIndex}`}
-        className={cx(
-          { [border("top")]: sectionIndex !== 0 },
-          { [stickyFooter]: footer }
-        )}
-      >
-        {children}
-      </div>
-    );
-  };
-
   const getDropdownContents = (highlightedIndex, getItemProps) =>
     (React.Children.toArray(children) as Array<
       React.ReactElement<DropdownSectionProps>
@@ -127,7 +90,7 @@ const DropdownMenu: React.SFC<DropdownMenuProps> = props => {
     }>(
       (acc, item, sectionIndex) => {
         const { sections = [] } = acc;
-        const { children, footer } = item.props;
+        const { children } = item.props;
         const menuItems = React.Children.toArray(children);
         const childrenWithKeys = menuItems.map((child, i) => {
           acc.menuItemIndex++;
@@ -150,16 +113,7 @@ const DropdownMenu: React.SFC<DropdownMenuProps> = props => {
         });
 
         return {
-          sections: [
-            ...sections,
-            <SectionWrapper
-              footer={footer}
-              key={`dropdown-${sectionIndex}`}
-              sectionIndex={sectionIndex}
-            >
-              {childrenWithKeys}
-            </SectionWrapper>
-          ],
+          sections: [...sections, childrenWithKeys],
           menuItemIndex: acc.menuItemIndex
         };
       },
@@ -195,7 +149,17 @@ const DropdownMenu: React.SFC<DropdownMenuProps> = props => {
                   { suppressRefError: true }
                 )}
               >
-                {getDropdownContents(highlightedIndex, getItemProps).sections}
+                {getDropdownContents(
+                  highlightedIndex,
+                  getItemProps
+                ).sections.map((sectionContent, i) => (
+                  <div
+                    key={`dropdown-${i}`}
+                    className={cx({ [border("top")]: i !== 0 })}
+                  >
+                    {sectionContent}
+                  </div>
+                ))}
               </PopoverBox>
             }
             disablePortal={disablePortal}

--- a/packages/dropdownMenu/components/DropdownSection.tsx
+++ b/packages/dropdownMenu/components/DropdownSection.tsx
@@ -5,14 +5,9 @@ export interface DropdownSectionProps {
   children:
     | React.ReactElement<DropdownMenuItemProps>
     | Array<React.ReactElement<DropdownMenuItemProps>>;
-  /**
-   * Allows one section to be a sticky footer within the dropdown
-   */
-  footer?: boolean;
 }
 
 const DropdownSection: React.SFC<DropdownSectionProps> = ({ children }) => (
-  <>{children}</>
+  <React.Fragment>{children}</React.Fragment>
 );
-
 export default DropdownSection;

--- a/packages/dropdownMenu/stories/Dropdown.stories.tsx
+++ b/packages/dropdownMenu/stories/Dropdown.stories.tsx
@@ -10,7 +10,6 @@ import { PopoverListItemAppearances } from "../../shared/types/popoverListItemAp
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { grafanaLogo, kibanaLogo, kubernetesLogo } from "./avatarImgs";
 import PrimaryDropdownButton from "../../button/components/PrimaryDropdownButton";
-import { ProductIcons } from "../../icons/dist/product-icons-enum";
 
 export default {
   title: "Overlays/DropdownMenu",
@@ -217,102 +216,6 @@ export const WithSections = () => (
       </DropdownMenuItem>
       <DropdownMenuItem key="stop" value="stop">
         Stop
-      </DropdownMenuItem>
-    </DropdownSection>
-  </DropdownMenu>
-);
-
-export const WithFooterSection = () => (
-  <DropdownMenu
-    menuMaxHeight={420}
-    trigger={<PrimaryDropdownButton>Workspaces</PrimaryDropdownButton>}
-  >
-    <DropdownSection>
-      <DropdownMenuItem key="workspace1" value="workspace1">
-        <DropdownMenuItemIcon shape={ProductIcons.Global} />
-        Global
-      </DropdownMenuItem>
-    </DropdownSection>
-    <DropdownSection>
-      <DropdownMenuItem key="default-workspace" value="default-workspace">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Default Workspace
-      </DropdownMenuItem>
-      <DropdownMenuItem
-        key="management-cluster-workspace"
-        value="management-cluster-workspace"
-      >
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Management Cluster Workspace
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace1" value="workspace1">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 1
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace2" value="workspace2">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 2
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace3" value="workspace3">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 3
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace4" value="workspace4">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 4
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace5" value="workspace5">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 5
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace6" value="workspace6">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 6
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace7" value="workspace7">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 7
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace8" value="workspace8">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 8
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace9" value="workspace9">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 9
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace10" value="workspace10">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 10
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace11" value="workspace11">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 11
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace12" value="workspace12">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 12
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace13" value="workspace13">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 13
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace14" value="workspace14">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 14
-      </DropdownMenuItem>
-      <DropdownMenuItem key="workspace15" value="workspace15">
-        <DropdownMenuItemIcon shape={ProductIcons.Components} />
-        Workspace 15
-      </DropdownMenuItem>
-    </DropdownSection>
-
-    <DropdownSection footer>
-      <DropdownMenuItem key="create-workspace" value="create-workspace">
-        Create Workspace
-      </DropdownMenuItem>
-      <DropdownMenuItem key="manage-workspaces" value="manage-workspaces">
-        Manage Workspaces
       </DropdownMenuItem>
     </DropdownSection>
   </DropdownMenu>

--- a/packages/dropdownMenu/tests/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/dropdownMenu/tests/__snapshots__/DropdownMenu.test.tsx.snap
@@ -47,8 +47,8 @@ exports[`Dropdown renders a closed dropdown 1`] = `
             menuRef={[Function]}
             role="listbox"
           >
-            <SectionWrapper
-              sectionIndex={0}
+            <div
+              className=""
             >
               <PopoverListItem
                 aria-selected={false}
@@ -118,7 +118,7 @@ exports[`Dropdown renders a closed dropdown 1`] = `
                   Stop
                 </DropdownMenuItem>
               </PopoverListItem>
-            </SectionWrapper>
+            </div>
           </Popover>
         }
         isOpen={false}
@@ -204,8 +204,8 @@ exports[`Dropdown renders a dropdown with a max height 1`] = `
             menuRef={[Function]}
             role="listbox"
           >
-            <SectionWrapper
-              sectionIndex={0}
+            <div
+              className=""
             >
               <PopoverListItem
                 aria-selected={false}
@@ -275,7 +275,7 @@ exports[`Dropdown renders a dropdown with a max height 1`] = `
                   Stop
                 </DropdownMenuItem>
               </PopoverListItem>
-            </SectionWrapper>
+            </div>
           </Popover>
         }
         isOpen={false}
@@ -361,8 +361,8 @@ exports[`Dropdown renders an open dropdown 1`] = `
             menuRef={[Function]}
             role="listbox"
           >
-            <SectionWrapper
-              sectionIndex={0}
+            <div
+              className=""
             >
               <PopoverListItem
                 aria-selected={false}
@@ -432,7 +432,7 @@ exports[`Dropdown renders an open dropdown 1`] = `
                   Stop
                 </DropdownMenuItem>
               </PopoverListItem>
-            </SectionWrapper>
+            </div>
           </Popover>
         }
         isOpen={true}
@@ -636,116 +636,111 @@ exports[`Dropdown renders an open dropdown 1`] = `
                           }
                         }
                       >
-                        <SectionWrapper
+                        <div
+                          className=""
                           key="dropdown-0"
-                          sectionIndex={0}
                         >
-                          <div
-                            className=""
-                            key="dropdown-0"
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-1-item-0"
+                            index={0}
+                            isActive={false}
+                            key=".$edit"
+                            listLength={4}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
                           >
-                            <PopoverListItem
+                            <div
                               aria-selected={false}
+                              className="css-1uile0g"
+                              data-cy="PopoverListItem"
                               id="downshift-1-item-0"
-                              index={0}
-                              isActive={false}
-                              key=".$edit"
-                              listLength={4}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-1uile0g"
-                                data-cy="PopoverListItem"
-                                id="downshift-1-item-0"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Edit
-                              </div>
-                            </PopoverListItem>
-                            <PopoverListItem
+                              Edit
+                            </div>
+                          </PopoverListItem>
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-1-item-1"
+                            index={1}
+                            isActive={false}
+                            key=".$scale"
+                            listLength={4}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
+                          >
+                            <div
                               aria-selected={false}
+                              className="css-1j6n8hw"
+                              data-cy="PopoverListItem"
                               id="downshift-1-item-1"
-                              index={1}
-                              isActive={false}
-                              key=".$scale"
-                              listLength={4}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-1j6n8hw"
-                                data-cy="PopoverListItem"
-                                id="downshift-1-item-1"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Scale
-                              </div>
-                            </PopoverListItem>
-                            <PopoverListItem
+                              Scale
+                            </div>
+                          </PopoverListItem>
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-1-item-2"
+                            index={2}
+                            isActive={false}
+                            key=".$restart"
+                            listLength={4}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
+                          >
+                            <div
                               aria-selected={false}
+                              className="css-1j6n8hw"
+                              data-cy="PopoverListItem"
                               id="downshift-1-item-2"
-                              index={2}
-                              isActive={false}
-                              key=".$restart"
-                              listLength={4}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-1j6n8hw"
-                                data-cy="PopoverListItem"
-                                id="downshift-1-item-2"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Restart
-                              </div>
-                            </PopoverListItem>
-                            <PopoverListItem
+                              Restart
+                            </div>
+                          </PopoverListItem>
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-1-item-3"
+                            index={3}
+                            isActive={false}
+                            key=".$stop"
+                            listLength={4}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
+                          >
+                            <div
                               aria-selected={false}
+                              className="css-35mrzw"
+                              data-cy="PopoverListItem"
                               id="downshift-1-item-3"
-                              index={3}
-                              isActive={false}
-                              key=".$stop"
-                              listLength={4}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-35mrzw"
-                                data-cy="PopoverListItem"
-                                id="downshift-1-item-3"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Stop
-                              </div>
-                            </PopoverListItem>
-                          </div>
-                        </SectionWrapper>
+                              Stop
+                            </div>
+                          </PopoverListItem>
+                        </div>
                       </div>
                     </Popover>
                   </div>
@@ -809,8 +804,8 @@ exports[`Dropdown renders an open dropdown with multiple sections 1`] = `
             menuRef={[Function]}
             role="listbox"
           >
-            <SectionWrapper
-              sectionIndex={0}
+            <div
+              className=""
             >
               <PopoverListItem
                 aria-selected={false}
@@ -846,9 +841,9 @@ exports[`Dropdown renders an open dropdown with multiple sections 1`] = `
                   Scale
                 </DropdownMenuItem>
               </PopoverListItem>
-            </SectionWrapper>
-            <SectionWrapper
-              sectionIndex={1}
+            </div>
+            <div
+              className="css-fqgy4m"
             >
               <PopoverListItem
                 aria-selected={false}
@@ -884,9 +879,9 @@ exports[`Dropdown renders an open dropdown with multiple sections 1`] = `
                   Restart Delay
                 </DropdownMenuItem>
               </PopoverListItem>
-            </SectionWrapper>
-            <SectionWrapper
-              sectionIndex={2}
+            </div>
+            <div
+              className="css-fqgy4m"
             >
               <PopoverListItem
                 aria-selected={false}
@@ -922,7 +917,7 @@ exports[`Dropdown renders an open dropdown with multiple sections 1`] = `
                   Stop
                 </DropdownMenuItem>
               </PopoverListItem>
-            </SectionWrapper>
+            </div>
           </Popover>
         }
         isOpen={true}
@@ -1236,186 +1231,171 @@ exports[`Dropdown renders an open dropdown with multiple sections 1`] = `
                           }
                         }
                       >
-                        <SectionWrapper
+                        <div
+                          className=""
                           key="dropdown-0"
-                          sectionIndex={0}
                         >
-                          <div
-                            className=""
-                            key="dropdown-0"
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-3-item-0"
+                            index={0}
+                            isActive={false}
+                            key=".$edit"
+                            listLength={2}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
                           >
-                            <PopoverListItem
+                            <div
                               aria-selected={false}
+                              className="css-1uile0g"
+                              data-cy="PopoverListItem"
                               id="downshift-3-item-0"
-                              index={0}
-                              isActive={false}
-                              key=".$edit"
-                              listLength={2}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-1uile0g"
-                                data-cy="PopoverListItem"
-                                id="downshift-3-item-0"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Edit
-                              </div>
-                            </PopoverListItem>
-                            <PopoverListItem
+                              Edit
+                            </div>
+                          </PopoverListItem>
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-3-item-1"
+                            index={1}
+                            isActive={false}
+                            key=".$scale"
+                            listLength={2}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
+                          >
+                            <div
                               aria-selected={false}
+                              className="css-35mrzw"
+                              data-cy="PopoverListItem"
                               id="downshift-3-item-1"
-                              index={1}
-                              isActive={false}
-                              key=".$scale"
-                              listLength={2}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-35mrzw"
-                                data-cy="PopoverListItem"
-                                id="downshift-3-item-1"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Scale
-                              </div>
-                            </PopoverListItem>
-                          </div>
-                        </SectionWrapper>
-                        <SectionWrapper
+                              Scale
+                            </div>
+                          </PopoverListItem>
+                        </div>
+                        <div
+                          className="css-fqgy4m"
                           key="dropdown-1"
-                          sectionIndex={1}
                         >
-                          <div
-                            className="css-fqgy4m"
-                            key="dropdown-1"
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-3-item-2"
+                            index={0}
+                            isActive={false}
+                            key=".$restart"
+                            listLength={2}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
                           >
-                            <PopoverListItem
+                            <div
                               aria-selected={false}
+                              className="css-1uile0g"
+                              data-cy="PopoverListItem"
                               id="downshift-3-item-2"
-                              index={0}
-                              isActive={false}
-                              key=".$restart"
-                              listLength={2}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-1uile0g"
-                                data-cy="PopoverListItem"
-                                id="downshift-3-item-2"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Restart
-                              </div>
-                            </PopoverListItem>
-                            <PopoverListItem
-                              aria-selected={false}
-                              id="downshift-3-item-3"
-                              index={1}
-                              isActive={false}
-                              key=".$restartDelay"
-                              listLength={2}
-                              onClick={[Function]}
-                              onMouseDown={[Function]}
-                              onMouseMove={[Function]}
-                              role="option"
-                            >
-                              <div
-                                aria-selected={false}
-                                className="css-35mrzw"
-                                data-cy="PopoverListItem"
-                                id="downshift-3-item-3"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Restart Delay
-                              </div>
-                            </PopoverListItem>
-                          </div>
-                        </SectionWrapper>
-                        <SectionWrapper
-                          key="dropdown-2"
-                          sectionIndex={2}
-                        >
-                          <div
-                            className="css-fqgy4m"
-                            key="dropdown-2"
+                              Restart
+                            </div>
+                          </PopoverListItem>
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-3-item-3"
+                            index={1}
+                            isActive={false}
+                            key=".$restartDelay"
+                            listLength={2}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
                           >
-                            <PopoverListItem
+                            <div
                               aria-selected={false}
+                              className="css-35mrzw"
+                              data-cy="PopoverListItem"
+                              id="downshift-3-item-3"
+                              onClick={[Function]}
+                              onMouseDown={[Function]}
+                              onMouseMove={[Function]}
+                              role="option"
+                            >
+                              Restart Delay
+                            </div>
+                          </PopoverListItem>
+                        </div>
+                        <div
+                          className="css-fqgy4m"
+                          key="dropdown-2"
+                        >
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-3-item-4"
+                            index={0}
+                            isActive={false}
+                            key=".$pause"
+                            listLength={2}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
+                          >
+                            <div
+                              aria-selected={false}
+                              className="css-1uile0g"
+                              data-cy="PopoverListItem"
                               id="downshift-3-item-4"
-                              index={0}
-                              isActive={false}
-                              key=".$pause"
-                              listLength={2}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-1uile0g"
-                                data-cy="PopoverListItem"
-                                id="downshift-3-item-4"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Pause
-                              </div>
-                            </PopoverListItem>
-                            <PopoverListItem
+                              Pause
+                            </div>
+                          </PopoverListItem>
+                          <PopoverListItem
+                            aria-selected={false}
+                            id="downshift-3-item-5"
+                            index={1}
+                            isActive={false}
+                            key=".$stop"
+                            listLength={2}
+                            onClick={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseMove={[Function]}
+                            role="option"
+                          >
+                            <div
                               aria-selected={false}
+                              className="css-35mrzw"
+                              data-cy="PopoverListItem"
                               id="downshift-3-item-5"
-                              index={1}
-                              isActive={false}
-                              key=".$stop"
-                              listLength={2}
                               onClick={[Function]}
                               onMouseDown={[Function]}
                               onMouseMove={[Function]}
                               role="option"
                             >
-                              <div
-                                aria-selected={false}
-                                className="css-35mrzw"
-                                data-cy="PopoverListItem"
-                                id="downshift-3-item-5"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseMove={[Function]}
-                                role="option"
-                              >
-                                Stop
-                              </div>
-                            </PopoverListItem>
-                          </div>
-                        </SectionWrapper>
+                              Stop
+                            </div>
+                          </PopoverListItem>
+                        </div>
                       </div>
                     </Popover>
                   </div>

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -1559,8 +1559,8 @@ exports[`Table v2 rendering renders default 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -1630,7 +1630,7 @@ exports[`Table v2 rendering renders default 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -1953,8 +1953,8 @@ exports[`Table v2 rendering renders default 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -2024,7 +2024,7 @@ exports[`Table v2 rendering renders default 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -2347,8 +2347,8 @@ exports[`Table v2 rendering renders default 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -2418,7 +2418,7 @@ exports[`Table v2 rendering renders default 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -2741,8 +2741,8 @@ exports[`Table v2 rendering renders default 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -2812,7 +2812,7 @@ exports[`Table v2 rendering renders default 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -3135,8 +3135,8 @@ exports[`Table v2 rendering renders default 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -3206,7 +3206,7 @@ exports[`Table v2 rendering renders default 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -4849,8 +4849,8 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -4920,7 +4920,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -5243,8 +5243,8 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -5314,7 +5314,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -5637,8 +5637,8 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -5708,7 +5708,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -6031,8 +6031,8 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -6102,7 +6102,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}
@@ -6425,8 +6425,8 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                           menuRef={[Function]}
                           role="listbox"
                         >
-                          <SectionWrapper
-                            sectionIndex={0}
+                          <div
+                            className=""
                           >
                             <PopoverListItem
                               aria-selected={false}
@@ -6496,7 +6496,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                                 Stop
                               </DropdownMenuItem>
                             </PopoverListItem>
-                          </SectionWrapper>
+                          </div>
                         </Popover>
                       }
                       isOpen={false}


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

We are having issues with these integrated changes on Kommander UI within the Cypress testing due to items detaching from the DOM and Cypress is unable to `cy.click()` on them. 

We can revert these changes for now and add them back again in the future with Cypress ugrades. 

Changes to reference - https://github.com/dcos-labs/ui-kit/pull/626


## Testing

Open up storybook and check the dropdown menu stories. 

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
