### PR TITLE
feat: add optional `dataCy` attribute

### DIFF
--- a/packages/configurationmap/components/ConfigurationMapLabel.tsx
+++ b/packages/configurationmap/components/ConfigurationMapLabel.tsx
@@ -3,7 +3,15 @@ import { cx } from "@emotion/css";
 import { breakWord, textWeight, padding } from "../../shared/styles/styleUtils";
 import { configurationMapLabel } from "../style";
 
-const ConfigurationMapLabel: React.FC = ({ children }) => (
+interface ConfigurationMapLabelProps {
+  children: React.ReactNode;
+  dataCy?: string;
+}
+
+const ConfigurationMapLabel = ({
+  children,
+  dataCy
+}: ConfigurationMapLabelProps) => (
   <div
     className={cx(
       configurationMapLabel,
@@ -11,7 +19,7 @@ const ConfigurationMapLabel: React.FC = ({ children }) => (
       textWeight("medium"),
       breakWord
     )}
-    data-cy="configurationMapLabel"
+    data-cy={dataCy ?? "configurationMapLabel"}
   >
     {children}
   </div>

--- a/packages/configurationmap/components/ConfigurationMapRow.tsx
+++ b/packages/configurationmap/components/ConfigurationMapRow.tsx
@@ -6,9 +6,10 @@ import { flex, padding, border } from "../../shared/styles/styleUtils";
 interface ConfigurationMapRowProps {
   children: React.ReactNode;
   onlyShowActionOnHover?: boolean;
+  dataCy?: string;
 }
 
-const ConfigurationMapRow: React.FC<ConfigurationMapRowProps> = props => (
+const ConfigurationMapRow = (props: ConfigurationMapRowProps) => (
   <div
     className={cx(
       { [showActionOnHoverStyle]: props.onlyShowActionOnHover },
@@ -17,7 +18,7 @@ const ConfigurationMapRow: React.FC<ConfigurationMapRowProps> = props => (
       flex(),
       padding("vert", "xs")
     )}
-    data-cy="configurationMapRow"
+    data-cy={props.dataCy ?? "configurationMapRow"}
   >
     {props.children}
   </div>

--- a/packages/configurationmap/components/ConfigurationMapValue.tsx
+++ b/packages/configurationmap/components/ConfigurationMapValue.tsx
@@ -3,10 +3,18 @@ import { cx } from "@emotion/css";
 import { flexItem, breakWord } from "../../shared/styles/styleUtils";
 import { ddReset } from "../../shared/styles/styleUtils/resets/definitionListReset";
 
-const ConfigurationMapValue = ({ children }) => (
+interface ConfigurationMapValueProps {
+  children: React.ReactNode;
+  dataCy?: string;
+}
+
+const ConfigurationMapValue = ({
+  children,
+  dataCy
+}: ConfigurationMapValueProps) => (
   <div
     className={cx(ddReset, flexItem("grow"), breakWord)}
-    data-cy="configurationMapValue"
+    data-cy={dataCy ?? "configurationMapValue"}
   >
     {children}
   </div>


### PR DESCRIPTION
This adds an optional `dataCy` attributes
to `ConfigurationMap{Label,Row,Value}` to be able
to search efficiently with cypress for that values

Related to D2IQ-81001

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
