### PR TITLE
feat: add optional id and data-cy to props

### DIFF
--- a/packages/accordion/__snapshots__/accordion.test.tsx.snap
+++ b/packages/accordion/__snapshots__/accordion.test.tsx.snap
@@ -1,10 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Accordion rendering renders an item with interactive content 1`] = `
-<Accordion
-  allowMultipleExpanded={false}
-  data-cy="accordion"
->
+<Accordion>
   <Component
     allowMultipleExpanded={false}
   >
@@ -18,7 +15,6 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
         data-cy="accordion"
       >
         <AccordionItem
-          data-cy="accordionItem"
           id="customId"
         >
           <Component
@@ -68,6 +64,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                     >
                       <span
                         className="css-1nhhn1w"
+                        data-cy="accordionItemTitleInner"
                       >
                         <span
                           className="css-1321nl5"
@@ -113,10 +110,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitleInteractive>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
                   aria-labelledby="customId-heading"
                   className="css-13hugf8"
@@ -130,12 +124,10 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
             </div>
           </Component>
         </AccordionItem>
-        <AccordionItem
-          data-cy="accordionItem"
-        >
+        <AccordionItem>
           <Component
             expandedItems={Array []}
-            id="accordionItem5"
+            id="accordionItem-3"
           >
             <div
               data-cy="accordionItem"
@@ -155,14 +147,14 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                     data-cy="accordionItemTitle accordionItemTitle.danger"
                   >
                     <ResetButton
-                      aria-controls="accordionItem5-content"
+                      aria-controls="accordionItem-3-content"
                       aria-expanded={false}
                       className="css-jd8ubb"
                       data-cy="accordionItemTitle-button"
                       onClick={[Function]}
                     >
                       <button
-                        aria-controls="accordionItem5-content"
+                        aria-controls="accordionItem-3-content"
                         aria-expanded={false}
                         className="css-odh0fh"
                         data-cy="accordionItemTitle-button"
@@ -180,6 +172,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                     >
                       <span
                         className="css-1nhhn1w"
+                        data-cy="accordionItemTitleInner"
                       >
                         <span
                           className="css-1321nl5"
@@ -208,7 +201,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                           className="css-bleycz"
                         >
                           <h3
-                            id="accordionItem5-heading"
+                            id="accordionItem-3-heading"
                           >
                             Panel 1
                           </h3>
@@ -218,7 +211,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                             test
                           </button>
                           <button
-                            aria-controls="accordionItem5-content"
+                            aria-controls="accordionItem-3-content"
                             aria-expanded={false}
                             id="toggle"
                             onClick={[Function]}
@@ -231,16 +224,13 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitleInteractive>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
-                  aria-labelledby="accordionItem5-heading"
+                  aria-labelledby="accordionItem-3-heading"
                   className="css-13hugf8"
                   data-cy="accordionItemContent"
                   hidden={true}
-                  id="accordionItem5-content"
+                  id="accordionItem-3-content"
                 >
                   Content 2
                 </div>
@@ -248,12 +238,10 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
             </div>
           </Component>
         </AccordionItem>
-        <AccordionItem
-          data-cy="accordionItem"
-        >
+        <AccordionItem>
           <Component
             expandedItems={Array []}
-            id="accordionItem6"
+            id="accordionItem-4"
           >
             <div
               data-cy="accordionItem"
@@ -273,7 +261,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                     data-cy="accordionItemTitle accordionItemTitle.disabled"
                   >
                     <ResetButton
-                      aria-controls="accordionItem6-content"
+                      aria-controls="accordionItem-4-content"
                       aria-expanded={false}
                       className="css-jd8ubb"
                       data-cy="accordionItemTitle-button"
@@ -281,7 +269,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                       onClick={[Function]}
                     >
                       <button
-                        aria-controls="accordionItem6-content"
+                        aria-controls="accordionItem-4-content"
                         aria-expanded={false}
                         className="css-1tjctub"
                         data-cy="accordionItemTitle-button"
@@ -300,6 +288,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                     >
                       <span
                         className="css-1nhhn1w"
+                        data-cy="accordionItemTitleInner"
                       >
                         <span
                           className="css-1321nl5"
@@ -330,7 +319,7 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                           <h3
                             className="css-fmvpil"
                             data-cy="accordionItemTitle-heading"
-                            id="accordionItem6-heading"
+                            id="accordionItem-4-heading"
                           >
                             Panel 1
                           </h3>
@@ -345,16 +334,13 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitleInteractive>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
-                  aria-labelledby="accordionItem6-heading"
+                  aria-labelledby="accordionItem-4-heading"
                   className="css-13hugf8"
                   data-cy="accordionItemContent"
                   hidden={true}
-                  id="accordionItem6-content"
+                  id="accordionItem-4-content"
                 >
                   Content 1
                 </div>
@@ -370,8 +356,6 @@ exports[`Accordion rendering renders an item with interactive content 1`] = `
 
 exports[`Accordion rendering renders with expanded items 1`] = `
 <Accordion
-  allowMultipleExpanded={false}
-  data-cy="accordion"
   initialExpandedItems={
     Array [
       "panel1",
@@ -400,7 +384,6 @@ exports[`Accordion rendering renders with expanded items 1`] = `
         data-cy="accordion"
       >
         <AccordionItem
-          data-cy="accordionItem"
           id="panel1"
         >
           <Component
@@ -416,10 +399,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
             <div
               data-cy="accordionItem accordionItem.expanded"
             >
-              <AccordionItemTitle
-                data-cy="accordionItemTitle"
-                headingLevel={3}
-              >
+              <AccordionItemTitle>
                 <AccordionItemTitleOuter
                   data-cy="accordionItemTitle"
                   isExpanded={true}
@@ -456,6 +436,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                             >
                               <span
                                 className="css-13atth2"
+                                data-cy="accordionItemTitleInner"
                               >
                                 <span
                                   className="css-1321nl5"
@@ -494,10 +475,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitle>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
                   aria-labelledby="panel1-heading"
                   className="css-72kisv"
@@ -512,7 +490,6 @@ exports[`Accordion rendering renders with expanded items 1`] = `
           </Component>
         </AccordionItem>
         <AccordionItem
-          data-cy="accordionItem"
           id="panel2"
         >
           <Component
@@ -528,10 +505,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
             <div
               data-cy="accordionItem accordionItem.expanded"
             >
-              <AccordionItemTitle
-                data-cy="accordionItemTitle"
-                headingLevel={3}
-              >
+              <AccordionItemTitle>
                 <AccordionItemTitleOuter
                   data-cy="accordionItemTitle"
                   isExpanded={true}
@@ -568,6 +542,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                             >
                               <span
                                 className="css-13atth2"
+                                data-cy="accordionItemTitleInner"
                               >
                                 <span
                                   className="css-1321nl5"
@@ -606,10 +581,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitle>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
                   aria-labelledby="panel2-heading"
                   className="css-72kisv"
@@ -624,7 +596,6 @@ exports[`Accordion rendering renders with expanded items 1`] = `
           </Component>
         </AccordionItem>
         <AccordionItem
-          data-cy="accordionItem"
           id="panel3"
         >
           <Component
@@ -640,10 +611,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
             <div
               data-cy="accordionItem accordionItem.expanded"
             >
-              <AccordionItemTitle
-                data-cy="accordionItemTitle"
-                headingLevel={3}
-              >
+              <AccordionItemTitle>
                 <AccordionItemTitleOuter
                   data-cy="accordionItemTitle"
                   isExpanded={true}
@@ -680,6 +648,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                             >
                               <span
                                 className="css-13atth2"
+                                data-cy="accordionItemTitleInner"
                               >
                                 <span
                                   className="css-1321nl5"
@@ -718,10 +687,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitle>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
                   aria-labelledby="panel3-heading"
                   className="css-72kisv"
@@ -742,10 +708,7 @@ exports[`Accordion rendering renders with expanded items 1`] = `
 `;
 
 exports[`Accordion rendering renders with no expanded items 1`] = `
-<Accordion
-  allowMultipleExpanded={false}
-  data-cy="accordion"
->
+<Accordion>
   <Component
     allowMultipleExpanded={false}
   >
@@ -759,7 +722,6 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
         data-cy="accordion"
       >
         <AccordionItem
-          data-cy="accordionItem"
           id="customId"
         >
           <Component
@@ -771,8 +733,6 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
             >
               <AccordionItemTitle
                 appearance="danger"
-                data-cy="accordionItemTitle"
-                headingLevel={3}
               >
                 <AccordionItemTitleOuter
                   appearance="danger"
@@ -811,6 +771,7 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                             >
                               <span
                                 className="css-13atth2"
+                                data-cy="accordionItemTitleInner"
                               >
                                 <span
                                   className="css-1321nl5"
@@ -849,10 +810,7 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitle>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
                   aria-labelledby="customId-heading"
                   className="css-13hugf8"
@@ -866,20 +824,16 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
             </div>
           </Component>
         </AccordionItem>
-        <AccordionItem
-          data-cy="accordionItem"
-        >
+        <AccordionItem>
           <Component
             expandedItems={Array []}
-            id="accordionItem2"
+            id="accordionItem-1"
           >
             <div
               data-cy="accordionItem"
             >
               <AccordionItemTitle
-                data-cy="accordionItemTitle"
                 disabled={true}
-                headingLevel={3}
               >
                 <AccordionItemTitleOuter
                   data-cy="accordionItemTitle accordionItemTitle.disabled"
@@ -893,10 +847,10 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                     <h3
                       className="css-fmvpil"
                       data-cy="accordionItemTitle-heading"
-                      id="accordionItem2-heading"
+                      id="accordionItem-1-heading"
                     >
                       <ResetButton
-                        aria-controls="accordionItem2-content"
+                        aria-controls="accordionItem-1-content"
                         aria-expanded="false"
                         className="css-bleycz"
                         data-cy="accordionItemTitle-button"
@@ -904,7 +858,7 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                         onClick={[Function]}
                       >
                         <button
-                          aria-controls="accordionItem2-content"
+                          aria-controls="accordionItem-1-content"
                           aria-expanded="false"
                           className="css-1l66126"
                           data-cy="accordionItemTitle-button"
@@ -920,6 +874,7 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                             >
                               <span
                                 className="css-13atth2"
+                                data-cy="accordionItemTitleInner"
                               >
                                 <span
                                   className="css-1321nl5"
@@ -958,16 +913,13 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitle>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
-                  aria-labelledby="accordionItem2-heading"
+                  aria-labelledby="accordionItem-1-heading"
                   className="css-13hugf8"
                   data-cy="accordionItemContent"
                   hidden={true}
-                  id="accordionItem2-content"
+                  id="accordionItem-1-content"
                 >
                   Content 2
                 </div>
@@ -975,18 +927,15 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
             </div>
           </Component>
         </AccordionItem>
-        <AccordionItem
-          data-cy="accordionItem"
-        >
+        <AccordionItem>
           <Component
             expandedItems={Array []}
-            id="accordionItem3"
+            id="accordionItem-2"
           >
             <div
               data-cy="accordionItem"
             >
               <AccordionItemTitle
-                data-cy="accordionItemTitle"
                 headingLevel={2}
               >
                 <AccordionItemTitleOuter
@@ -1000,17 +949,17 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                     <h2
                       className="css-fmvpil"
                       data-cy="accordionItemTitle-heading"
-                      id="accordionItem3-heading"
+                      id="accordionItem-2-heading"
                     >
                       <ResetButton
-                        aria-controls="accordionItem3-content"
+                        aria-controls="accordionItem-2-content"
                         aria-expanded="false"
                         className="css-bleycz"
                         data-cy="accordionItemTitle-button"
                         onClick={[Function]}
                       >
                         <button
-                          aria-controls="accordionItem3-content"
+                          aria-controls="accordionItem-2-content"
                           aria-expanded="false"
                           className="css-1gh59q1"
                           data-cy="accordionItemTitle-button"
@@ -1025,6 +974,7 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                             >
                               <span
                                 className="css-13atth2"
+                                data-cy="accordionItemTitleInner"
                               >
                                 <span
                                   className="css-1321nl5"
@@ -1063,16 +1013,13 @@ exports[`Accordion rendering renders with no expanded items 1`] = `
                   </div>
                 </AccordionItemTitleOuter>
               </AccordionItemTitle>
-              <AccordionItemContent
-                data-cy="accordionItemContent"
-                paddingSize="m"
-              >
+              <AccordionItemContent>
                 <div
-                  aria-labelledby="accordionItem3-heading"
+                  aria-labelledby="accordionItem-2-heading"
                   className="css-13hugf8"
                   data-cy="accordionItemContent"
                   hidden={true}
-                  id="accordionItem3-content"
+                  id="accordionItem-2-content"
                 >
                   Content 3
                 </div>

--- a/packages/accordion/components/Accordion.tsx
+++ b/packages/accordion/components/Accordion.tsx
@@ -8,15 +8,16 @@ interface AccordionProps extends AccordionBaseProps {
    * An array of open accordion panel IDs
    */
   initialExpandedItems?: string[];
+  children: React.ReactNode[];
 }
 
-const Accordion: React.FC<AccordionProps> = ({
-  allowMultipleExpanded,
-  "data-cy": dataCy,
+const Accordion = ({
+  allowMultipleExpanded = false,
+  "data-cy": dataCy = "accordion",
   children,
   initialExpandedItems,
   onChange
-}) => {
+}: AccordionProps) => {
   return (
     <AccordionProvider
       allowMultipleExpanded={allowMultipleExpanded}
@@ -26,11 +27,6 @@ const Accordion: React.FC<AccordionProps> = ({
       <Stack data-cy={dataCy}>{children}</Stack>
     </AccordionProvider>
   );
-};
-
-Accordion.defaultProps = {
-  allowMultipleExpanded: false,
-  "data-cy": "accordion"
 };
 
 export default Accordion;

--- a/packages/accordion/components/AccordionContext.tsx
+++ b/packages/accordion/components/AccordionContext.tsx
@@ -5,6 +5,7 @@ interface AccordionProviderProps {
   controlledExpandedItems?: string[];
   initialExpandedItems?: string[];
   onChange?: (expandedItems: string[]) => void;
+  children: React.ReactNode;
 }
 
 type AccordionContext = {
@@ -14,13 +15,13 @@ type AccordionContext = {
 
 export const Context = createContext<AccordionContext | null>(null);
 
-export const Provider: React.FC<AccordionProviderProps> = ({
+export const Provider = ({
   allowMultipleExpanded,
   children,
   controlledExpandedItems,
   initialExpandedItems = [],
   onChange
-}) => {
+}: AccordionProviderProps) => {
   const [expandedItems, setExpanded] = useState<string[]>(
     controlledExpandedItems ? controlledExpandedItems : initialExpandedItems
   );

--- a/packages/accordion/components/AccordionItem.tsx
+++ b/packages/accordion/components/AccordionItem.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useId } from "react-id-generator";
+import nextId from "react-id-generator";
 import { Context as AccordionContext } from "./AccordionContext";
 import { Provider as AccordionItemProvider } from "./AccordionItemContext";
 
@@ -12,22 +12,21 @@ export interface AccordionItemProps {
    * A custom ID for the accordion panel
    */
   id?: string;
+  children?: React.ReactNode;
 }
 
-const AccordionItem: React.FC<AccordionItemProps> = ({
+const AccordionItem = ({
   children,
-  "data-cy": dataCy,
-  id
-}) => {
-  const [generatedId] = useId(1, "accordionItem");
-  const accordionItemId = id || generatedId;
+  "data-cy": dataCy = "accordionItem",
+  id = nextId("accordionItem-")
+}: AccordionItemProps) => {
   const accordionContext = React.useContext(AccordionContext);
-  const isExpanded = accordionContext?.expandedItems.includes(accordionItemId);
+  const isExpanded = accordionContext?.expandedItems.includes(id);
 
   return (
     <AccordionItemProvider
       expandedItems={accordionContext?.expandedItems || []}
-      id={accordionItemId}
+      id={id}
     >
       <div
         data-cy={[dataCy, ...(isExpanded ? [`${dataCy}.expanded`] : [])].join(
@@ -38,10 +37,6 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
       </div>
     </AccordionItemProvider>
   );
-};
-
-AccordionItem.defaultProps = {
-  "data-cy": "accordionItem"
 };
 
 export default AccordionItem;

--- a/packages/accordion/components/AccordionItemContent.tsx
+++ b/packages/accordion/components/AccordionItemContent.tsx
@@ -10,7 +10,7 @@ import { getAllFocusableChildNodes } from "../../utilities/getFocusableChildNode
 import { accordionItemContent } from "../style";
 import { SpaceSize } from "../../shared/styles/styleUtils/modifiers/modifierUtils";
 
-const AccordionItemContent: React.FC<{
+interface AccordionItemContentProps {
   /**
    * human-readable selector used for writing tests
    */
@@ -19,7 +19,14 @@ const AccordionItemContent: React.FC<{
    * the amount of space between the border and the content
    */
   paddingSize?: SpaceSize;
-}> = ({ children, "data-cy": dataCy, paddingSize }) => {
+  children: React.ReactNode;
+}
+
+const AccordionItemContent = ({
+  children,
+  "data-cy": dataCy = "accordionItemContent",
+  paddingSize = "m"
+}: AccordionItemContentProps) => {
   const contentRef = React.useRef<HTMLDivElement>(null);
   const accordionItemContext = React.useContext(AccordionItemContext);
   React.useEffect(() => {
@@ -58,11 +65,6 @@ const AccordionItemContent: React.FC<{
       {children}
     </div>
   );
-};
-
-AccordionItemContent.defaultProps = {
-  paddingSize: "m",
-  "data-cy": "accordionItemContent"
 };
 
 export default AccordionItemContent;

--- a/packages/accordion/components/AccordionItemContext.tsx
+++ b/packages/accordion/components/AccordionItemContext.tsx
@@ -1,8 +1,10 @@
 import React, { createContext } from "react";
+import nextId from "react-id-generator";
 
 interface AccordionProviderProps {
-  id: string;
+  id?: string;
   expandedItems: string[];
+  children: React.ReactNode;
 }
 
 type AccordionItemContext = {
@@ -14,11 +16,11 @@ type AccordionItemContext = {
 
 export const Context = createContext<AccordionItemContext | null>(null);
 
-export const Provider: React.FC<AccordionProviderProps> = ({
+export const Provider = ({
   children,
   expandedItems,
-  id: baseId
-}) => (
+  id: baseId = nextId("accordionProvider-")
+}: AccordionProviderProps) => (
   <Context.Provider
     value={{
       baseId,

--- a/packages/accordion/components/AccordionItemTitle.tsx
+++ b/packages/accordion/components/AccordionItemTitle.tsx
@@ -27,15 +27,16 @@ export interface AccordionItemTitleProps {
    * Priority of the heading. Numbers map to <h1> through <h6>
    */
   headingLevel?: HeadingLevel;
+  children: React.ReactNode;
 }
 
-const AccordionItemTitle: React.FC<AccordionItemTitleProps> = ({
+const AccordionItemTitle = ({
   appearance,
   children,
-  "data-cy": dataCy,
+  "data-cy": dataCy = "accordionItemTitle",
   disabled,
-  headingLevel
-}) => {
+  headingLevel = 3
+}: AccordionItemTitleProps) => {
   const HeadingTag: keyof React.ReactHTML = `h${headingLevel}` as
     | "h2"
     | "h3"
@@ -88,11 +89,6 @@ const AccordionItemTitle: React.FC<AccordionItemTitleProps> = ({
       </HeadingTag>
     </AccordionItemTitleOuter>
   );
-};
-
-AccordionItemTitle.defaultProps = {
-  headingLevel: 3,
-  "data-cy": "accordionItemTitle"
 };
 
 export default AccordionItemTitle;

--- a/packages/accordion/components/AccordionItemTitleInner.tsx
+++ b/packages/accordion/components/AccordionItemTitleInner.tsx
@@ -7,10 +7,19 @@ import Icon from "../../icon/components/Icon";
 import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { fillWidth, accordionTitleInteractive } from "../style";
 
-const AccordionItemTitleInner: React.FC<{
+export interface AccordionItemTitleInnerProps {
   isExpanded?: boolean;
   isInteractive?: boolean;
-}> = ({ children, isExpanded, isInteractive }) => {
+  children: React.ReactNode;
+  ["data-cy"]?: string;
+}
+
+const AccordionItemTitleInner = ({
+  children,
+  isExpanded,
+  isInteractive,
+  "data-cy": dataCy = "accordionItemTitleInner"
+}: AccordionItemTitleInnerProps) => {
   const contentRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     const allFocusable: HTMLElement[] = contentRef.current
@@ -31,6 +40,7 @@ const AccordionItemTitleInner: React.FC<{
       className={cx(padding("all"), flex({ align: "center" }), {
         [accordionTitleInteractive]: isInteractive
       })}
+      data-cy={dataCy}
     >
       <span className={padding("right", "xs")}>
         <Icon

--- a/packages/accordion/components/AccordionItemTitleOuter.tsx
+++ b/packages/accordion/components/AccordionItemTitleOuter.tsx
@@ -14,15 +14,16 @@ interface AccordionItemTitleOuterProps {
   disabled?: boolean;
   isExpanded?: boolean;
   ["data-cy"]?: string;
+  children?: React.ReactNode;
 }
 
-const AccordionItemTitleOuter: React.FC<AccordionItemTitleOuterProps> = ({
+const AccordionItemTitleOuter = ({
   appearance,
   children,
-  "data-cy": dataCy,
+  "data-cy": dataCy = "accordionItemTitleOuter",
   disabled,
   isExpanded
-}) => (
+}: AccordionItemTitleOuterProps) => (
   <div
     className={cx(border("all"), accordionTitle, {
       [accordionTitleDanger]: appearance === "danger",

--- a/packages/accordion/components/StatelessAccordion.tsx
+++ b/packages/accordion/components/StatelessAccordion.tsx
@@ -8,15 +8,16 @@ interface AccordionProps extends AccordionBaseProps {
    * An array of open accordion panel IDs
    */
   expandedItems?: string[];
+  children: React.ReactNode;
 }
 
-const Accordion: React.FC<AccordionProps> = ({
-  allowMultipleExpanded,
-  "data-cy": dataCy,
+const Accordion = ({
+  allowMultipleExpanded = false,
+  "data-cy": dataCy = "accordion",
   children,
   expandedItems = [],
   onChange
-}) => {
+}: AccordionProps) => {
   return (
     <AccordionProvider
       allowMultipleExpanded={allowMultipleExpanded}
@@ -26,11 +27,6 @@ const Accordion: React.FC<AccordionProps> = ({
       <Stack data-cy={dataCy}>{children}</Stack>
     </AccordionProvider>
   );
-};
-
-Accordion.defaultProps = {
-  allowMultipleExpanded: false,
-  "data-cy": "accordion"
 };
 
 export default Accordion;

--- a/packages/segmentedControl/components/SegmentedControl.tsx
+++ b/packages/segmentedControl/components/SegmentedControl.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import nextId from "react-id-generator";
 import { segmentedControlContainer } from "../style";
 import { SegmentedControlButtonProps } from "../components/SegmentedControlButton";
 
@@ -10,7 +11,7 @@ export interface SegmentedControlProps {
   /**
    * A unique identifier for the segmented control
    */
-  id: string;
+  id?: string;
   /**
    * Callback for when a user makes a selection. The active segment value is the first parameter
    */
@@ -19,10 +20,20 @@ export interface SegmentedControlProps {
    * The value of the selected segment input
    */
   selectedSegment?: string;
+  /**
+   * human-readable selector used for writing tests
+   */
+  ["data-cy"]?: string;
 }
 
 const SegmentedControl = (props: SegmentedControlProps) => {
-  const { children, id, selectedSegment, onSelect } = props;
+  const {
+    children,
+    id = nextId("segmentedControl-"),
+    selectedSegment,
+    onSelect,
+    "data-cy": dataCy = "segmentedControl"
+  } = props;
   const handleChange = (onChangeFn, e) => {
     if (onSelect) {
       onSelect(e.target.value);
@@ -33,7 +44,7 @@ const SegmentedControl = (props: SegmentedControlProps) => {
   };
 
   return (
-    <div className={segmentedControlContainer} data-cy="segmentedControl">
+    <div className={segmentedControlContainer} data-cy={dataCy}>
       {children.map((segment, i) => {
         return React.cloneElement(segment, {
           isActive: selectedSegment === segment.props.value,

--- a/packages/selectInput/components/SelectInput.tsx
+++ b/packages/selectInput/components/SelectInput.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cx } from "@emotion/css";
+import nextId from "react-id-generator";
 import {
   optionalIcon,
   select,
@@ -46,7 +47,7 @@ export interface SelectInputProps extends React.HTMLProps<HTMLSelectElement> {
   /**
    * Unique identifier used for the form input component
    */
-  id: string;
+  id?: string;
   /**
    * Sets the contents of the input label. This can be a `string` or any `ReactNode`.
    */
@@ -94,7 +95,7 @@ class SelectInput extends React.PureComponent<
       appearance,
       errors,
       iconStart,
-      id,
+      id = nextId("selectInput-"),
       options,
       showInputLabel,
       inputLabel,

--- a/packages/shared/components/FormFieldWrapper.tsx
+++ b/packages/shared/components/FormFieldWrapper.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import nextId from "react-id-generator";
 import { cx } from "@emotion/css";
 import {
   flush,
@@ -23,12 +24,17 @@ interface FormFieldWrapperProps {
   children: (renderProps: RenderProps) => React.ReactNode;
   errors?: React.ReactNode[];
   hintContent?: React.ReactNode;
-  id: string;
+  id?: string;
 }
 
 class FormFieldWrapper extends React.PureComponent<FormFieldWrapperProps, {}> {
   public render() {
-    const { children, errors, hintContent, id } = this.props;
+    const {
+      children,
+      errors,
+      hintContent,
+      id = nextId("formFieldWrapper-")
+    } = this.props;
 
     return children({
       getValidationErrors: this.getValidationErrors(errors, id),

--- a/packages/slideToggle/components/SlideToggle.tsx
+++ b/packages/slideToggle/components/SlideToggle.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cx } from "@emotion/css";
+import nextId from "react-id-generator";
 import {
   flex,
   flexItem,
@@ -24,7 +25,7 @@ import {
   toggle,
   toggleRound,
   toggleContainer,
-  toggleInputApperances,
+  toggleInputAppearances,
   toggleInputLabel,
   toggleInputFeedbackText
 } from "../style";
@@ -41,7 +42,7 @@ export interface SlideToggleProps extends React.HTMLProps<HTMLInputElement> {
   /**
    * Unique identifier used for the input element
    */
-  id: string;
+  id?: string;
   /**
    * The text or node content that appears next to the input
    */
@@ -74,7 +75,7 @@ const SlideToggle: React.FC<React.PropsWithRef<SlideToggleProps>> = props => {
     children,
     disabled,
     hintContent,
-    id,
+    id = nextId("slideToggle-"),
     inputLabel,
     showInputLabel,
     vertAlign,
@@ -146,12 +147,12 @@ const SlideToggle: React.FC<React.PropsWithRef<SlideToggleProps>> = props => {
                   />
                   <div
                     className={cx(toggle, toggleRound, {
-                      [toggleInputApperances[`${appearance}-focus`]]: hasFocus,
-                      [toggleInputApperances[`${appearance}-active`]]: checked,
-                      [toggleInputApperances["focus-active"]]:
+                      [toggleInputAppearances[`${appearance}-focus`]]: hasFocus,
+                      [toggleInputAppearances[`${appearance}-active`]]: checked,
+                      [toggleInputAppearances["focus-active"]]:
                         checked && hasFocus,
-                      [toggleInputApperances.disabled]: disabled,
-                      [toggleInputApperances["disabled-active"]]:
+                      [toggleInputAppearances.disabled]: disabled,
+                      [toggleInputAppearances["disabled-active"]]:
                         disabled && checked
                     })}
                   >

--- a/packages/slideToggle/style.ts
+++ b/packages/slideToggle/style.ts
@@ -25,7 +25,7 @@ export const toggleInputFeedbackText = css`
   padding-left: ${toggleInputWidth + parseInt(spaceS, 10)}px;
 `;
 
-export const toggleInputApperances = {
+export const toggleInputAppearances = {
   disabled: css`
     border: solid;
     border-width: ${toggleRoundBorder}px;

--- a/packages/tablev2/Table.tsx
+++ b/packages/tablev2/Table.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import nextId from "react-id-generator";
 import { cx } from "@emotion/css";
 import * as style from "./style";
 import { Draggable, Sorter } from "./Util";
@@ -103,7 +104,7 @@ const rowClassName = <A extends unknown>(
 
 type HeaderCellProps<Entry> = {
   column: Column<Entry>;
-  id: string;
+  id?: string;
   state: State;
   textAlign?: "left" | "right" | "center";
   update: (a: Partial<State>) => void;
@@ -117,7 +118,7 @@ const ariaSortStringMap: { asc: "ascending"; desc: "descending" } = {
 
 function HeaderCell<Entry>({
   column,
-  id,
+  id = nextId("headerCell-"),
   update,
   state,
   showScrollShadow

--- a/packages/textarea/components/Textarea.tsx
+++ b/packages/textarea/components/Textarea.tsx
@@ -15,7 +15,7 @@ export interface TextareaProps extends React.HTMLProps<HTMLTextAreaElement> {
   /**
    * Unique identifier used for the form textarea element
    */
-  id: string;
+  id?: string;
   /**
    * Sets the current appearance of the component. This defaults to InputAppearance.Standard, but supports `InputAppearance.Error` & `InputAppearance.Success` appearances as well.
    */

--- a/packages/toggleInput/components/ToggleInput.tsx
+++ b/packages/toggleInput/components/ToggleInput.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cx } from "@emotion/css";
+import nextId from "react-id-generator";
 
 import {
   flex,
@@ -23,7 +24,7 @@ import {
   toggleInputFeedbackText,
   toggleInputLabel,
   toggleInput,
-  toggleInputApperances
+  toggleInputAppearances
 } from "../style";
 import { InputAppearance } from "../../shared/types/inputAppearance";
 import FormFieldWrapper from "../../shared/components/FormFieldWrapper";
@@ -40,7 +41,7 @@ export interface ToggleInputProps extends React.HTMLProps<HTMLInputElement> {
   /**
    * Unique identifier used for the input element
    */
-  id: string;
+  id?: string;
   /**
    * The text or node content that appears next to the input
    */
@@ -86,7 +87,7 @@ const ToggleInput = React.forwardRef<HTMLInputElement, LocalToggleInputProps>(
       children,
       disabled,
       hintContent,
-      id,
+      id = nextId("toggleInput-"),
       inputLabel,
       showInputLabel,
       vertAlign,
@@ -150,13 +151,13 @@ const ToggleInput = React.forwardRef<HTMLInputElement, LocalToggleInputProps>(
                 <>
                   <div
                     className={cx(toggleInput, {
-                      [toggleInputApperances[`${appearance}-focus`]]: hasFocus,
-                      [toggleInputApperances[`${appearance}-active`]]:
+                      [toggleInputAppearances[`${appearance}-focus`]]: hasFocus,
+                      [toggleInputAppearances[`${appearance}-active`]]:
                         checked || isIndeterminate,
-                      [toggleInputApperances["focus-active"]]:
+                      [toggleInputAppearances["focus-active"]]:
                         checked && hasFocus,
-                      [toggleInputApperances.disabled]: disabled,
-                      [toggleInputApperances["disabled-active"]]:
+                      [toggleInputAppearances.disabled]: disabled,
+                      [toggleInputAppearances["disabled-active"]]:
                         disabled && checked,
                       [checkboxInput]: inputType === "checkbox",
                       [radioInput]: inputType === "radio",

--- a/packages/toggleInput/style.ts
+++ b/packages/toggleInput/style.ts
@@ -33,7 +33,7 @@ export const toggleInputFeedbackText = css`
   padding-left: ${toggleInputHeight + parseInt(toggleInputTextPadding, 10)}px;
 `;
 
-export const toggleInputApperances = {
+export const toggleInputAppearances = {
   disabled: css`
     background-color: ${themeBgDisabled};
     border-color: ${themeBgDisabled};

--- a/packages/toggleWrapper/components/ToggleWrapper.tsx
+++ b/packages/toggleWrapper/components/ToggleWrapper.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import nextId from "react-id-generator";
 import { visuallyHidden, display } from "../../shared/styles/styleUtils";
 
 interface RenderProps {
@@ -18,11 +19,15 @@ export interface ToggleWrapperProps extends React.HTMLProps<HTMLInputElement> {
   /**
    * The unique identifier for the toggle
    */
-  id: string;
+  id?: string;
   /**
    * The type of boolean input element
    */
   type?: "checkbox" | "radio";
+  /**
+   * human-readable selector used for writing tests
+   */
+  ["data-cy"]?: string;
 }
 
 interface LocalToggleWrapperProps extends ToggleWrapperProps {
@@ -53,7 +58,13 @@ class ToggleWrapper extends React.PureComponent<
   }
 
   public render() {
-    const { children, id, isActive, ...other } = this.props;
+    const {
+      children,
+      id = nextId("toggleWrapper-"),
+      "data-cy": dataCy = "toggleWrapper-input",
+      isActive,
+      ...other
+    } = this.props;
     const { hasFocus } = this.state;
     delete other.checked;
     delete other.className;
@@ -71,7 +82,7 @@ class ToggleWrapper extends React.PureComponent<
           className={visuallyHidden}
           checked={isActive}
           aria-checked={isActive}
-          data-cy="toggleWrapper-input"
+          data-cy={dataCy}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           {...other}

--- a/packages/toggleWrapper/tests/__snapshots__/ToggleWrapper.test.tsx.snap
+++ b/packages/toggleWrapper/tests/__snapshots__/ToggleWrapper.test.tsx.snap
@@ -22,12 +22,14 @@ exports[`ToggleWrapper renders 1`] = `
 >
   <label
     className="emotion-0"
+    htmlFor="toggleWrapper-1"
   >
     <input
       aria-checked={true}
       checked={true}
       className="emotion-1"
       data-cy="toggleWrapper-input"
+      id="toggleWrapper-1"
       onBlur={[Function]}
       onFocus={[Function]}
       type="checkbox"
@@ -61,12 +63,14 @@ exports[`ToggleWrapper renders as a radio input 1`] = `
 >
   <label
     className="emotion-0"
+    htmlFor="toggleWrapper-2"
   >
     <input
       aria-checked={true}
       checked={true}
       className="emotion-1"
       data-cy="toggleWrapper-input"
+      id="toggleWrapper-2"
       onBlur={[Function]}
       onFocus={[Function]}
       type="radio"

--- a/packages/tooltip/components/Tooltip.tsx
+++ b/packages/tooltip/components/Tooltip.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import nextId from "react-id-generator";
 import Dropdownable, {
   Direction
 } from "../../dropdownable/components/Dropdownable";
@@ -7,7 +8,7 @@ import { getFirstFocusableChildNode } from "../../utilities/getFocusableChildNod
 
 export interface BaseTooltipProps {
   children: React.ReactNode | string;
-  id: string;
+  id?: string;
   maxWidth?: number | null;
   minWidth?: number;
 }
@@ -30,7 +31,7 @@ const Tooltip = ({
   ariaLabel,
   children,
   disablePortal,
-  id,
+  id = nextId("tooltip-"),
   maxWidth = 300,
   minWidth,
   onClose,

--- a/packages/utilities/label.tsx
+++ b/packages/utilities/label.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import nextId from "react-id-generator";
 import { cx } from "@emotion/css";
 import { InputAppearance } from "../shared/types/inputAppearance";
 import {
@@ -24,11 +25,18 @@ const reqStar = <span className={cx(tintText(themeError))}> *</span>;
 export const renderLabel: React.FC<{
   appearance?: string;
   hidden?: boolean;
-  id: string;
+  id?: string;
   label?: React.ReactNode;
   required?: boolean;
   tooltipContent?: React.ReactNode;
-}> = ({ appearance, hidden, id, label, required, tooltipContent }) => {
+}> = ({
+  appearance,
+  hidden,
+  label,
+  id = nextId(),
+  required,
+  tooltipContent
+}) => {
   const hasError = appearance === InputAppearance.Error;
   const labelClassName = hidden ? cx(visuallyHidden) : getLabelStyle(hasError);
   const labelNode = (


### PR DESCRIPTION
Closes D2IQ-64874

Changes: 
- required `id` props set to optional with dynamically created defaults with nextId()
- `data-cy` props added where applicable and given default values
- Refactored some React.FC components
- Fixed typo on: "toggleInputApperances"

Avoided any breaking changes. Required ids should already have values set in the UI. Continued the usage of any default values of data-cy. 

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [x] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
