### PR TITLE
Fix for tabIndex values with updated react-focus-lock versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react-chartist": "0.14.4",
         "react-click-outside": "3.0.1",
         "react-delegate-component": "1.0.0",
-        "react-focus-lock": "2.6.0",
+        "react-focus-lock": "2.8.1",
         "react-id-generator": "3.0.2",
         "react-popper": "2.2.5",
         "react-tabs": "3.2.3",
@@ -17817,9 +17817,9 @@
       }
     },
     "node_modules/focus-lock": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.2.tgz",
-      "integrity": "sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.10.2.tgz",
+      "integrity": "sha512-DSaI/UHZ/02sg1P616aIWgToQcrKKBmcCvomDZ1PZvcJFj350PnWhSJxJ76T3e5/GbtQEARIACtbrdlrF9C5kA==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -17828,9 +17828,9 @@
       }
     },
     "node_modules/focus-lock/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -30447,12 +30447,12 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.6.0.tgz",
-      "integrity": "sha512-2yB5KWyaefbvFDgqvsg/KpIjbqVlhIY2c/dyDcokDLhB3Ib7I4bjsrta5OkI5euUoIu5xBTyBwIQZPykUJAr1g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.8.1.tgz",
+      "integrity": "sha512-4kb9I7JIiBm0EJ+CsIBQ+T1t5qtmwPRbFGYFQ0t2q2qIpbFbYTHDjnjJVFB7oMBtXityEOQehblJPjqSIf3Amg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.9.2",
+        "focus-lock": "^0.10.2",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.5",
         "use-callback-ref": "^1.2.5",
@@ -50605,17 +50605,17 @@
       }
     },
     "focus-lock": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.2.tgz",
-      "integrity": "sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.10.2.tgz",
+      "integrity": "sha512-DSaI/UHZ/02sg1P616aIWgToQcrKKBmcCvomDZ1PZvcJFj350PnWhSJxJ76T3e5/GbtQEARIACtbrdlrF9C5kA==",
       "requires": {
         "tslib": "^2.0.3"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -60129,12 +60129,12 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-focus-lock": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.6.0.tgz",
-      "integrity": "sha512-2yB5KWyaefbvFDgqvsg/KpIjbqVlhIY2c/dyDcokDLhB3Ib7I4bjsrta5OkI5euUoIu5xBTyBwIQZPykUJAr1g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.8.1.tgz",
+      "integrity": "sha512-4kb9I7JIiBm0EJ+CsIBQ+T1t5qtmwPRbFGYFQ0t2q2qIpbFbYTHDjnjJVFB7oMBtXityEOQehblJPjqSIf3Amg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.9.2",
+        "focus-lock": "^0.10.2",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.5",
         "use-callback-ref": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-chartist": "0.14.4",
     "react-click-outside": "3.0.1",
     "react-delegate-component": "1.0.0",
-    "react-focus-lock": "2.6.0",
+    "react-focus-lock": "2.8.1",
     "react-id-generator": "3.0.2",
     "react-popper": "2.2.5",
     "react-tabs": "3.2.3",

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -828,9 +828,46 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                       tabindex="0"
                     />
                     <div
+                      data-focus-lock-disabled="false"
+                    >
+                      <div
+                        class="emotion-0"
+                        role="button"
+                        tabindex="-1"
+                      />
+                      <div
+                        class="emotion-1"
+                      >
+                        <div
+                          class="emotion-2"
+                          role="dialog"
+                          tabindex="-1"
+                        >
+                          <div
+                            class="emotion-3"
+                          >
+                            <div
+                              tabindex="0"
+                            >
+                              I am modal content
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
                       data-focus-guard="true"
                       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                      tabindex="1"
+                      tabindex="0"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <div>
+                    <div
+                      data-focus-guard="true"
+                      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+                      tabindex="0"
                     />
                     <div
                       data-focus-lock-disabled="false"
@@ -875,11 +912,6 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                       tabindex="0"
                     />
                     <div
-                      data-focus-guard="true"
-                      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                      tabindex="1"
-                    />
-                    <div
                       data-focus-lock-disabled="false"
                     >
                       <div
@@ -920,58 +952,6 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                       data-focus-guard="true"
                       style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
                       tabindex="0"
-                    />
-                    <div
-                      data-focus-guard="true"
-                      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                      tabindex="1"
-                    />
-                    <div
-                      data-focus-lock-disabled="false"
-                    >
-                      <div
-                        class="emotion-0"
-                        role="button"
-                        tabindex="-1"
-                      />
-                      <div
-                        class="emotion-1"
-                      >
-                        <div
-                          class="emotion-2"
-                          role="dialog"
-                          tabindex="-1"
-                        >
-                          <div
-                            class="emotion-3"
-                          >
-                            <div
-                              tabindex="0"
-                            >
-                              I am modal content
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      data-focus-guard="true"
-                      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                      tabindex="0"
-                    />
-                  </div>
-                </div>
-                <div>
-                  <div>
-                    <div
-                      data-focus-guard="true"
-                      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                      tabindex="0"
-                    />
-                    <div
-                      data-focus-guard="true"
-                      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                      tabindex="1"
                     />
                     <div
                       data-focus-lock-disabled="false"
@@ -1479,11 +1459,6 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                       tabindex="0"
                     />
                     <div
-                      data-focus-guard="true"
-                      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                      tabindex="1"
-                    />
-                    <div
                       data-focus-lock-disabled="false"
                     >
                       <div
@@ -1633,22 +1608,6 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                         }
                       }
                       tabIndex={0}
-                    />
-                    <div
-                      data-focus-guard={true}
-                      key="guard-nearest"
-                      style={
-                        Object {
-                          "height": "0px",
-                          "left": "1px",
-                          "overflow": "hidden",
-                          "padding": 0,
-                          "position": "fixed",
-                          "top": "1px",
-                          "width": "1px",
-                        }
-                      }
-                      tabIndex={1}
                     />
                     <SideEffect(FocusWatcher)
                       autoFocus={true}
@@ -3735,9 +3694,46 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                     tabindex="0"
                   />
                   <div
+                    data-focus-lock-disabled="false"
+                  >
+                    <div
+                      class="emotion-0"
+                      role="button"
+                      tabindex="-1"
+                    />
+                    <div
+                      class="emotion-1"
+                    >
+                      <div
+                        class="emotion-2"
+                        role="dialog"
+                        tabindex="-1"
+                      >
+                        <div
+                          class="emotion-3"
+                        >
+                          <div
+                            tabindex="0"
+                          >
+                            I am modal content
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
                     data-focus-guard="true"
                     style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="1"
+                    tabindex="0"
+                  />
+                </div>
+              </div>
+              <div>
+                <div>
+                  <div
+                    data-focus-guard="true"
+                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+                    tabindex="0"
                   />
                   <div
                     data-focus-lock-disabled="false"
@@ -3782,11 +3778,6 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                     tabindex="0"
                   />
                   <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="1"
-                  />
-                  <div
                     data-focus-lock-disabled="false"
                   >
                     <div
@@ -3827,58 +3818,6 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                     data-focus-guard="true"
                     style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
                     tabindex="0"
-                  />
-                  <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="1"
-                  />
-                  <div
-                    data-focus-lock-disabled="false"
-                  >
-                    <div
-                      class="emotion-0"
-                      role="button"
-                      tabindex="-1"
-                    />
-                    <div
-                      class="emotion-1"
-                    >
-                      <div
-                        class="emotion-2"
-                        role="dialog"
-                        tabindex="-1"
-                      >
-                        <div
-                          class="emotion-3"
-                        >
-                          <div
-                            tabindex="0"
-                          >
-                            I am modal content
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="0"
-                  />
-                </div>
-              </div>
-              <div>
-                <div>
-                  <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="0"
-                  />
-                  <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="1"
                   />
                   <div
                     data-focus-lock-disabled="false"
@@ -4008,11 +3947,6 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                     tabindex="0"
                   />
                   <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="1"
-                  />
-                  <div
                     data-focus-lock-disabled="false"
                   >
                     <div
@@ -4138,11 +4072,6 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                     data-focus-guard="true"
                     style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
                     tabindex="0"
-                  />
-                  <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="1"
                   />
                   <div
                     data-focus-lock-disabled="false"
@@ -4592,11 +4521,6 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                     tabindex="0"
                   />
                   <div
-                    data-focus-guard="true"
-                    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                    tabindex="1"
-                  />
-                  <div
                     data-focus-lock-disabled="false"
                   >
                     <div
@@ -4728,22 +4652,6 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                       }
                     }
                     tabIndex={0}
-                  />
-                  <div
-                    data-focus-guard={true}
-                    key="guard-nearest"
-                    style={
-                      Object {
-                        "height": "0px",
-                        "left": "1px",
-                        "overflow": "hidden",
-                        "padding": 0,
-                        "position": "fixed",
-                        "top": "1px",
-                        "width": "1px",
-                      }
-                    }
-                    tabIndex={1}
                   />
                   <SideEffect(FocusWatcher)
                     autoFocus={true}
@@ -6088,11 +5996,6 @@ exports[`Modal ModalBase renders ModalBase 1`] = `
                   tabindex="0"
                 />
                 <div
-                  data-focus-guard="true"
-                  style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                  tabindex="1"
-                />
-                <div
                   data-focus-lock-disabled="false"
                 >
                   <div
@@ -6242,11 +6145,6 @@ exports[`Modal ModalBase renders ModalBase 1`] = `
                   tabindex="0"
                 />
                 <div
-                  data-focus-guard="true"
-                  style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                  tabindex="1"
-                />
-                <div
                   data-focus-lock-disabled="false"
                 >
                   <div
@@ -6311,22 +6209,6 @@ exports[`Modal ModalBase renders ModalBase 1`] = `
                     }
                   }
                   tabIndex={0}
-                />
-                <div
-                  data-focus-guard={true}
-                  key="guard-nearest"
-                  style={
-                    Object {
-                      "height": "0px",
-                      "left": "1px",
-                      "overflow": "hidden",
-                      "padding": 0,
-                      "position": "fixed",
-                      "top": "1px",
-                      "width": "1px",
-                    }
-                  }
-                  tabIndex={1}
                 />
                 <SideEffect(FocusWatcher)
                   autoFocus={true}

--- a/packages/popover/tests/__snapshots__/Popover.test.tsx.snap
+++ b/packages/popover/tests/__snapshots__/Popover.test.tsx.snap
@@ -498,11 +498,6 @@ exports[`Popover renders an open dropdown 1`] = `
                           tabindex="0"
                         />
                         <div
-                          data-focus-guard="true"
-                          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                          tabindex="1"
-                        />
-                        <div
                           data-focus-lock-disabled="false"
                         >
                           <div
@@ -608,11 +603,6 @@ exports[`Popover renders an open dropdown 1`] = `
                           tabindex="0"
                         />
                         <div
-                          data-focus-guard="true"
-                          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-                          tabindex="1"
-                        />
-                        <div
                           data-focus-lock-disabled="false"
                         >
                           <div
@@ -700,22 +690,6 @@ exports[`Popover renders an open dropdown 1`] = `
                               }
                             }
                             tabIndex={0}
-                          />
-                          <div
-                            data-focus-guard={true}
-                            key="guard-nearest"
-                            style={
-                              Object {
-                                "height": "0px",
-                                "left": "1px",
-                                "overflow": "hidden",
-                                "padding": 0,
-                                "position": "fixed",
-                                "top": "1px",
-                                "width": "1px",
-                              }
-                            }
-                            tabIndex={1}
                           />
                           <SideEffect(FocusWatcher)
                             autoFocus={true}


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots
With this update, the div with tabIndex="1" is removed from the snapshot. This is a good indicator that it will be our fix in the UI based on the a11y violation that tabIndex values should not be greater than 0. 
![Screen Shot 2022-04-27 at 12 22 12 PM](https://user-images.githubusercontent.com/34781875/165765284-77cbbce5-5462-46c3-9bae-f2f3e8163e84.png)

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
