### PR TITLE
fix: reorder addons to fix storybook warning

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,14 +16,6 @@ module.exports = {
     return { ...config, ...customWebpack };
   },
   addons: [
-    "@storybook/addon-knobs",
-    {
-      name: "@storybook/addon-essentials",
-      options: {
-        actions: false
-      }
-    },
-    "@storybook/addon-a11y",
     {
       name: "@storybook/addon-docs",
       options: {
@@ -32,6 +24,14 @@ module.exports = {
         sourceLoaderOptions: null,
         transcludeMarkdown: true
       }
-    }
+    },
+    {
+      name: "@storybook/addon-essentials",
+      options: {
+        actions: false
+      }
+    },
+    "@storybook/addon-knobs",
+    "@storybook/addon-a11y"
   ]
 };


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

Reordered the addons. Storybook gave a warning that addon-docs should come before addon-controls which is part of the addon-essentials pack. 

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
