### PR TITLE
Removing Deprecated SFC References

### DIFF
--- a/packages/dropdownMenu/components/DropdownMenu.tsx
+++ b/packages/dropdownMenu/components/DropdownMenu.tsx
@@ -55,7 +55,7 @@ export interface DropdownMenuProps {
   disablePortal?: boolean;
 }
 
-const DropdownMenu: React.SFC<DropdownMenuProps> = props => {
+const DropdownMenu = (props: DropdownMenuProps) => {
   const {
     children,
     disablePortal,

--- a/packages/dropdownMenu/components/DropdownMenuItem.tsx
+++ b/packages/dropdownMenu/components/DropdownMenuItem.tsx
@@ -13,8 +13,8 @@ export interface DropdownMenuItemProps {
   children: React.ReactNode;
 }
 
-const DropdownMenuItem: React.SFC<DropdownMenuItemProps> = ({ children }) => (
-  <React.Fragment>{children}</React.Fragment>
+const DropdownMenuItem = ({ children }: DropdownMenuItemProps) => (
+  <>{children}</>
 );
 
 export default DropdownMenuItem;

--- a/packages/dropdownMenu/components/DropdownSection.tsx
+++ b/packages/dropdownMenu/components/DropdownSection.tsx
@@ -7,7 +7,6 @@ export interface DropdownSectionProps {
     | Array<React.ReactElement<DropdownMenuItemProps>>;
 }
 
-const DropdownSection: React.SFC<DropdownSectionProps> = ({ children }) => (
-  <React.Fragment>{children}</React.Fragment>
-);
+const DropdownSection = ({ children }: DropdownSectionProps) => <>{children}</>;
+
 export default DropdownSection;

--- a/packages/formStructure/components/FieldGroup.tsx
+++ b/packages/formStructure/components/FieldGroup.tsx
@@ -7,9 +7,10 @@ interface FieldGroupProps {
    * The direction the children are laid out in. Can be set for all viewport sizes, or configured to have different values at different viewport width breakpoints
    */
   direction?: BreakpointConfig<"column" | "row">;
+  children: React.ReactNode;
 }
 
-const FieldGroup: React.SFC<FieldGroupProps> = ({ children, direction }) => (
+const FieldGroup = ({ children, direction }: FieldGroupProps) => (
   <Flex gutterSize="m" direction={direction}>
     {(
       React.Children.toArray(children) as Array<

--- a/packages/formStructure/components/FieldListColumn.tsx
+++ b/packages/formStructure/components/FieldListColumn.tsx
@@ -50,6 +50,6 @@ export const FieldListColumn: <
   FieldListColumnProps<T, E> & FieldListColumnWidthProps
 > = () => <React.Fragment />;
 
-export const FieldListColumnSeparator: React.SFC<
+export const FieldListColumnSeparator: React.FC<
   FieldListColumnWidthProps
 > = () => <React.Fragment />;

--- a/packages/formStructure/components/FormMessage.tsx
+++ b/packages/formStructure/components/FormMessage.tsx
@@ -5,7 +5,7 @@ import { SpacingBox } from "../../styleUtils/modifiers";
 
 type FormMessageProps = Omit<InfoBoxProps, "message">;
 
-const FormMessage: React.SFC<FormMessageProps> = ({ children, ...other }) => (
+const FormMessage: React.FC<FormMessageProps> = ({ children, ...other }) => (
   <SpacingBox side="bottom" spacingSize="l" data-cy="formMessage">
     <InfoBoxInline message={children} {...other} />
   </SpacingBox>

--- a/packages/formStructure/components/FormSection.tsx
+++ b/packages/formStructure/components/FormSection.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { SpacingBox } from "../../styleUtils/modifiers";
 
-const FormSection: React.SFC = ({ children }) => (
+const FormSection = ({ children }) => (
   <SpacingBox side="bottom" spacingSize="xl" data-cy="formSection">
     {children}
   </SpacingBox>

--- a/packages/formStructure/components/FormSectionHeader.tsx
+++ b/packages/formStructure/components/FormSectionHeader.tsx
@@ -7,10 +7,7 @@ interface FormSectionHeaderProps {
   subtitle?: React.ReactNode;
 }
 
-const FormSectionHeader: React.SFC<FormSectionHeaderProps> = ({
-  title,
-  subtitle
-}) => (
+const FormSectionHeader = ({ title, subtitle }: FormSectionHeaderProps) => (
   <SpacingBox side="bottom" spacingSize="m" data-cy="formSectionHeader">
     <HeadingText2 data-cy="formSectionHeader-title">{title}</HeadingText2>
     {subtitle && (

--- a/packages/formStructure/components/FormSubSection.tsx
+++ b/packages/formStructure/components/FormSubSection.tsx
@@ -8,12 +8,10 @@ import { Flex, FlexItem } from "../../styleUtils/layout";
 
 interface FormSubSectionProps {
   onRemove?: (event?: React.SyntheticEvent<HTMLElement>) => void;
+  children: React.ReactNode;
 }
 
-const FormSubSection: React.SFC<FormSubSectionProps> = ({
-  children,
-  onRemove
-}) => {
+const FormSubSection = ({ children, onRemove }: FormSubSectionProps) => {
   const subSectionContent = <div className={formFieldStack}>{children}</div>;
   return (
     <Card data-cy="formSubSection">

--- a/packages/inlineBorderedItems/components/InlineBorderedItems.tsx
+++ b/packages/inlineBorderedItems/components/InlineBorderedItems.tsx
@@ -9,7 +9,7 @@ export interface InlineBorderedItemsProps {
   gutterSize?: SpaceSize;
 }
 
-const InlineBorderedItems: React.SFC<InlineBorderedItemsProps> = ({
+const InlineBorderedItems: React.FC<InlineBorderedItemsProps> = ({
   children,
   gutterSize
 }) => <div className={inlineBorderedItems(gutterSize!)}>{children}</div>;

--- a/packages/list/components/BorderedList.tsx
+++ b/packages/list/components/BorderedList.tsx
@@ -4,7 +4,7 @@ import { cx } from "@emotion/css";
 import { SharedListProps } from "./List";
 import { listReset } from "../../shared/styles/styleUtils";
 
-const BorderedList: React.SFC<SharedListProps> = props => {
+const BorderedList = (props: SharedListProps) => {
   const { tag, children } = props;
   const BorderedListEl = tag;
 

--- a/packages/loadingIndicator/components/InlineLoadingIndicator.tsx
+++ b/packages/loadingIndicator/components/InlineLoadingIndicator.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Icon } from "../../icon";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
 
-const InlineLoadingIndicator: React.SFC = () => (
+const InlineLoadingIndicator = () => (
   <Icon
     shape={SystemIcons.Spinner}
     size="xs"

--- a/packages/loadingIndicator/components/SectionLoadingIndicator.tsx
+++ b/packages/loadingIndicator/components/SectionLoadingIndicator.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { sectionLoadingWrapper, sectionLoadingIndicator } from "../style";
 
-const SectionLoadingIndicator: React.SFC = () => (
+const SectionLoadingIndicator = () => (
   <div className={sectionLoadingWrapper}>
     <div
       className={sectionLoadingIndicator}

--- a/packages/messagePanel/components/MessagePanel.tsx
+++ b/packages/messagePanel/components/MessagePanel.tsx
@@ -26,15 +26,16 @@ export interface MessagePanelProps {
    * A secondary action a user can take in the empty state
    */
   secondaryAction?: React.ReactNode;
+  children: React.ReactNode;
 }
 
-const MessagePanel: React.FC<MessagePanelProps> = ({
+const MessagePanel = ({
   appearance,
   heading,
   children,
   primaryAction,
   secondaryAction
-}) => {
+}: MessagePanelProps) => {
   const hasActions = primaryAction || secondaryAction;
 
   return (

--- a/packages/messagePanel/components/MessagePanelActions.tsx
+++ b/packages/messagePanel/components/MessagePanelActions.tsx
@@ -6,10 +6,10 @@ export interface MessagePanelActionsProps {
   secondaryAction?: React.ReactNode;
 }
 
-const MessagePanelActions: React.SFC<MessagePanelActionsProps> = ({
+const MessagePanelActions = ({
   primaryAction,
   secondaryAction
-}) => (
+}: MessagePanelActionsProps) => (
   <Flex align="center" justify="center" gutterSize="m">
     {secondaryAction ? (
       <FlexItem flex="shrink">{secondaryAction}</FlexItem>

--- a/packages/messagePanel/components/MessagePanelWithGraphic.tsx
+++ b/packages/messagePanel/components/MessagePanelWithGraphic.tsx
@@ -21,14 +21,14 @@ interface MessagePanelWithGraphicProps extends MessagePanelProps {
   graphicDimensions?: GraphicDimensions;
 }
 
-const MessagePanelWithGraphic: React.SFC<MessagePanelWithGraphicProps> = ({
+const MessagePanelWithGraphic = ({
   graphicSrc,
   graphicDimensions,
   heading,
   children,
   primaryAction,
   secondaryAction
-}) => {
+}: MessagePanelWithGraphicProps) => {
   const hasActions = primaryAction || secondaryAction;
   return (
     <div data-cy="messagePanelWithGraphic">

--- a/packages/messagePanel/components/MessagePanelWrapper.tsx
+++ b/packages/messagePanel/components/MessagePanelWrapper.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { SpacingBox } from "../../styleUtils/modifiers";
 
-const MessagePanelWrapper: React.SFC = ({ children }) => (
+const MessagePanelWrapper = ({ children }) => (
   <SpacingBox spacingSize={{ default: "l", medium: "xl", large: "xxl" }}>
     {children}
   </SpacingBox>

--- a/packages/popover/components/PopoverListItemAvatar.tsx
+++ b/packages/popover/components/PopoverListItemAvatar.tsx
@@ -8,7 +8,7 @@ interface PopoverListItemAvatarProps extends AvatarProps {
   position?: "start" | "end";
 }
 
-const PopoverListItemAvatar: React.SFC<PopoverListItemAvatarProps> = props => (
+const PopoverListItemAvatar = (props: PopoverListItemAvatarProps) => (
   <Avatar {...props} />
 );
 

--- a/packages/segmentedControl/components/SegmentedControl.tsx
+++ b/packages/segmentedControl/components/SegmentedControl.tsx
@@ -21,7 +21,7 @@ export interface SegmentedControlProps {
   selectedSegment?: string;
 }
 
-const SegmentedControl: React.SFC<SegmentedControlProps> = props => {
+const SegmentedControl = (props: SegmentedControlProps) => {
   const { children, id, selectedSegment, onSelect } = props;
   const handleChange = (onChangeFn, e) => {
     if (onSelect) {

--- a/packages/textInputButton/components/TextInputButton.tsx
+++ b/packages/textInputButton/components/TextInputButton.tsx
@@ -6,7 +6,7 @@ import { IconShapes } from "../../icon/components/Icon";
 export interface TextInputButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
-   * The fill color of the icon inside the b utton
+   * The fill color of the icon inside the button
    */
   color?: string;
   /**
@@ -15,11 +15,7 @@ export interface TextInputButtonProps
   shape: IconShapes;
 }
 
-const TextInputButton: React.SFC<TextInputButtonProps> = ({
-  shape,
-  color,
-  ...other
-}) => {
+const TextInputButton = ({ shape, color, ...other }: TextInputButtonProps) => {
   delete other.className;
   delete other.children;
 


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

SFC is deprecated. If we want to update to React 18 we will need to first address this. I wanted to dedicate a PR to focus solely on the transition away from Stateless Functional Component.

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
