### PR TITLE
fix: remove semantic-release-jira plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,11 +1,3 @@
 {
-  "branches": "master",
-  "verifyConditions": ["semantic-release-jira"],
-  "success": [
-    {
-      "path": "semantic-release-jira",
-      "apiURL": "https://jira.d2iq.com/rest/api/2/issue/${issueKey}",
-      "apiJSON": "{ \"update\": { \"labels\": [ { \"add\": \"ui-kit:v${version}\" } ] } }"
-    }
-  ]
+  "branches": "master"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,6 @@
         "react-test-renderer": "16.8.6",
         "rimraf": "3.0.2",
         "semantic-release": "18.0.0",
-        "semantic-release-jira": "3.0.0",
         "style-dictionary": "3.0.3",
         "svg-inline-loader": "0.8.0",
         "svgo": "1.1.1",
@@ -33744,22 +33743,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/semantic-release-jira": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-jira/-/semantic-release-jira-3.0.0.tgz",
-      "integrity": "sha512-v6XwixGaFwyRlvYEwrSSXh7AVEDgUqQEOAx/iuMnmnbTyZ6/RsZk6TiMeIisEnQt5r04W1mSAkPJ0PpVDz0Z5g==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.20",
-        "node-fetch": "^2.6.1"
-      }
-    },
-    "node_modules/semantic-release-jira/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/semantic-release/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -65594,24 +65577,6 @@
           "version": "20.2.9",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
-        }
-      }
-    },
-    "semantic-release-jira": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-jira/-/semantic-release-jira-3.0.0.tgz",
-      "integrity": "sha512-v6XwixGaFwyRlvYEwrSSXh7AVEDgUqQEOAx/iuMnmnbTyZ6/RsZk6TiMeIisEnQt5r04W1mSAkPJ0PpVDz0Z5g==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.20",
-        "node-fetch": "^2.6.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "react-test-renderer": "16.8.6",
     "rimraf": "3.0.2",
     "semantic-release": "18.0.0",
-    "semantic-release-jira": "3.0.0",
     "style-dictionary": "3.0.3",
     "svg-inline-loader": "0.8.0",
     "svgo": "1.1.1",


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->
This plugin was initially intended to help keep track of issues with JIRA with the open-source intentions of ui-kit. We no longer need this at the moment. However, we may choose to integrate it again in the future if the open-source aspect of ui-kit further develops. 

## Testing

Will need to see how this does through Jenkins ultimately. 

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
