### PR TITLE
chore: removed max size deprecated dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "downshift": "6.1.7",
         "eslint-plugin-prettier": "4.0.0",
         "memoize-one": "6.0.0",
-        "popper-max-size-modifier": "0.2.0",
         "react-chartist": "0.14.4",
         "react-click-outside": "3.0.1",
         "react-delegate-component": "1.0.0",
@@ -28797,15 +28796,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/popper-max-size-modifier": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
-      "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
-      "deprecated": "We recommend switching to Floating UI which supports this modifier out of the box: https://floating-ui.com/docs/size",
-      "peerDependencies": {
-        "@popperjs/core": "^2.2.0"
       }
     },
     "node_modules/posix-character-classes": {
@@ -57900,12 +57890,6 @@
       "requires": {
         "@babel/runtime": "^7.17.8"
       }
-    },
-    "popper-max-size-modifier": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
-      "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
-      "requires": {}
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "downshift": "6.1.7",
     "eslint-plugin-prettier": "4.0.0",
     "memoize-one": "6.0.0",
-    "popper-max-size-modifier": "0.2.0",
     "react-chartist": "0.14.4",
     "react-click-outside": "3.0.1",
     "react-delegate-component": "1.0.0",

--- a/packages/dropdownMenu/tests/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/dropdownMenu/tests/__snapshots__/DropdownMenu.test.tsx.snap
@@ -977,11 +977,11 @@ exports[`Dropdown renders an open dropdown with multiple sections 1`] = `
                       >
                         <div
                           aria-labelledby="downshift-1-label"
-                          class="css-5kh9pm"
+                          class="css-1uapjdz"
                           data-cy="popover"
                           id="downshift-1-menu"
                           role="listbox"
-                          style="overflow: auto; max-height: 768px; max-width: 0px;"
+                          style="overflow: auto;"
                         >
                           <div
                             class=""

--- a/packages/dropdownable/components/Dropdownable.tsx
+++ b/packages/dropdownable/components/Dropdownable.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties } from "react";
 import { usePopper } from "react-popper";
-import { ModifierPhases, Modifier } from "@popperjs/core";
-import maxSize from "popper-max-size-modifier";
+import { Modifier } from "@popperjs/core";
 import Overlay from "../../shared/components/Overlay";
 import DropdownContents from "./DropdownContents";
 import { zIndexDropdownable } from "../../design-tokens/build/js/designTokens";
@@ -58,23 +57,6 @@ const getFlipModifier = (preferredDirections?: Direction | Direction[]) => {
   return null;
 };
 
-const applyMaxSize = {
-  name: "applyMaxSize",
-  enabled: true,
-  phase: "beforeWrite" as ModifierPhases,
-  requires: ["maxSize"],
-  fn({ state }) {
-    // The `maxSize` modifier provides this data
-    const { width, height } = state.modifiersData.maxSize;
-
-    state.styles.popper = {
-      ...state.styles.popper,
-      maxWidth: `${width}px`,
-      maxHeight: `${height}px`
-    };
-  }
-};
-
 const Dropdownable: React.FC<DropdownableProps> = ({
   isOpen,
   dropdown,
@@ -91,8 +73,6 @@ const Dropdownable: React.FC<DropdownableProps> = ({
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     placement: getPreferredDirection(preferredDirections),
     modifiers: [
-      maxSize,
-      applyMaxSize,
       getFlipModifier(preferredDirections)
       // we need valid modifiers here otherwise we get a bunch of console errors
     ].filter(Boolean) as Array<Partial<Modifier<string, object>>>


### PR DESCRIPTION
This feature was not working and I am not sure replacing it is worth the effort.

Expected behaviour:
When you have a pop up, it is not covered up by the bottom of the window. It is supposed to fit to the bottom of the screen.

So this feature does not work. The problem is usePopper raises the div outside of its parent div to the top of the DOM. As such there is no parent div so max-width and max-height do not work. They have another library called useFloating, but that _outputs_ refs instead of taking them, so it would take some refactoring. I say we just rip this out for two reason.

1. This was never working so no one would miss it.
2. There is already some behavior for when this occurs. The pop up flips to the other side of the parent element.

If we wanted to revisit this, I say we make a new story saying replace usePopper with the floating-ui library.
## Testing

None, it doesn't work.

## Trade-offs

See above. 

## Dependencies

The deprecated `popper-max-size-modifier` has been removed.

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
