### PR TITLE
refactor: link components

### DIFF
--- a/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
+++ b/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`ButtonBase renders all appearances with props 1`] = `
   padding-left: 4px;
 }
 
-<FocusStyleManager
+<Memo(FocusStyleManager)
   focusEnabledClass="css-xcotv6"
 >
   <button
@@ -176,7 +176,7 @@ exports[`ButtonBase renders all appearances with props 1`] = `
       </span>
     </span>
   </button>
-</FocusStyleManager>
+</Memo(FocusStyleManager)>
 `;
 
 exports[`ButtonBase renders all appearances with props 2`] = `
@@ -308,7 +308,7 @@ exports[`ButtonBase renders all appearances with props 2`] = `
   padding-left: 4px;
 }
 
-<FocusStyleManager
+<Memo(FocusStyleManager)
   focusEnabledClass="css-1h85cd2"
 >
   <button
@@ -347,7 +347,7 @@ exports[`ButtonBase renders all appearances with props 2`] = `
       </span>
     </span>
   </button>
-</FocusStyleManager>
+</Memo(FocusStyleManager)>
 `;
 
 exports[`ButtonBase renders all appearances with props 3`] = `
@@ -487,7 +487,7 @@ exports[`ButtonBase renders all appearances with props 3`] = `
   padding-left: 4px;
 }
 
-<FocusStyleManager
+<Memo(FocusStyleManager)
   focusEnabledClass="css-bwvukd"
 >
   <button
@@ -526,7 +526,7 @@ exports[`ButtonBase renders all appearances with props 3`] = `
       </span>
     </span>
   </button>
-</FocusStyleManager>
+</Memo(FocusStyleManager)>
 `;
 
 exports[`ButtonBase renders all appearances with props 4`] = `
@@ -666,7 +666,7 @@ exports[`ButtonBase renders all appearances with props 4`] = `
   padding-left: 4px;
 }
 
-<FocusStyleManager
+<Memo(FocusStyleManager)
   focusEnabledClass="css-txv5vz"
 >
   <button
@@ -705,7 +705,7 @@ exports[`ButtonBase renders all appearances with props 4`] = `
       </span>
     </span>
   </button>
-</FocusStyleManager>
+</Memo(FocusStyleManager)>
 `;
 
 exports[`ButtonBase renders all appearances with props 5`] = `
@@ -845,7 +845,7 @@ exports[`ButtonBase renders all appearances with props 5`] = `
   padding-left: 4px;
 }
 
-<FocusStyleManager
+<Memo(FocusStyleManager)
   focusEnabledClass="css-u3f3k6"
 >
   <button
@@ -884,5 +884,5 @@ exports[`ButtonBase renders all appearances with props 5`] = `
       </span>
     </span>
   </button>
-</FocusStyleManager>
+</Memo(FocusStyleManager)>
 `;

--- a/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
+++ b/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Dropdownable is visible after opening 1`] = `
         appearance="primary"
         data-cy="primaryButton"
       >
-        <FocusStyleManager
+        <Memo(FocusStyleManager)
           focusEnabledClass="css-xcotv6"
         >
           <button
@@ -70,7 +70,7 @@ exports[`Dropdownable is visible after opening 1`] = `
               Click me
             </span>
           </button>
-        </FocusStyleManager>
+        </Memo(FocusStyleManager)>
       </ButtonBase>
     </PrimaryButton>
   </div>
@@ -133,7 +133,7 @@ exports[`Dropdownable is visible after opening 2`] = `
         appearance="primary"
         data-cy="primaryButton"
       >
-        <FocusStyleManager
+        <Memo(FocusStyleManager)
           focusEnabledClass="css-xcotv6"
         >
           <button
@@ -147,7 +147,7 @@ exports[`Dropdownable is visible after opening 2`] = `
               Click me
             </span>
           </button>
-        </FocusStyleManager>
+        </Memo(FocusStyleManager)>
       </ButtonBase>
     </PrimaryButton>
   </div>

--- a/packages/fullscreenView/tests/__snapshots__/fullscreenView.test.tsx.snap
+++ b/packages/fullscreenView/tests/__snapshots__/fullscreenView.test.tsx.snap
@@ -260,7 +260,7 @@ exports[`FullscreenView renders FullscreenView 1`] = `
                   data-cy="secondaryButton"
                   onClick={[MockFunction]}
                 >
-                  <FocusStyleManager
+                  <Memo(FocusStyleManager)
                     focusEnabledClass="css-1h85cd2"
                   >
                     <button
@@ -274,7 +274,7 @@ exports[`FullscreenView renders FullscreenView 1`] = `
                         Close
                       </span>
                     </button>
-                  </FocusStyleManager>
+                  </Memo(FocusStyleManager)>
                 </ButtonBase>
               </SecondaryButton>
             </div>
@@ -298,7 +298,7 @@ exports[`FullscreenView renders FullscreenView 1`] = `
                   appearance="primary"
                   data-cy="primaryButton"
                 >
-                  <FocusStyleManager
+                  <Memo(FocusStyleManager)
                     focusEnabledClass="css-xcotv6"
                   >
                     <button
@@ -312,7 +312,7 @@ exports[`FullscreenView renders FullscreenView 1`] = `
                         CTA
                       </span>
                     </button>
-                  </FocusStyleManager>
+                  </Memo(FocusStyleManager)>
                 </ButtonBase>
               </PrimaryButton>
             </div>

--- a/packages/link/components/Link.tsx
+++ b/packages/link/components/Link.tsx
@@ -3,11 +3,7 @@ import ResetLink from "./ResetLink";
 import { ExpandedLinkProps } from "../types";
 import { defaultLink } from "../style";
 
-const Link: React.StatelessComponent<ExpandedLinkProps> = ({
-  children,
-  className,
-  ...other
-}) => (
+const Link = ({ children, className, ...other }: ExpandedLinkProps) => (
   <ResetLink className={defaultLink} {...other}>
     {children}
   </ResetLink>

--- a/packages/link/components/ResetLink.tsx
+++ b/packages/link/components/ResetLink.tsx
@@ -4,11 +4,7 @@ import { ExpandedLinkProps } from "../types";
 import { linkReset } from "../../shared/styles/styleUtils/resets/linkReset";
 import UnstyledLink from "./UnstyledLink";
 
-const ResetLink: React.FunctionComponent<ExpandedLinkProps> = ({
-  className,
-  children,
-  ...other
-}) => (
+const ResetLink = ({ className, children, ...other }: ExpandedLinkProps) => (
   <UnstyledLink className={cx(linkReset, className)} {...other}>
     {children}
   </UnstyledLink>

--- a/packages/link/components/UnstyledLink.tsx
+++ b/packages/link/components/UnstyledLink.tsx
@@ -1,32 +1,24 @@
 import React from "react";
-import { ExpandedLinkProps } from "../types";
 import { LinkComponentContext } from "../../uiKitProvider/link/context";
+import { ExpandedLinkProps } from "../types";
 
-class UnstyledLink extends React.Component<ExpandedLinkProps> {
-  static contextType = LinkComponentContext;
-  render() {
-    const LinkComponent = this.context;
+const UnstyledLink = (props: ExpandedLinkProps) => {
+  const { href, url, target, openInNewTab, children, ...rest } = props;
 
-    if (LinkComponent) {
-      return <LinkComponent {...this.props} />;
-    }
-
-    const { href, url, target, openInNewTab, children, ...rest } = this.props;
-    const rel = target === "_blank" || openInNewTab ? "noopener" : undefined;
-    const blankTargetOrDefault = !target && openInNewTab ? "_blank" : target;
-
-    return (
-      <a
-        href={href || url}
-        target={blankTargetOrDefault}
-        // https://web.dev/external-anchors-use-rel-noopener/
-        rel={rel}
-        {...rest}
-      >
-        {children}
-      </a>
-    );
+  // Context is used for `UIKitProvider` link delegation
+  const LinkComponent = React.useContext(LinkComponentContext);
+  if (LinkComponent) {
+    return <LinkComponent {...props} />;
   }
-}
 
-export { UnstyledLink as default };
+  const rel = target === "_blank" || openInNewTab ? "noopener" : undefined;
+  const blankTargetOrDefault = !target && openInNewTab ? "_blank" : target;
+
+  return (
+    <a href={href || url} target={blankTargetOrDefault} rel={rel} {...rest}>
+      {children}
+    </a>
+  );
+};
+
+export default UnstyledLink;

--- a/packages/link/stories/link.stories.tsx
+++ b/packages/link/stories/link.stories.tsx
@@ -11,20 +11,22 @@ export default {
 };
 
 const Template: Story<LinkProps> = args => (
-  <Link url="http://google.com/" openInNewTab={true} {...args}>
-    Go to Google
+  <Link url="http://www.d2iq.com" openInNewTab={true} {...args}>
+    Visit D2iQ
   </Link>
 );
 export const Default = Template.bind({});
 
 export const _ResetLink = args => (
   <div>
-    The{" "}
+    <Text>
+      ResetLink will reset inherited Link styles to take on new styles.
+    </Text>
     <Text tag="span" color="red">
-      <ResetLink {...args} url="http://google.com">
-        red text
+      <ResetLink {...args} url="http://d2iq.com">
+        This red text is a link
       </ResetLink>
     </Text>{" "}
-    is a link, but it is not styled like one.
+    that is inheriting color from a Text component.
   </div>
 );

--- a/packages/link/types.ts
+++ b/packages/link/types.ts
@@ -2,13 +2,14 @@ import React from "react";
 
 export interface LinkProps {
   /**
-   * a url the user will be navigated to when clicking the button. This also changes the tag to `<a>`
+   * A url the user will be navigated to when clicking the link. This also changes the tag to `<a>`.
    */
   url?: string;
   /**
-   * if the `url` prop is set, this will open that link in a new tab
+   * If the `url` prop is set, this will open that link in a new tab.
    */
   openInNewTab?: boolean;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
 export type ExpandedLinkProps = LinkProps &

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -2741,7 +2741,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         data-cy="secondaryButton"
                                         onClick={[MockFunction]}
                                       >
-                                        <FocusStyleManager
+                                        <Memo(FocusStyleManager)
                                           focusEnabledClass="css-1h85cd2"
                                         >
                                           <button
@@ -2755,7 +2755,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                               Close
                                             </span>
                                           </button>
-                                        </FocusStyleManager>
+                                        </Memo(FocusStyleManager)>
                                       </ButtonBase>
                                     </SecondaryButton>
                                   </div>
@@ -2767,7 +2767,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         appearance="primary"
                                         data-cy="primaryButton"
                                       >
-                                        <FocusStyleManager
+                                        <Memo(FocusStyleManager)
                                           focusEnabledClass="css-xcotv6"
                                         >
                                           <button
@@ -2781,7 +2781,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                               CTA
                                             </span>
                                           </button>
-                                        </FocusStyleManager>
+                                        </Memo(FocusStyleManager)>
                                       </ButtonBase>
                                     </PrimaryButton>
                                   </div>
@@ -5634,7 +5634,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                               data-cy="secondaryButton"
                                               onClick={[MockFunction]}
                                             >
-                                              <FocusStyleManager
+                                              <Memo(FocusStyleManager)
                                                 focusEnabledClass="css-1h85cd2"
                                               >
                                                 <button
@@ -5648,7 +5648,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                                     Close
                                                   </span>
                                                 </button>
-                                              </FocusStyleManager>
+                                              </Memo(FocusStyleManager)>
                                             </ButtonBase>
                                           </SecondaryButton>
                                         </div>
@@ -5672,7 +5672,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                               appearance="primary"
                                               data-cy="primaryButton"
                                             >
-                                              <FocusStyleManager
+                                              <Memo(FocusStyleManager)
                                                 focusEnabledClass="css-xcotv6"
                                               >
                                                 <button
@@ -5686,7 +5686,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                                     CTA
                                                   </span>
                                                 </button>
-                                              </FocusStyleManager>
+                                              </Memo(FocusStyleManager)>
                                             </ButtonBase>
                                           </PrimaryButton>
                                         </div>

--- a/packages/shared/components/FocusStyleManager.tsx
+++ b/packages/shared/components/FocusStyleManager.tsx
@@ -2,30 +2,31 @@ import * as React from "react";
 
 import { InteractionModeEngine } from "../../utilities/interactionMode";
 
-class FocusStyleManager extends React.PureComponent<{
+interface FocusStyleManagerProps {
   focusEnabledClass: string;
   children: React.ReactElement;
-}> {
-  focusWrapperRef: Element | undefined;
-
-  public componentDidMount() {
-    const focusEngine = new InteractionModeEngine(
-      this.focusWrapperRef as Element,
-      this.props.focusEnabledClass || "focus-enabled",
-      document.documentElement
-    );
-    focusEngine.start();
-  }
-
-  public render() {
-    return React.cloneElement(React.Children.only(this.props.children), {
-      ref: this.setRef
-    });
-  }
-
-  private readonly setRef = ref => {
-    this.focusWrapperRef = ref;
-  };
 }
 
-export default FocusStyleManager;
+const FocusStyleManager = ({
+  focusEnabledClass,
+  children
+}: FocusStyleManagerProps) => {
+  const focusWrapperRef = React.useRef<HTMLDivElement>();
+
+  React.useEffect(() => {
+    if (focusWrapperRef.current) {
+      const focusEngine = new InteractionModeEngine(
+        focusWrapperRef.current as Element,
+        focusEnabledClass || "focus-enabled",
+        document.documentElement
+      );
+      focusEngine.start();
+    }
+  }, [focusWrapperRef]);
+
+  return React.cloneElement(React.Children.only(children), {
+    ref: focusWrapperRef
+  });
+};
+
+export default React.memo(FocusStyleManager);

--- a/packages/themes/components/UIKitThemeProvider.tsx
+++ b/packages/themes/components/UIKitThemeProvider.tsx
@@ -8,16 +8,12 @@ interface UIKitThemeProviderProps {
   children: React.ReactNode;
 }
 
-export class UIKitThemeProvider extends React.PureComponent<
-  UIKitThemeProviderProps,
-  {}
-> {
-  public render() {
-    const { children, appTheme } = this.props;
-    injectCustomProperties(appTheme);
+const UIKitThemeProvider = ({
+  children,
+  appTheme
+}: UIKitThemeProviderProps) => {
+  injectCustomProperties(appTheme);
+  return <ThemeProvider theme={appTheme}>{children}</ThemeProvider>;
+};
 
-    return <ThemeProvider theme={appTheme}>{children}</ThemeProvider>;
-  }
-}
-
-export default UIKitThemeProvider;
+export default React.memo(UIKitThemeProvider);

--- a/packages/uiKitProvider/components/UIKitProvider.tsx
+++ b/packages/uiKitProvider/components/UIKitProvider.tsx
@@ -10,18 +10,18 @@ export interface UIKitProviderProps {
   theme?: Theme;
 }
 
-class UIKitProvider extends React.Component<UIKitProviderProps, {}> {
-  public render() {
-    const { children, theme, linkComponent } = this.props;
-
-    return (
-      <UIKitThemeProvider appTheme={theme || ({} as Theme)}>
-        <LinkComponentContext.Provider value={linkComponent}>
-          {children}
-        </LinkComponentContext.Provider>
-      </UIKitThemeProvider>
-    );
-  }
-}
+const UIKitProvider = ({
+  children,
+  theme,
+  linkComponent
+}: UIKitProviderProps) => {
+  return (
+    <UIKitThemeProvider appTheme={theme || ({} as Theme)}>
+      <LinkComponentContext.Provider value={linkComponent}>
+        {children}
+      </LinkComponentContext.Provider>
+    </UIKitThemeProvider>
+  );
+};
 
 export default UIKitProvider;

--- a/packages/uiKitProvider/stories/helpers/customLink.tsx
+++ b/packages/uiKitProvider/stories/helpers/customLink.tsx
@@ -1,6 +1,14 @@
 import React, { useState } from "react";
+import { ExpandedLinkProps } from "../../../link/types";
 
-const CustomLinkComponent = ({ children, href, onClick, ...rest }) => {
+const CustomLinkComponent = ({
+  url,
+  href,
+  children,
+  openInNewTab,
+  onClick,
+  ...rest
+}: ExpandedLinkProps) => {
   const [clicked, setClicked] = useState<boolean>(false);
   const handleCustomClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -14,4 +22,4 @@ const CustomLinkComponent = ({ children, href, onClick, ...rest }) => {
   );
 };
 
-export { CustomLinkComponent as default };
+export default CustomLinkComponent;


### PR DESCRIPTION
Converting link components to functional components with updated types and additional cleanup.

Refactoring the components to move away from class components and better prop types to prepare for React 18.

Refactored components include:
- FocusStyleManager
- UnstyledLink
- Link
- UIKItProvider
- UIKitThemeProvider
- customLink

Some of these components impact each other which is why they are grouped together in these changes.

<!-- See Checklist for PR creators below. -->

## Testing

Regression testing on the stories for the components listed above. 

Button components should have the same functionality, they should still have an outline or underline with keyboard navigation. 

<!--
How can one see the result of your work? e.g. modifications to a story, test in an app that uses ui-kit
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Dependencies

<!--
What needs to happen before this can be merged? e.g. PRs merged, other events
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist for PR creator

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] If this PR is associated with a JIRA, it is mentioned in commit message footer ("Closes …")
- [ ] If this PR contains breaking changes, is stated in commit message body ("BREAKING CHANGE: …")
- [x] Info for applicable sections above is provided
