### PR TITLE
fix: badgebutton children and data-cy props

### DIFF
--- a/packages/badge/components/badgeButton.tsx
+++ b/packages/badge/components/badgeButton.tsx
@@ -18,14 +18,16 @@ export interface BadgeButtonProps {
    * browser default value for this is -1
    */
   tabIndex?: number;
-  children: JSX.Element | string;
+  children: React.ReactNode[] | React.ReactNode;
+  ["data-cy"]?: string;
 }
 
 const BadgeButton = ({
   appearance = "default",
   children,
   onClick,
-  tabIndex = -1
+  tabIndex = -1,
+  "data-cy": dataCy = "badgeButton"
 }: BadgeButtonProps) => {
   const className = css`
     outline: none;
@@ -34,7 +36,7 @@ const BadgeButton = ({
   `;
 
   return (
-    <Clickable action={onClick} tabIndex={tabIndex} data-cy="badgeButton">
+    <Clickable action={onClick} tabIndex={tabIndex} data-cy={dataCy}>
       <span className={className}>{children}</span>
     </Clickable>
   );


### PR DESCRIPTION
<!-- See Checklist for PR creators below. -->

This is a fix for the `children` props on `BadgeButton` which should allow a string or any elements we pass in. This can be covered with the use of `React.ReactNode` which is consistent with other `children` props in ui-kit. Took the opportunity here to allow for a customizable data-cy prop as well. 

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
