### PR TITLE
fix: testing fix for react18 prop updates

### DIFF
--- a/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
+++ b/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
@@ -26,9 +26,6 @@ exports[`CodeSnippet renders default 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   height: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -116,20 +113,12 @@ exports[`CodeSnippet renders default 1`] = `
         className="emotion-2"
         data-cy="spacingBox"
       >
-        <Flex
-          align="flex-start"
-          direction="row"
-          gutterSize="none"
-          justify="flex-start"
-          wrap="nowrap"
-        >
+        <Flex>
           <div
             className="emotion-3"
             data-cy="flex"
           >
-            <FlexItem
-              flex="grow"
-            >
+            <FlexItem>
               <div
                 className="emotion-4"
                 data-cy="flexItem"
@@ -196,9 +185,6 @@ exports[`CodeSnippet renders with copy button 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   height: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -327,20 +313,12 @@ exports[`CodeSnippet renders with copy button 1`] = `
         className="emotion-2"
         data-cy="spacingBox"
       >
-        <Flex
-          align="flex-start"
-          direction="row"
-          gutterSize="none"
-          justify="flex-start"
-          wrap="nowrap"
-        >
+        <Flex>
           <div
             className="emotion-3"
             data-cy="flex"
           >
-            <FlexItem
-              flex="grow"
-            >
+            <FlexItem>
               <div
                 className="emotion-4"
                 data-cy="flexItem"

--- a/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
+++ b/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
@@ -146,9 +146,6 @@ exports[`Sidebar renders 1`] = `
           <Flex
             align="center"
             direction="row"
-            gutterSize="none"
-            justify="flex-start"
-            wrap="nowrap"
           >
             <div
               className="emotion-2"
@@ -182,9 +179,7 @@ exports[`Sidebar renders 1`] = `
                   </Icon>
                 </div>
               </FlexItem>
-              <FlexItem
-                flex="grow"
-              >
+              <FlexItem>
                 <div
                   className="emotion-5"
                   data-cy="flexItem"

--- a/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`MessagePanel renders with primary and secondary actions 1`] = `
         Body content
       </div>
       <div
-        class="css-jtsifh"
+        class="css-bhf0my"
         data-cy="flex"
       >
         <div

--- a/packages/messagePanel/tests/__snapshots__/messagePanelWithGraphic.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanelWithGraphic.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`MessagePanelWithGraphic renders with primary and secondary actions 1`] 
     </div>
   </div>
   <div
-    class="css-jtsifh"
+    class="css-bhf0my"
     data-cy="flex"
   >
     <div

--- a/packages/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/packages/pagination/__snapshots__/pagination.test.tsx.snap
@@ -16,10 +16,6 @@ exports[`Pagination rendering renders default 1`] = `
 
 <Flex
   align="center"
-  direction="row"
-  gutterSize="none"
-  justify="flex-start"
-  wrap="nowrap"
 >
   <div
     className="emotion-0"
@@ -28,10 +24,7 @@ exports[`Pagination rendering renders default 1`] = `
   </div>
   <Flex
     align="center"
-    direction="row"
     gutterSize="s"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
@@ -89,10 +82,6 @@ exports[`Pagination rendering renders prev and next buttons as links 1`] = `
 
 <Flex
   align="center"
-  direction="row"
-  gutterSize="none"
-  justify="flex-start"
-  wrap="nowrap"
 >
   <div
     className="emotion-0"
@@ -101,10 +90,7 @@ exports[`Pagination rendering renders prev and next buttons as links 1`] = `
   </div>
   <Flex
     align="center"
-    direction="row"
     gutterSize="s"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
@@ -164,10 +150,6 @@ exports[`Pagination rendering renders w/ custom item label 1`] = `
 
 <Flex
   align="center"
-  direction="row"
-  gutterSize="none"
-  justify="flex-start"
-  wrap="nowrap"
 >
   <div
     className="emotion-0"
@@ -176,10 +158,7 @@ exports[`Pagination rendering renders w/ custom item label 1`] = `
   </div>
   <Flex
     align="center"
-    direction="row"
     gutterSize="s"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
@@ -240,17 +219,10 @@ exports[`Pagination rendering renders w/ page length menu 1`] = `
 
 <Flex
   align="center"
-  direction="row"
-  gutterSize="none"
-  justify="flex-start"
-  wrap="nowrap"
 >
   <Flex
     align="center"
-    direction="row"
     gutterSize="xs"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
@@ -303,10 +275,7 @@ exports[`Pagination rendering renders w/ page length menu 1`] = `
   </div>
   <Flex
     align="center"
-    direction="row"
     gutterSize="s"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
@@ -363,10 +332,6 @@ exports[`Pagination rendering renders w/ totalItems set 1`] = `
 
 <Flex
   align="center"
-  direction="row"
-  gutterSize="none"
-  justify="flex-start"
-  wrap="nowrap"
 >
   <div
     className="emotion-0"
@@ -375,10 +340,7 @@ exports[`Pagination rendering renders w/ totalItems set 1`] = `
   </div>
   <Flex
     align="center"
-    direction="row"
     gutterSize="s"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
@@ -437,10 +399,6 @@ exports[`Pagination rendering renders w/ totalPages, pageLength, and totalItems 
 
 <Flex
   align="center"
-  direction="row"
-  gutterSize="none"
-  justify="flex-start"
-  wrap="nowrap"
 >
   <div
     className="emotion-0"
@@ -449,10 +407,7 @@ exports[`Pagination rendering renders w/ totalPages, pageLength, and totalItems 
   </div>
   <Flex
     align="center"
-    direction="row"
     gutterSize="s"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
@@ -499,8 +454,6 @@ exports[`Pagination rendering renders w/ totalPages, pageLength, and totalItems 
 exports[`Pagination rendering renders wrapped in a PaginationContainer 1`] = `
 <Flex
   align="flex-end"
-  direction="row"
-  gutterSize="none"
   justify="flex-end"
   wrap="wrap"
 >

--- a/packages/popover/tests/__snapshots__/PopoverListItem.test.tsx.snap
+++ b/packages/popover/tests/__snapshots__/PopoverListItem.test.tsx.snap
@@ -20,17 +20,12 @@ exports[`PopoverListItem renders 1`] = `
 >
   <Flex
     align="center"
-    direction="row"
     gutterSize="xs"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
     />
-    <FlexItem
-      flex="grow"
-    >
+    <FlexItem>
       item content content
     </FlexItem>
     <FlexItem
@@ -61,17 +56,12 @@ exports[`PopoverListItem renders active 1`] = `
 >
   <Flex
     align="center"
-    direction="row"
     gutterSize="xs"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
     />
-    <FlexItem
-      flex="grow"
-    >
+    <FlexItem>
       item content content
     </FlexItem>
     <FlexItem
@@ -105,17 +95,12 @@ exports[`PopoverListItem renders active and selected 1`] = `
 >
   <Flex
     align="center"
-    direction="row"
     gutterSize="xs"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
     />
-    <FlexItem
-      flex="grow"
-    >
+    <FlexItem>
       item content content
     </FlexItem>
     <FlexItem
@@ -149,17 +134,12 @@ exports[`PopoverListItem renders all appearances 1`] = `
 >
   <Flex
     align="center"
-    direction="row"
     gutterSize="xs"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
     />
-    <FlexItem
-      flex="grow"
-    >
+    <FlexItem>
       item content content
     </FlexItem>
     <FlexItem
@@ -192,17 +172,12 @@ exports[`PopoverListItem renders disabled 1`] = `
 >
   <Flex
     align="center"
-    direction="row"
     gutterSize="xs"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
     />
-    <FlexItem
-      flex="grow"
-    >
+    <FlexItem>
       item content content
     </FlexItem>
     <FlexItem
@@ -234,17 +209,12 @@ exports[`PopoverListItem renders selected 1`] = `
 >
   <Flex
     align="center"
-    direction="row"
     gutterSize="xs"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <FlexItem
       flex="shrink"
     />
-    <FlexItem
-      flex="grow"
-    >
+    <FlexItem>
       item content content
     </FlexItem>
     <FlexItem

--- a/packages/progressbar/tests/__snapshots__/ProgressBar.test.tsx.snap
+++ b/packages/progressbar/tests/__snapshots__/ProgressBar.test.tsx.snap
@@ -47,10 +47,8 @@ exports[`ProgressBar renders all sizes 1`] = `
   >
     <Flex
       align="center"
-      direction="row"
       gutterSize="s"
       justify="flex-end"
-      wrap="nowrap"
     />
   </SpacingBox>
   <svg
@@ -116,10 +114,8 @@ exports[`ProgressBar renders all sizes 2`] = `
   >
     <Flex
       align="center"
-      direction="row"
       gutterSize="s"
       justify="flex-end"
-      wrap="nowrap"
     />
   </SpacingBox>
   <svg
@@ -185,10 +181,8 @@ exports[`ProgressBar renders isProcessing 1`] = `
   >
     <Flex
       align="center"
-      direction="row"
       gutterSize="s"
       justify="flex-end"
-      wrap="nowrap"
     />
   </SpacingBox>
   <svg
@@ -228,14 +222,10 @@ exports[`ProgressBar renders with caption text and value text 1`] = `
   >
     <Flex
       align="center"
-      direction="row"
       gutterSize="s"
       justify="flex-end"
-      wrap="nowrap"
     >
-      <FlexItem
-        flex="grow"
-      >
+      <FlexItem>
         <CaptionText
           align="inherit"
           tag="div"
@@ -302,10 +292,8 @@ exports[`ProgressBar renders with multiple segments of data 1`] = `
   >
     <Flex
       align="center"
-      direction="row"
       gutterSize="s"
       justify="flex-end"
-      wrap="nowrap"
     />
   </SpacingBox>
   <svg
@@ -352,10 +340,8 @@ exports[`ProgressBar renders with one segment of data 1`] = `
   >
     <Flex
       align="center"
-      direction="row"
       gutterSize="s"
       justify="flex-end"
-      wrap="nowrap"
     />
   </SpacingBox>
   <svg

--- a/packages/promo/__snapshots__/promos.test.tsx.snap
+++ b/packages/promo/__snapshots__/promos.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Promos renders PromoBanner 1`] = `
             Some promo details
           </div>
           <div
-            class="css-1z0oasc"
+            class="css-hs4ndh"
             data-cy="flex"
           >
             <div
@@ -206,7 +206,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
             Some promo details
           </div>
           <div
-            class="css-1z0oasc"
+            class="css-hs4ndh"
             data-cy="flex"
           >
             <div
@@ -350,7 +350,7 @@ exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
             Some promo details
           </div>
           <div
-            class="css-1z0oasc"
+            class="css-hs4ndh"
             data-cy="flex"
           >
             <div
@@ -501,7 +501,7 @@ exports[`Promos renders PromoInline 1`] = `
                 Some promo details
               </div>
               <div
-                class="css-1z0oasc"
+                class="css-hs4ndh"
                 data-cy="flex"
               >
                 <div

--- a/packages/styleUtils/layout/flexbox/components/Flex.tsx
+++ b/packages/styleUtils/layout/flexbox/components/Flex.tsx
@@ -17,37 +17,41 @@ export interface FlexProps extends FlexboxProperties {
    * Which HTML tag to render the component with
    */
   tag?: keyof React.ReactHTML;
+  /**
+   * human-readable selector used for writing tests
+   */
+  ["data-cy"]?: string;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
-const Flex: React.FC<FlexProps> = ({
+const Flex = ({
   children,
   className,
-  gutterSize,
+  gutterSize = "none",
   tag = "div",
+  "data-cy": dataCy = "flex",
   ...flexboxProperties
-}) => {
+}: FlexProps): JSX.Element => {
+  const {
+    direction = "row",
+    align = "flex-start",
+    wrap = "nowrap",
+    justify = "flex-start"
+  } = flexboxProperties;
   const FlexEl = tag;
 
   return (
     <FlexEl
       className={css`
-        ${flex({ ...flexboxProperties })};
-        ${applyFlexItemGutters(flexboxProperties.direction, gutterSize)};
+        ${flex({ align, wrap, justify, ...flexboxProperties })};
+        ${applyFlexItemGutters(direction, gutterSize)};
         ${className};
       `}
-      data-cy="flex"
+      data-cy={dataCy}
     >
       {children}
     </FlexEl>
   );
-};
-
-Flex.defaultProps = {
-  align: "flex-start",
-  direction: "row",
-  wrap: "nowrap",
-  justify: "flex-start",
-  gutterSize: "none"
 };
 
 export default Flex;

--- a/packages/styleUtils/layout/flexbox/components/FlexItem.tsx
+++ b/packages/styleUtils/layout/flexbox/components/FlexItem.tsx
@@ -27,6 +27,11 @@ interface FlexItemProps {
    * Which HTML tag to render the component with
    */
   tag?: keyof React.ReactHTML;
+  /**
+   * human-readable selector used for writing tests
+   */
+  ["data-cy"]?: string;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
 const getResponsiveFlexItemStyles = flexVal =>
@@ -36,14 +41,15 @@ const getResponsiveFlexItemStyles = flexVal =>
         atMediaUp[breakpoint](flexItem(flexVal[breakpoint]))
       );
 
-const FlexItem: React.FC<FlexItemProps> = ({
+const FlexItem = ({
   children,
   className,
-  flex,
+  flex = "grow",
   growFactor,
   order,
-  tag = "div"
-}) => {
+  tag = "div",
+  "data-cy": dataCy = "flexItem"
+}: FlexItemProps): JSX.Element => {
   const FlexItemEl = tag;
 
   return (
@@ -54,15 +60,11 @@ const FlexItem: React.FC<FlexItemProps> = ({
         ${getResponsiveStyle("order", order)};
         ${className};
       `}
-      data-cy="flexItem"
+      data-cy={dataCy}
     >
       {children}
     </FlexItemEl>
   );
-};
-
-FlexItem.defaultProps = {
-  flex: "grow"
 };
 
 export default FlexItem;

--- a/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
+++ b/packages/styleUtils/layout/flexbox/tests/__snapshots__/Flex.test.tsx.snap
@@ -7,9 +7,6 @@ exports[`Flex renders default 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   height: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -49,14 +46,10 @@ exports[`Flex renders default 1`] = `
   className="emotion-0"
   data-cy="flex"
 >
-  <FlexItem
-    flex="grow"
-  >
+  <FlexItem>
     content
   </FlexItem>
-  <FlexItem
-    flex="grow"
-  >
+  <FlexItem>
     content
   </FlexItem>
 </div>
@@ -111,14 +104,10 @@ exports[`Flex renders with all props 1`] = `
   className="emotion-0"
   data-cy="flex"
 >
-  <FlexItem
-    flex="grow"
-  >
+  <FlexItem>
     content
   </FlexItem>
-  <FlexItem
-    flex="grow"
-  >
+  <FlexItem>
     content
   </FlexItem>
 </div>
@@ -286,14 +275,10 @@ exports[`Flex renders with responsive props 1`] = `
   className="emotion-0"
   data-cy="flex"
 >
-  <FlexItem
-    flex="grow"
-  >
+  <FlexItem>
     content
   </FlexItem>
-  <FlexItem
-    flex="grow"
-  >
+  <FlexItem>
     content
   </FlexItem>
 </div>

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -442,15 +442,11 @@ exports[`Table v2 rendering renders default 1`] = `
               tooltipContent="test"
             >
               <Flex
-                align="flex-start"
                 className="css-ukcnvo"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
-                  className="css-12zerzy"
+                  className="css-4vm7kd"
                   data-cy="flex"
                 >
                   <div
@@ -3731,15 +3727,11 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
               tooltipContent="test"
             >
               <Flex
-                align="flex-start"
                 className="css-ukcnvo"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
-                  className="css-12zerzy"
+                  className="css-4vm7kd"
                   data-cy="flex"
                 >
                   <div

--- a/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
+++ b/packages/textInput/tests/__snapshots__/TextInputWithBadges.test.tsx.snap
@@ -146,9 +146,6 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
   -ms-flex-align: center;
   align-items: center;
   height: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -331,18 +328,13 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
             >
               <Flex
                 align="center"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
                   className="emotion-4"
                   data-cy="flex"
                 >
-                  <FlexItem
-                    flex="grow"
-                  >
+                  <FlexItem>
                     <div
                       className="emotion-5"
                       data-cy="flexItem"
@@ -415,18 +407,13 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
             >
               <Flex
                 align="center"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
                   className="emotion-4"
                   data-cy="flex"
                 >
-                  <FlexItem
-                    flex="grow"
-                  >
+                  <FlexItem>
                     <div
                       className="emotion-5"
                       data-cy="flexItem"
@@ -499,18 +486,13 @@ exports[`TextInputWithBadges renders badges with custom BadgeAppearance 1`] = `
             >
               <Flex
                 align="center"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
                   className="emotion-4"
                   data-cy="flex"
                 >
-                  <FlexItem
-                    flex="grow"
-                  >
+                  <FlexItem>
                     <div
                       className="emotion-5"
                       data-cy="flexItem"
@@ -913,9 +895,6 @@ exports[`TextInputWithBadges renders with badges 1`] = `
   -ms-flex-align: center;
   align-items: center;
   height: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
@@ -1098,18 +1077,13 @@ exports[`TextInputWithBadges renders with badges 1`] = `
             >
               <Flex
                 align="center"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
                   className="emotion-4"
                   data-cy="flex"
                 >
-                  <FlexItem
-                    flex="grow"
-                  >
+                  <FlexItem>
                     <div
                       className="emotion-5"
                       data-cy="flexItem"
@@ -1182,18 +1156,13 @@ exports[`TextInputWithBadges renders with badges 1`] = `
             >
               <Flex
                 align="center"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
                   className="emotion-4"
                   data-cy="flex"
                 >
-                  <FlexItem
-                    flex="grow"
-                  >
+                  <FlexItem>
                     <div
                       className="emotion-5"
                       data-cy="flexItem"
@@ -1266,18 +1235,13 @@ exports[`TextInputWithBadges renders with badges 1`] = `
             >
               <Flex
                 align="center"
-                direction="row"
                 gutterSize="xxs"
-                justify="flex-start"
-                wrap="nowrap"
               >
                 <div
                   className="emotion-4"
                   data-cy="flex"
                 >
-                  <FlexItem
-                    flex="grow"
-                  >
+                  <FlexItem>
                     <div
                       className="emotion-5"
                       data-cy="flexItem"

--- a/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
+++ b/packages/toggleBox/tests/__snapshots__/ToggleBoxGroup.test.tsx.snap
@@ -116,8 +116,6 @@ exports[`ToggleBoxGroup renders default 1`] = `
     align="stretch"
     direction="row"
     gutterSize="m"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <div
       className="emotion-0"
@@ -125,7 +123,6 @@ exports[`ToggleBoxGroup renders default 1`] = `
     >
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-exosphere"
       >
         <div
@@ -197,7 +194,6 @@ exports[`ToggleBoxGroup renders default 1`] = `
       </FlexItem>
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-thermosphere"
       >
         <div
@@ -269,7 +265,6 @@ exports[`ToggleBoxGroup renders default 1`] = `
       </FlexItem>
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-mesosphere"
       >
         <div
@@ -484,8 +479,6 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
       align="stretch"
       direction="row"
       gutterSize="m"
-      justify="flex-start"
-      wrap="nowrap"
     >
       <div
         className="emotion-2"
@@ -493,7 +486,6 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
       >
         <FlexItem
           className="emotion-3"
-          flex="grow"
           key="buttonWrapper-exosphere"
         >
           <div
@@ -565,7 +557,6 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
         </FlexItem>
         <FlexItem
           className="emotion-3"
-          flex="grow"
           key="buttonWrapper-thermosphere"
         >
           <div
@@ -637,7 +628,6 @@ exports[`ToggleBoxGroup renders with a label 1`] = `
         </FlexItem>
         <FlexItem
           className="emotion-3"
-          flex="grow"
           key="buttonWrapper-mesosphere"
         >
           <div
@@ -862,8 +852,6 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
     align="stretch"
     direction="row"
     gutterSize="m"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <div
       className="emotion-0"
@@ -871,7 +859,6 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
     >
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-exosphere"
       >
         <div
@@ -943,7 +930,6 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
       </FlexItem>
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-thermosphere"
       >
         <div
@@ -1015,7 +1001,6 @@ exports[`ToggleBoxGroup renders with a selected ToggleBox 1`] = `
       </FlexItem>
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-mesosphere"
       >
         <div
@@ -1208,8 +1193,6 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
     align="stretch"
     direction="column"
     gutterSize="xxl"
-    justify="flex-start"
-    wrap="nowrap"
   >
     <div
       className="emotion-0"
@@ -1217,7 +1200,6 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
     >
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-exosphere"
       >
         <div
@@ -1289,7 +1271,6 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
       </FlexItem>
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-thermosphere"
       >
         <div
@@ -1361,7 +1342,6 @@ exports[`ToggleBoxGroup renders with custom direction and gutter size 1`] = `
       </FlexItem>
       <FlexItem
         className="emotion-1"
-        flex="grow"
         key="buttonWrapper-mesosphere"
       >
         <div


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

React 18 is not a fan of React.FC usage. I am testing out the refactoring of this component to help troubleshoot the transition of @types/react. I've made a point to add a customizable data-cy prop for `Flex` and `FlexItem`.

The snapshots have changed but I am still setting defaultProps in the component. The before and after comparison remains the same. You can see these props set when inspecting the elements.

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

Before:

<img width="1246" alt="Screen Shot 2022-04-29 at 12 32 14 PM" src="https://user-images.githubusercontent.com/34781875/165994512-459be23d-113b-4c2e-b069-03c46ee81db3.png">

<img width="1246" alt="Screen Shot 2022-04-29 at 12 31 33 PM" src="https://user-images.githubusercontent.com/34781875/165994607-8b600f65-2aa4-4451-a74b-f056789b7cb4.png">




After:
<img width="1248" alt="Screen Shot 2022-04-29 at 12 31 59 PM" src="https://user-images.githubusercontent.com/34781875/165994528-0238ebd4-3377-4f99-915f-bf83d5f6a64e.png">


<img width="1251" alt="Screen Shot 2022-04-29 at 12 31 47 PM" src="https://user-images.githubusercontent.com/34781875/165994565-c9c0a356-6782-45e8-a359-86be1bf4d6a9.png">


<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
