### PR TITLE
feat: allow text wrapping for tables

### DIFF
--- a/packages/tablev2/Table.tsx
+++ b/packages/tablev2/Table.tsx
@@ -45,6 +45,11 @@ export type Column<A, B = string> = {
    * Text alignment for cells in the column
    */
   textAlign?: React.CSSProperties["textAlign"];
+
+  /**
+   * The contentNoWrap prop sets the `whitespace` to `nowrap` which prevents content from wrapping within the cell. The default is set to true to preserve truncation backwards compatibility.
+   */
+  contentNoWrap?: boolean;
 };
 
 // we internally use a different type than we expose in the API.
@@ -272,20 +277,23 @@ const Row = React.memo(function Row<A>({
 
   return (
     <div role="row" className={className} key={`row-${rowId}`}>
-      {columns.map(({ id: colID, render, textAlign, sorter }) => (
-        <div
-          key={rowId + colID}
-          aria-describedby={colID}
-          className={cx(style.cell(textAlign), {
-            [style.makeSpaceForSortIndicator]:
-              Boolean(sorter) && textAlign === "right",
-            [style.rowScrollShadow]: showScrollShadow
-          })}
-          role="gridcell"
-        >
-          {render(el)}
-        </div>
-      ))}
+      {columns.map(
+        ({ id: colID, render, textAlign, sorter, contentNoWrap = true }) => (
+          <div
+            key={rowId + colID}
+            aria-describedby={colID}
+            className={cx(style.cell(textAlign), {
+              [style.makeSpaceForSortIndicator]:
+                Boolean(sorter) && textAlign === "right",
+              [style.rowScrollShadow]: showScrollShadow,
+              [style.nowrap]: contentNoWrap
+            })}
+            role="gridcell"
+          >
+            {render(el)}
+          </div>
+        )
+      )}
     </div>
   );
 });

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -307,7 +307,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-zm3jtb"
+            className="css-1flfuvq"
             id="name"
             role="columnheader"
           >
@@ -434,7 +434,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-sh5s31"
+            className="css-1khggit"
             id="username"
             role="columnheader"
           >
@@ -643,7 +643,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-g4yot0"
+            className="css-r8gcxz"
             id="email"
             role="columnheader"
           >
@@ -747,7 +747,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-kh9svd"
+            className="css-1c1nlm0"
             id="phone"
             role="columnheader"
           >
@@ -851,7 +851,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-kh9svd"
+            className="css-1c1nlm0"
             id="company"
             role="columnheader"
           >
@@ -955,7 +955,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-kh9svd"
+            className="css-1c1nlm0"
             id="website"
             role="columnheader"
           >
@@ -1059,7 +1059,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-kh9svd"
+            className="css-1c1nlm0"
             id="empty"
             role="columnheader"
           >
@@ -1163,7 +1163,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-kh9svd"
+            className="css-1c1nlm0"
             id="muted"
             role="columnheader"
           >
@@ -1267,7 +1267,7 @@ exports[`Table v2 rendering renders default 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-kh9svd"
+            className="css-1c1nlm0"
             id="dropdown"
             role="columnheader"
           >
@@ -1406,7 +1406,7 @@ exports[`Table v2 rendering renders default 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-1lzx8ik"
+          className="css-18tezmg"
           key="0name"
           role="gridcell"
         >
@@ -1418,7 +1418,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-5xsmrx"
+          className="css-bbdu6u"
           key="0username"
           role="gridcell"
         >
@@ -1426,7 +1426,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1xn3oo1"
+          className="css-146hpp5"
           key="0email"
           role="gridcell"
         >
@@ -1434,7 +1434,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="0phone"
           role="gridcell"
         >
@@ -1442,7 +1442,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="0company"
           role="gridcell"
         >
@@ -1450,7 +1450,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="0website"
           role="gridcell"
         >
@@ -1462,7 +1462,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="0empty"
           role="gridcell"
         >
@@ -1472,7 +1472,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="0muted"
           role="gridcell"
         >
@@ -1498,7 +1498,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="0dropdown"
           role="gridcell"
         >
@@ -1800,7 +1800,7 @@ exports[`Table v2 rendering renders default 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-1lzx8ik"
+          className="css-18tezmg"
           key="1name"
           role="gridcell"
         >
@@ -1812,7 +1812,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-5xsmrx"
+          className="css-bbdu6u"
           key="1username"
           role="gridcell"
         >
@@ -1820,7 +1820,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1xn3oo1"
+          className="css-146hpp5"
           key="1email"
           role="gridcell"
         >
@@ -1828,7 +1828,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="1phone"
           role="gridcell"
         >
@@ -1836,7 +1836,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="1company"
           role="gridcell"
         >
@@ -1844,7 +1844,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="1website"
           role="gridcell"
         >
@@ -1856,7 +1856,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="1empty"
           role="gridcell"
         >
@@ -1866,7 +1866,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="1muted"
           role="gridcell"
         >
@@ -1892,7 +1892,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="1dropdown"
           role="gridcell"
         >
@@ -2194,7 +2194,7 @@ exports[`Table v2 rendering renders default 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-1lzx8ik"
+          className="css-18tezmg"
           key="2name"
           role="gridcell"
         >
@@ -2206,7 +2206,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-5xsmrx"
+          className="css-bbdu6u"
           key="2username"
           role="gridcell"
         >
@@ -2214,7 +2214,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1xn3oo1"
+          className="css-146hpp5"
           key="2email"
           role="gridcell"
         >
@@ -2222,7 +2222,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="2phone"
           role="gridcell"
         >
@@ -2230,7 +2230,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="2company"
           role="gridcell"
         >
@@ -2238,7 +2238,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="2website"
           role="gridcell"
         >
@@ -2250,7 +2250,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="2empty"
           role="gridcell"
         >
@@ -2260,7 +2260,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="2muted"
           role="gridcell"
         >
@@ -2286,7 +2286,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="2dropdown"
           role="gridcell"
         >
@@ -2588,7 +2588,7 @@ exports[`Table v2 rendering renders default 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-1lzx8ik"
+          className="css-18tezmg"
           key="3name"
           role="gridcell"
         >
@@ -2600,7 +2600,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-5xsmrx"
+          className="css-bbdu6u"
           key="3username"
           role="gridcell"
         >
@@ -2608,7 +2608,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1xn3oo1"
+          className="css-146hpp5"
           key="3email"
           role="gridcell"
         >
@@ -2616,7 +2616,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="3phone"
           role="gridcell"
         >
@@ -2624,7 +2624,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="3company"
           role="gridcell"
         >
@@ -2632,7 +2632,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="3website"
           role="gridcell"
         >
@@ -2644,7 +2644,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="3empty"
           role="gridcell"
         >
@@ -2654,7 +2654,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="3muted"
           role="gridcell"
         >
@@ -2680,7 +2680,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="3dropdown"
           role="gridcell"
         >
@@ -2982,7 +2982,7 @@ exports[`Table v2 rendering renders default 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-1lzx8ik"
+          className="css-18tezmg"
           key="4name"
           role="gridcell"
         >
@@ -2994,7 +2994,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-5xsmrx"
+          className="css-bbdu6u"
           key="4username"
           role="gridcell"
         >
@@ -3002,7 +3002,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1xn3oo1"
+          className="css-146hpp5"
           key="4email"
           role="gridcell"
         >
@@ -3010,7 +3010,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="4phone"
           role="gridcell"
         >
@@ -3018,7 +3018,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="4company"
           role="gridcell"
         >
@@ -3026,7 +3026,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="4website"
           role="gridcell"
         >
@@ -3038,7 +3038,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="4empty"
           role="gridcell"
         >
@@ -3048,7 +3048,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="4muted"
           role="gridcell"
         >
@@ -3074,7 +3074,7 @@ exports[`Table v2 rendering renders default 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1sy3y6t"
+          className="css-1nq8pb0"
           key="4dropdown"
           role="gridcell"
         >
@@ -3597,7 +3597,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-3frdu1"
+            className="css-17u43ww"
             id="name"
             role="columnheader"
           >
@@ -3724,7 +3724,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-11bdzya"
+            className="css-1uu6o1d"
             id="username"
             role="columnheader"
           >
@@ -3933,7 +3933,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-9th4yf"
+            className="css-78zwz7"
             id="email"
             role="columnheader"
           >
@@ -4037,7 +4037,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-tqmn7d"
+            className="css-5gz6jn"
             id="phone"
             role="columnheader"
           >
@@ -4141,7 +4141,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-tqmn7d"
+            className="css-5gz6jn"
             id="company"
             role="columnheader"
           >
@@ -4245,7 +4245,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-tqmn7d"
+            className="css-5gz6jn"
             id="website"
             role="columnheader"
           >
@@ -4349,7 +4349,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-tqmn7d"
+            className="css-5gz6jn"
             id="empty"
             role="columnheader"
           >
@@ -4453,7 +4453,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-tqmn7d"
+            className="css-5gz6jn"
             id="muted"
             role="columnheader"
           >
@@ -4557,7 +4557,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         >
           <div
             aria-sort="none"
-            className="css-tqmn7d"
+            className="css-5gz6jn"
             id="dropdown"
             role="columnheader"
           >
@@ -4696,7 +4696,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-xog1xq"
+          className="css-qiqfhd"
           key="0name"
           role="gridcell"
         >
@@ -4708,7 +4708,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-o6m2ut"
+          className="css-1madxjt"
           key="0username"
           role="gridcell"
         >
@@ -4716,7 +4716,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1ni7mf1"
+          className="css-1p35xjg"
           key="0email"
           role="gridcell"
         >
@@ -4724,7 +4724,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="0phone"
           role="gridcell"
         >
@@ -4732,7 +4732,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="0company"
           role="gridcell"
         >
@@ -4740,7 +4740,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="0website"
           role="gridcell"
         >
@@ -4752,7 +4752,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="0empty"
           role="gridcell"
         >
@@ -4762,7 +4762,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="0muted"
           role="gridcell"
         >
@@ -4788,7 +4788,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="0dropdown"
           role="gridcell"
         >
@@ -5090,7 +5090,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-xog1xq"
+          className="css-qiqfhd"
           key="1name"
           role="gridcell"
         >
@@ -5102,7 +5102,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-o6m2ut"
+          className="css-1madxjt"
           key="1username"
           role="gridcell"
         >
@@ -5110,7 +5110,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1ni7mf1"
+          className="css-1p35xjg"
           key="1email"
           role="gridcell"
         >
@@ -5118,7 +5118,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="1phone"
           role="gridcell"
         >
@@ -5126,7 +5126,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="1company"
           role="gridcell"
         >
@@ -5134,7 +5134,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="1website"
           role="gridcell"
         >
@@ -5146,7 +5146,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="1empty"
           role="gridcell"
         >
@@ -5156,7 +5156,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="1muted"
           role="gridcell"
         >
@@ -5182,7 +5182,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="1dropdown"
           role="gridcell"
         >
@@ -5484,7 +5484,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-xog1xq"
+          className="css-qiqfhd"
           key="2name"
           role="gridcell"
         >
@@ -5496,7 +5496,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-o6m2ut"
+          className="css-1madxjt"
           key="2username"
           role="gridcell"
         >
@@ -5504,7 +5504,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1ni7mf1"
+          className="css-1p35xjg"
           key="2email"
           role="gridcell"
         >
@@ -5512,7 +5512,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="2phone"
           role="gridcell"
         >
@@ -5520,7 +5520,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="2company"
           role="gridcell"
         >
@@ -5528,7 +5528,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="2website"
           role="gridcell"
         >
@@ -5540,7 +5540,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="2empty"
           role="gridcell"
         >
@@ -5550,7 +5550,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="2muted"
           role="gridcell"
         >
@@ -5576,7 +5576,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="2dropdown"
           role="gridcell"
         >
@@ -5878,7 +5878,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-xog1xq"
+          className="css-qiqfhd"
           key="3name"
           role="gridcell"
         >
@@ -5890,7 +5890,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-o6m2ut"
+          className="css-1madxjt"
           key="3username"
           role="gridcell"
         >
@@ -5898,7 +5898,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1ni7mf1"
+          className="css-1p35xjg"
           key="3email"
           role="gridcell"
         >
@@ -5906,7 +5906,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="3phone"
           role="gridcell"
         >
@@ -5914,7 +5914,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="3company"
           role="gridcell"
         >
@@ -5922,7 +5922,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="3website"
           role="gridcell"
         >
@@ -5934,7 +5934,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="3empty"
           role="gridcell"
         >
@@ -5944,7 +5944,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="3muted"
           role="gridcell"
         >
@@ -5970,7 +5970,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="3dropdown"
           role="gridcell"
         >
@@ -6272,7 +6272,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
       >
         <div
           aria-describedby="name"
-          className="css-xog1xq"
+          className="css-qiqfhd"
           key="4name"
           role="gridcell"
         >
@@ -6284,7 +6284,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="username"
-          className="css-o6m2ut"
+          className="css-1madxjt"
           key="4username"
           role="gridcell"
         >
@@ -6292,7 +6292,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="email"
-          className="css-1ni7mf1"
+          className="css-1p35xjg"
           key="4email"
           role="gridcell"
         >
@@ -6300,7 +6300,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="phone"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="4phone"
           role="gridcell"
         >
@@ -6308,7 +6308,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="company"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="4company"
           role="gridcell"
         >
@@ -6316,7 +6316,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="website"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="4website"
           role="gridcell"
         >
@@ -6328,7 +6328,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="empty"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="4empty"
           role="gridcell"
         >
@@ -6338,7 +6338,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="muted"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="4muted"
           role="gridcell"
         >
@@ -6364,7 +6364,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         </div>
         <div
           aria-describedby="dropdown"
-          className="css-1gnx2w7"
+          className="css-ml97ay"
           key="4dropdown"
           role="gridcell"
         >

--- a/packages/tablev2/style.ts
+++ b/packages/tablev2/style.ts
@@ -4,7 +4,6 @@ import {
   border,
   padding,
   pseudoElTriangle,
-  textTruncate,
   textWeight
 } from "../shared/styles/styleUtils";
 import { iconSizes } from "../shared/styles/styleUtils/layout/iconSizes";
@@ -91,11 +90,17 @@ export const sortableButton = css`
   max-width: 100%;
 `;
 
+export const nowrap = css`
+  white-space: nowrap;
+`;
+
 // min-width: 0 is needed to support text truncation in columns that are sized with the `fr` unit
 const cellPaddingSize = "xs";
 export const cell = (textAlign: React.CSSProperties["textAlign"]) => css`
   ${padding("all", cellPaddingSize)};
-  ${textTruncate};
+  text-overflow: ellipsis;
+  overflow: -moz-hidden-unscrollable;
+  overflow: hidden;
   background-color: ${dt.themeBgPrimary};
   min-width: 0;
   padding-right: calc(
@@ -125,8 +130,6 @@ export const headerCell = (textAlign: React.CSSProperties["textAlign"]) =>
   css`
     ${cell(textAlign)};
     ${textWeight("medium")};
-    overflow: visible;
-    white-space: nowrap;
     --draggable-opacity: 0;
     &:hover {
       --draggable-opacity: 1;

--- a/packages/tablev2/tablev2.stories.tsx
+++ b/packages/tablev2/tablev2.stories.tsx
@@ -154,6 +154,54 @@ export const ColumnsWithCustomWidths = () => (
   />
 );
 
+export const ColumnsWithWrappingContent = () => (
+  <Table
+    data={initialData}
+    // toId fn needed to make react render stuff fast.
+    toId={el => el.id.toString()}
+    columns={[
+      {
+        id: "name",
+        header: "Name",
+        render: x => x.name,
+        initialWidth: "100px",
+        contentNoWrap: false
+      },
+      {
+        id: "username",
+        header: "Username",
+        render: x => x.username,
+        contentNoWrap: false
+      },
+      {
+        id: "email",
+        header: "E-mail",
+        render: x => x.email,
+        contentNoWrap: false
+      },
+      {
+        id: "phone",
+        header: "Phone",
+        render: x => x.phone,
+        contentNoWrap: false
+      },
+      {
+        id: "website",
+        header: "Website",
+        render: x => x.website,
+        contentNoWrap: false
+      },
+      {
+        id: "company",
+        header: "Company",
+        render: x => x.company.name,
+        initialWidth: "200px",
+        contentNoWrap: false
+      }
+    ]}
+  />
+);
+
 export const SortableColumns = () => (
   <Table
     data={initialData}


### PR DESCRIPTION
Closes D2IQ-84285

<!-- See Checklist for PR creators below. -->

If you set `contentNoWrap` false, the content of a column will allow for text wrapping instead of full truncation. 

Text will still "truncate" with the ellipsis after wrapping if it extends into overflow, as we wouldn't want something long (that cannot break) such as an email address to overlap other table cells or become cut off. We still want the user to understand that there is more text there with the ellipsis in that case.

## Testing

Compare the Storybook story for Content Wrapping and ensure previous behavior on other Table stories.

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
<img width="1743" alt="Screen Shot 2022-02-01 at 3 22 59 PM" src="https://user-images.githubusercontent.com/34781875/152053677-2b709a00-295f-4e01-8548-4164b636912d.png">


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
