### PR TITLE
fix: change type for children prop in the Accordian component

### DIFF
--- a/packages/accordion/components/Accordion.tsx
+++ b/packages/accordion/components/Accordion.tsx
@@ -8,7 +8,7 @@ interface AccordionProps extends AccordionBaseProps {
    * An array of open accordion panel IDs
    */
   initialExpandedItems?: string[];
-  children: React.ReactNode[];
+  children: React.ReactNode | React.ReactNode[];
 }
 
 const Accordion = ({


### PR DESCRIPTION
The component was getting a Typescript error when used with only a single ReactNode passed in as a child, so
the type needed to be updated to allow for for both a single ReactNode and an array of ReactNodes

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [ ] Info for applicable sections above is provided
