### PR TITLE
feat: improve grid features and alignment options

### DIFF
--- a/packages/styleUtils/layout/gridList/components/GridList.tsx
+++ b/packages/styleUtils/layout/gridList/components/GridList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { css } from "@emotion/css";
+import { css, cx } from "@emotion/css";
 import { gridColumnTemplate } from "../style";
 import { SpaceSize } from "../../../../shared/styles/styleUtils/modifiers/modifierUtils";
 import {
@@ -8,46 +8,62 @@ import {
 } from "../../../../shared/styles/styleUtils";
 import { BreakpointConfig } from "../../../../shared/styles/breakpoints";
 
-interface GridListProps {
+export interface GridListProps {
   /**
-   * How many columns the grid should be. Can be set for all viewport sizes, or configured to have different values at different viewport width breakpoints
+   * Sets the amount of grid columns explicitly. Can be set for all viewport sizes, or configured to have different values at different viewport width breakpoints. If not set, automatic responsive grid styling will be in effect.
    */
-  columnCount: BreakpointConfig<number>;
+  columnCount?: BreakpointConfig<number>;
   /**
-   * The size of the space between each list item. Can be set for all viewport sizes, or configured to have different values at different viewport width breakpoints
+   * The size of the space (gap) between each list item. Can be set for all viewport sizes, or configured to have different values at different viewport width breakpoints. The default size is set to medium ("m" = 16px);
    */
   gutterSize?: SpaceSize;
   /**
-   * Which HTML list tag to render the component with
+   * Which HTML list tag to render the component with.
    */
-  tag: "ul" | "ol";
+  tag?: "ul" | "ol";
   children:
     | Array<React.ReactElement<HTMLLIElement>>
     | React.ReactElement<HTMLLIElement>;
+  /**
+   * Additional styles to extend the component.
+   */
+
+  className?: string;
+
+  /**
+   * Human-readable selector used for writing tests.
+   */
+  ["data-cy"]?: string;
+  /**
+   * Centers grid children by implementing `place-items: center;` Optimal for grids that could have a state with only 1 grid child.
+   */
+  centerItems?: boolean;
 }
 
-const GridList = (props: GridListProps) => {
-  const { children, columnCount, gutterSize, tag } = props;
+const GridList = ({
+  children,
+  columnCount,
+  gutterSize = "m",
+  tag = "ul",
+  centerItems = false,
+  className,
+  "data-cy": dataCy = "gridList"
+}: GridListProps) => {
   const GridListEl = tag;
 
+  const gridStyles = css`
+    display: grid;
+    ${getResponsiveSpacingStyle("grid-gap", gutterSize)};
+    ${gridColumnTemplate(columnCount)};
+    ${listReset};
+    place-items: ${centerItems ? "center" : "normal"};
+  `;
+
   return (
-    <GridListEl
-      className={css`
-        display: grid;
-        ${getResponsiveSpacingStyle("grid-gap", gutterSize)};
-        ${gridColumnTemplate(columnCount)};
-        ${listReset};
-      `}
-      data-cy="gridList"
-    >
+    <GridListEl className={cx(gridStyles, className)} data-cy={dataCy}>
       {children}
     </GridListEl>
   );
-};
-
-GridList.defaultProps = {
-  gutterSize: "m",
-  tag: "ul"
 };
 
 export default GridList;

--- a/packages/styleUtils/layout/gridList/stories/GridList.stories.tsx
+++ b/packages/styleUtils/layout/gridList/stories/GridList.stories.tsx
@@ -1,75 +1,60 @@
 import * as React from "react";
-import { withKnobs, number, select } from "@storybook/addon-knobs";
+import { GridListProps } from "../components/GridList";
 import styled from "@emotion/styled";
 import GridList from "../components/GridList";
-import { themeBorder } from "../../../../design-tokens/build/js/designTokens";
-import { SpaceSize } from "../../../../shared/styles/styleUtils/modifiers/modifierUtils";
+import {
+  spaceL,
+  themeBrandPrimary
+} from "../../../../design-tokens/build/js/designTokens";
+import { Story, Meta } from "@storybook/react";
 
-const BorderedBox = styled("div")`
-  border: 1px solid ${themeBorder};
+const GridChild = styled.div`
+  border: 2px solid ${themeBrandPrimary};
+  padding: ${spaceL};
 `;
 
 const gridChildren = new Array(12).fill(0).map((_, i) => (
   <li key={i}>
-    <BorderedBox>item</BorderedBox>
+    <GridChild>Child</GridChild>
   </li>
 ));
 
 export default {
   title: "Layout/GridList",
-  decorators: [withKnobs],
-  component: GridList
-};
+  component: GridList,
+  argTypes: {
+    columnCount: {
+      control: { type: "number" }
+    },
+    gutterSize: {
+      options: ["none", "xxs", "xs", "s", "m", "l", "xl", "xxl"],
+      control: { type: "select" }
+    },
+    centerItems: {
+      options: [true, false],
+      control: { type: "boolean" }
+    },
+    tag: {
+      options: ["ol", "ul"],
+      control: { type: "inline-radio" }
+    },
+    className: {
+      control: { disable: true }
+    },
+    "data-cy": {
+      control: { disable: true }
+    }
+  }
+} as Meta;
 
-export const ColumnCount = () => {
-  const columnCount = number("columnCount", 3);
-  return (
-    <div>
-      <p>Use the Knobs panel to adjust the number of columns per row</p>
-      <GridList columnCount={columnCount}>{gridChildren}</GridList>
-    </div>
-  );
-};
-
-export const ResponsiveColumnCount = () => (
-  <div>
-    <p>Change the width of the viewport to see the column count change</p>
-    <GridList columnCount={{ small: 1, medium: 2, large: 3 }}>
-      {gridChildren}
-    </GridList>
-  </div>
+const Template: Story<GridListProps> = args => (
+  <GridList {...args}>{gridChildren}</GridList>
 );
 
-export const GutterSize = () => {
-  const gutterSizes = {
-    xxs: "xxs",
-    xs: "xs",
-    s: "s",
-    m: "m",
-    l: "l",
-    xl: "xl",
-    xxl: "xxl",
-    none: "none"
-  };
-  const gutterSize = select("gutterSizes", gutterSizes, "m");
-  return (
-    <div>
-      <p>Use the Knobs panel to adjust the gutter size</p>
-      <GridList gutterSize={gutterSize as SpaceSize} columnCount={3}>
-        {gridChildren}
-      </GridList>
-    </div>
-  );
-};
+export const DynamicExample = Template.bind({});
 
-export const ResponsiveGutterSize = () => (
-  <div>
-    <p>Change the width of the viewport to see the gutter size change</p>
-    <GridList
-      gutterSize={{ small: "m", medium: "l", large: "xl" }}
-      columnCount={3}
-    >
-      {gridChildren}
-    </GridList>
-  </div>
-);
+export const ResponsiveGridSizing = Template.bind({});
+ResponsiveGridSizing.args = {
+  gutterSize: { small: "m", medium: "l", large: "xl" },
+  columnCount: { small: 1, medium: 2, large: 3 }
+};

--- a/packages/styleUtils/layout/gridList/style.ts
+++ b/packages/styleUtils/layout/gridList/style.ts
@@ -7,7 +7,9 @@ export const gridColumnTemplate = columnCount => {
           acc[breakpoint] = `repeat(${columnCount[breakpoint]}, 1fr)`;
           return acc;
         }, {})
-      : `repeat(${columnCount}, minmax(0, 1fr))`;
+      : columnCount
+      ? `repeat(${columnCount}, minmax(0, 1fr))`
+      : `repeat(auto-fill, minmax(min(320px, 100%), 1fr));`;
   // 👆explicitly setting the min to 0 so content doesn't overflow the grid cell
   // see: https://github.com/rachelandrew/cssgrid-ama/issues/25
 

--- a/packages/styleUtils/layout/gridList/tests/__snapshots__/GridList.test.tsx.snap
+++ b/packages/styleUtils/layout/gridList/tests/__snapshots__/GridList.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`GridList renders default 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 0;
+  place-items: normal;
 }
 
 <ul
@@ -35,6 +36,7 @@ exports[`GridList renders with all props 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 0;
+  place-items: normal;
 }
 
 <ol
@@ -58,6 +60,7 @@ exports[`GridList renders with responsive props 1`] = `
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 0;
+  place-items: normal;
 }
 
 @media (min-width: 0) {


### PR DESCRIPTION
I have done this in a way that I do not believe will break any of the styles and `GridList` usage in Kommander. Columns can still be explicitly set, have responsive options, but now will have a backup style that is a fluid grid. GridList items can be centered with a new optional prop, which provides some additional benefits such as the containers shrinking to fit their content instead of stretching. 
I've taken the opportunity here to update the story and create some useful Controls which can be used to compare to the old functionality of the GridList here - https://dcos-labs.github.io/ui-kit/?path=/story/layout-gridlist--column-count
I am still using BREAKING CHANGE to be safe, mostly due to the change in how to use some of the `GridList` props.

BREAKING CHANGE
Before this fix columnCount was required, new behavior includes defaults for when it is not set to become a fluid grid that sets the amount of rows and columns based on available space.
Before you could not center grid items, now the optional centerItems prop can be used.
Other features include a data-cy prop, and className for further customizations.

Closes D2IQ-81475

<!-- See Checklist for PR creators below. -->

## Testing

Test out the `GridList` controls. 
<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [x] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
