### PR TITLE
feat: add gap property to flex component

### DIFF
--- a/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanel.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`MessagePanel renders with primary and secondary actions 1`] = `
         Body content
       </div>
       <div
-        class="css-bhf0my"
+        class="css-e35dnx"
         data-cy="flex"
       >
         <div

--- a/packages/messagePanel/tests/__snapshots__/messagePanelWithGraphic.test.tsx.snap
+++ b/packages/messagePanel/tests/__snapshots__/messagePanelWithGraphic.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`MessagePanelWithGraphic renders with primary and secondary actions 1`] 
     </div>
   </div>
   <div
-    class="css-bhf0my"
+    class="css-e35dnx"
     data-cy="flex"
   >
     <div

--- a/packages/promo/__snapshots__/promos.test.tsx.snap
+++ b/packages/promo/__snapshots__/promos.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Promos renders PromoBanner 1`] = `
       </div>
     </button>
     <div
-      class="css-1qfp4eg"
+      class="css-6cf51q"
       data-cy="flex"
     >
       <div
@@ -62,7 +62,7 @@ exports[`Promos renders PromoBanner 1`] = `
             Some promo details
           </div>
           <div
-            class="css-hs4ndh"
+            class="css-u1cluu"
             data-cy="flex"
           >
             <div
@@ -177,7 +177,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
       </div>
     </button>
     <div
-      class="css-1qfp4eg"
+      class="css-6cf51q"
       data-cy="flex"
     >
       <div
@@ -206,7 +206,7 @@ exports[`Promos renders PromoBanner with a custom background color 1`] = `
             Some promo details
           </div>
           <div
-            class="css-hs4ndh"
+            class="css-u1cluu"
             data-cy="flex"
           >
             <div
@@ -321,7 +321,7 @@ exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
       </div>
     </button>
     <div
-      class="css-1qfp4eg"
+      class="css-6cf51q"
       data-cy="flex"
     >
       <div
@@ -350,7 +350,7 @@ exports[`Promos renders PromoBanner with a gradientStyle 1`] = `
             Some promo details
           </div>
           <div
-            class="css-hs4ndh"
+            class="css-u1cluu"
             data-cy="flex"
           >
             <div
@@ -472,7 +472,7 @@ exports[`Promos renders PromoInline 1`] = `
           </div>
         </button>
         <div
-          class="css-1qfp4eg"
+          class="css-6cf51q"
           data-cy="flex"
         >
           <div
@@ -501,7 +501,7 @@ exports[`Promos renders PromoInline 1`] = `
                 Some promo details
               </div>
               <div
-                class="css-hs4ndh"
+                class="css-u1cluu"
                 data-cy="flex"
               >
                 <div

--- a/packages/shared/styles/styleUtils/layout/flexbox.ts
+++ b/packages/shared/styles/styleUtils/layout/flexbox.ts
@@ -20,6 +20,10 @@ export interface FlexboxProperties {
    * How `FlexItem` children should handle wrapping. Can be set for all viewport sizes, or configured to have different values at different viewport width breakpoints
    */
   wrap?: BreakpointConfig<React.CSSProperties["flexWrap"]>;
+  /**
+   * Specify the gutter size for both column and row in a single value. This will override any value set via the gutterSize property.
+   */
+  gap?: BreakpointConfig<React.CSSProperties["gap"]>;
 }
 
 const flexStrategies = {
@@ -129,7 +133,7 @@ export const flexItem = (flexStrategy: "grow" | "shrink") =>
     ${flexStrategies[flexStrategy]};
   `;
 
-export const applyFlexItemGutters = (direction, gutterSize) => {
+export const applyFlexItemGutters = (direction, gutterSize, gap) => {
   if (!gutterSize) {
     return;
   }
@@ -148,17 +152,20 @@ export const applyFlexItemGutters = (direction, gutterSize) => {
   return css`
     ${getResponsiveSpacingStyle("column-gap", columnGap)};
     ${getResponsiveSpacingStyle("row-gap", rowGap)};
+    ${getResponsiveSpacingStyle("gap", gap)};
 
     // If column-gap or row-gap are not supported by the browser utilize padding for spacing
     @supports not (column-gap: 1px) {
       > *:not(:last-child) {
         ${getResponsiveSpacingStyle("padding-right", columnGap)};
+        ${getResponsiveSpacingStyle("padding-right", gap)};
       }
     }
 
     @supports not (row-gap: 1px) {
       > *:not(:last-child) {
         ${getResponsiveSpacingStyle("padding-bottom", rowGap)};
+        ${getResponsiveSpacingStyle("padding-bottom", gap)};
       }
     }
   `;

--- a/packages/styleUtils/layout/flexbox/components/Flex.tsx
+++ b/packages/styleUtils/layout/flexbox/components/Flex.tsx
@@ -36,7 +36,8 @@ const Flex = ({
     direction = "row",
     align = "flex-start",
     wrap = "nowrap",
-    justify = "flex-start"
+    justify = "flex-start",
+    gap = "inherit"
   } = flexboxProperties;
   const FlexEl = tag;
 
@@ -44,7 +45,7 @@ const Flex = ({
     <FlexEl
       className={css`
         ${flex({ align, wrap, justify, ...flexboxProperties })};
-        ${applyFlexItemGutters(direction, gutterSize)};
+        ${applyFlexItemGutters(direction, gutterSize, gap)};
         ${className};
       `}
       data-cy={dataCy}

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -446,7 +446,7 @@ exports[`Table v2 rendering renders default 1`] = `
                 gutterSize="xxs"
               >
                 <div
-                  className="css-4vm7kd"
+                  className="css-1fz6wig"
                   data-cy="flex"
                 >
                   <div
@@ -3731,7 +3731,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                 gutterSize="xxs"
               >
                 <div
-                  className="css-4vm7kd"
+                  className="css-1fz6wig"
                   data-cy="flex"
                 >
                   <div


### PR DESCRIPTION
Adding the gap property to the Flex component so the gutter size for columns and rows can be set with a single value.

Closes D2IQ-90211

<!-- See Checklist for PR creators below. -->

## Testing

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

I've added the style for `gap` just below where `column-gap` and `row-gap` are set so that if `gap` is set, it will override the other values. I'm not sure if this is the best solution, but it was certainly the easiest.

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
