### PR TITLE
fix(package.json): remove node dependency from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
         "fs-extra": "10.0.0",
         "jest": "23.6.0",
         "jest-runner-prettier": "0.2.6",
-        "node": "16.13.0",
         "npm": "7.24.0",
         "prettier": "1.19.1",
         "prop-types": "15.6.2",
@@ -26571,28 +26570,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-      "dev": true
-    },
-    "node_modules/node": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-16.13.0.tgz",
-      "integrity": "sha512-bCUq6u/0rVHBvCpxLFTv5/kPjJGTltcyWQ2EtqlZ6WOqSpkTVBFtNoJ9tSVIGmadb0KoRsWd2CyNs9bU/drxXQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-bin-setup": "^1.0.0"
-      },
-      "bin": {
-        "node": "bin/node"
-      },
-      "engines": {
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/node-bin-setup": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
-      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==",
       "dev": true
     },
     "node_modules/node-dir": {
@@ -59698,21 +59675,6 @@
           "dev": true
         }
       }
-    },
-    "node": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/node/-/node-16.13.0.tgz",
-      "integrity": "sha512-bCUq6u/0rVHBvCpxLFTv5/kPjJGTltcyWQ2EtqlZ6WOqSpkTVBFtNoJ9tSVIGmadb0KoRsWd2CyNs9bU/drxXQ==",
-      "dev": true,
-      "requires": {
-        "node-bin-setup": "^1.0.0"
-      }
-    },
-    "node-bin-setup": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
-      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q==",
-      "dev": true
     },
     "node-dir": {
       "version": "0.1.17",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "fs-extra": "10.0.0",
     "jest": "23.6.0",
     "jest-runner-prettier": "0.2.6",
-    "node": "16.13.0",
     "npm": "7.24.0",
     "prettier": "1.19.1",
     "prop-types": "15.6.2",


### PR DESCRIPTION
Removing node from package.json because it shouldn't need to be listed as a dependency, and also it's causing issues when trying to run `npm i` on an M1 Mac

<!-- See Checklist for PR creators below. -->

## Testing

Run `npm i` to check you can run the installs successfully. Maybe click on some of the components in the storybook to check that everything seems to be running ok.

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
