### PR TITLE
refactor: form controls to functions

### DIFF
--- a/packages/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/packages/pagination/__snapshots__/pagination.test.tsx.snap
@@ -238,8 +238,7 @@ exports[`Pagination rendering renders w/ page length menu 1`] = `
     <FlexItem
       flex="shrink"
     >
-      <SelectInput
-        appearance="standard"
+      <Memo()
         id="pageLengthMenu6"
         inputLabel="Items per page"
         onChange={[Function]}

--- a/packages/segmentedControl/components/SegmentedControlButton.tsx
+++ b/packages/segmentedControl/components/SegmentedControlButton.tsx
@@ -36,61 +36,53 @@ export interface SegmentedControlButtonProps {
    * Content that appears in a Tooltip when a users hovers the button
    */
   tooltipContent?: React.ReactNode;
+  children?: React.ReactNode;
 }
 
-class SegmentedControlButton extends React.PureComponent<SegmentedControlButtonProps> {
-  placeholderId = nextId("segmentedControlButton-");
-
-  render() {
-    const {
-      id = this.placeholderId,
-      isActive,
-      onChange,
-      name,
-      value,
-      tooltipContent,
-      children
-    } = this.props;
-    const segmentChildren = tooltipContent ? (
-      <Tooltip
-        id={`${id}-tooltip`}
-        trigger={<div className={segmentedControlButtonInner}>{children}</div>}
-      >
-        {tooltipContent}
-      </Tooltip>
-    ) : (
-      <div className={segmentedControlButtonInner}>{children}</div>
-    );
-
+const SegmentedControlButton = React.memo(
+  ({
+    id = nextId("segmentedControlButton-"),
+    isActive,
+    onChange,
+    name,
+    value,
+    tooltipContent,
+    children
+  }: SegmentedControlButtonProps) => {
     return (
-      <React.Fragment>
-        {/* eslint-disable jsx-a11y/role-has-required-aria-props */
-        /* This rule is asking for a `aria-checked` attribute on the input element.
-        We're already setting `checked`, so this is redundant and unnecessary.
-        */}
-        <FocusStyleManager focusEnabledClass={staticKeyboardFocusClassname}>
-          <label
-            className={cx(segmentedControlButton, {
-              [segmentedControlButtonActive]: this.props.isActive
-            })}
-            data-cy="segmentedControlButton"
-            htmlFor={id}
-          >
-            <input
-              className={visuallyHidden}
-              id={id}
-              type="radio"
-              name={name}
-              value={value}
-              checked={isActive}
-              onChange={onChange}
-            />
-            {segmentChildren}
-          </label>
-        </FocusStyleManager>
-      </React.Fragment>
+      <FocusStyleManager focusEnabledClass={staticKeyboardFocusClassname}>
+        <label
+          className={cx(segmentedControlButton, {
+            [segmentedControlButtonActive]: isActive
+          })}
+          data-cy="segmentedControlButton"
+          htmlFor={id}
+        >
+          <input
+            className={visuallyHidden}
+            id={id}
+            type="radio"
+            name={name}
+            value={value}
+            checked={isActive}
+            onChange={onChange}
+          />
+          {tooltipContent ? (
+            <Tooltip
+              id={`${id}-tooltip`}
+              trigger={
+                <div className={segmentedControlButtonInner}>{children}</div>
+              }
+            >
+              {tooltipContent}
+            </Tooltip>
+          ) : (
+            <div className={segmentedControlButtonInner}>{children}</div>
+          )}
+        </label>
+      </FocusStyleManager>
     );
   }
-}
+);
 
 export default SegmentedControlButton;

--- a/packages/segmentedControl/tests/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/packages/segmentedControl/tests/__snapshots__/SegmentedControl.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SegmentedControl renders default 1`] = `
   className="emotion-0"
   data-cy="segmentedControl"
 >
-  <SegmentedControlButton
+  <Memo()
     isActive={false}
     key="0"
     name="controlId"
@@ -22,8 +22,8 @@ exports[`SegmentedControl renders default 1`] = `
     value="one"
   >
     One
-  </SegmentedControlButton>
-  <SegmentedControlButton
+  </Memo()>
+  <Memo()
     isActive={false}
     key="1"
     name="controlId"
@@ -31,8 +31,8 @@ exports[`SegmentedControl renders default 1`] = `
     value="two"
   >
     Two
-  </SegmentedControlButton>
-  <SegmentedControlButton
+  </Memo()>
+  <Memo()
     isActive={false}
     key="2"
     name="controlId"
@@ -40,7 +40,7 @@ exports[`SegmentedControl renders default 1`] = `
     value="three"
   >
     Three
-  </SegmentedControlButton>
+  </Memo()>
 </div>
 `;
 
@@ -58,7 +58,7 @@ exports[`SegmentedControl renders with selected 1`] = `
   className="emotion-0"
   data-cy="segmentedControl"
 >
-  <SegmentedControlButton
+  <Memo()
     isActive={true}
     key="0"
     name="controlId"
@@ -66,8 +66,8 @@ exports[`SegmentedControl renders with selected 1`] = `
     value="one"
   >
     One
-  </SegmentedControlButton>
-  <SegmentedControlButton
+  </Memo()>
+  <Memo()
     isActive={false}
     key="1"
     name="controlId"
@@ -75,8 +75,8 @@ exports[`SegmentedControl renders with selected 1`] = `
     value="two"
   >
     Two
-  </SegmentedControlButton>
-  <SegmentedControlButton
+  </Memo()>
+  <Memo()
     isActive={false}
     key="2"
     name="controlId"
@@ -84,6 +84,6 @@ exports[`SegmentedControl renders with selected 1`] = `
     value="three"
   >
     Three
-  </SegmentedControlButton>
+  </Memo()>
 </div>
 `;

--- a/packages/selectInput/tests/SelectInput.test.tsx
+++ b/packages/selectInput/tests/SelectInput.test.tsx
@@ -32,10 +32,10 @@ describe("SelectInput", () => {
   });
 
   it("should render all appearances focus", () => {
-    Object.keys(SelectInput).forEach(appearance => {
+    Object.keys(InputAppearance).forEach(appearance => {
       const component = mount(
         <SelectInput
-          appearance={SelectInput[appearance]}
+          appearance={InputAppearance[appearance]}
           options={defaultOptions}
           id="layers"
           inputLabel="Atmosphere layer"

--- a/packages/selectInput/tests/__snapshots__/SelectInput.test.tsx.snap
+++ b/packages/selectInput/tests/__snapshots__/SelectInput.test.tsx.snap
@@ -72,6 +72,8 @@ exports[`SelectInput should render all appearances focus 1`] = `
   font-size: inherit;
   padding-left: 16px;
   padding-right: 16px;
+  background-color: rgba(125,88,255,0.05);
+  border-color: var(--themeBrandPrimary, #7D58FF);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -166,6 +168,10 @@ exports[`SelectInput should render all appearances focus 1`] = `
   padding-right: 16px;
 }
 
+.emotion-3 svg {
+  fill: var(--themeBrandPrimary, #7D58FF);
+}
+
 .emotion-4 {
   vertical-align: middle;
   fill: inherit;
@@ -175,13 +181,8 @@ exports[`SelectInput should render all appearances focus 1`] = `
   pointer-events: none;
 }
 
-<SelectInput
-  appearance={
-    Object {
-      "appearance": "standard",
-      "showInputLabel": true,
-    }
-  }
+<Memo()
+  appearance="standard"
   id="layers"
   inputLabel="Atmosphere layer"
   options={
@@ -213,13 +214,12 @@ exports[`SelectInput should render all appearances focus 1`] = `
       },
     ]
   }
-  showInputLabel={true}
 >
   <FormFieldWrapper
     id="layers"
   >
     <div
-      data-cy="selectInput selectInput.[object Object]"
+      data-cy="selectInput selectInput.standard"
     >
       <label
         className="emotion-0"
@@ -235,7 +235,7 @@ exports[`SelectInput should render all appearances focus 1`] = `
           aria-describedby=""
           aria-invalid={false}
           className="emotion-2"
-          data-cy="selectInput-select selectInput-select.[object Object]"
+          data-cy="selectInput-select selectInput-select.standard"
           id="layers"
           onBlur={[Function]}
           onFocus={[Function]}
@@ -305,5 +305,518 @@ exports[`SelectInput should render all appearances focus 1`] = `
       </span>
     </div>
   </FormFieldWrapper>
-</SelectInput>
+</Memo()>
+`;
+
+exports[`SelectInput should render all appearances focus 2`] = `
+.emotion-0 {
+  display: block;
+  padding-top: 0;
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-weight: 500;
+  color: var(--themeError, #EB293A);
+  fill: var(--themeError, #EB293A);
+}
+
+.emotion-1 {
+  position: relative;
+  border: 1px solid;
+  border-radius: 4px;
+  color: inherit;
+  height: 36px;
+  font-size: inherit;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: rgba(235,41,58,0.05);
+  border-color: var(--themeError, #EB293A);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1::-moz-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1::placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input {
+  font-size: inherit;
+  color: inherit;
+}
+
+.emotion-1 input::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input::-moz-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input::placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-2 {
+  background: none;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  color: inherit;
+  font-size: inherit;
+  padding-right: 32px;
+  width: 100%;
+  display: block;
+}
+
+.emotion-2:focus {
+  outline: 0;
+}
+
+.emotion-2:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 var(--themeTextColorPrimary, #1B2029);
+}
+
+.emotion-2::-ms-expand {
+  display: none;
+}
+
+.emotion-3 {
+  font-size: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.emotion-3 svg {
+  fill: var(--themeError, #EB293A);
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: inherit;
+}
+
+.emotion-4 use {
+  pointer-events: none;
+}
+
+<Memo()
+  appearance="error"
+  id="layers"
+  inputLabel="Atmosphere layer"
+  options={
+    Array [
+      Object {
+        "label": "Exosphere",
+        "value": "exosphere",
+      },
+      Object {
+        "label": "Thermosphere",
+        "value": "thermosphere",
+      },
+      Object {
+        "label": "Mesosphere",
+        "value": "mesosphere",
+      },
+      Object {
+        "label": "Stratosphere",
+        "value": "stratosphere",
+      },
+      Object {
+        "label": "Troposphere",
+        "value": "troposphere",
+      },
+      Object {
+        "disabled": true,
+        "label": "Can't touch this",
+        "value": "disabled",
+      },
+    ]
+  }
+>
+  <FormFieldWrapper
+    id="layers"
+  >
+    <div
+      data-cy="selectInput selectInput.error"
+    >
+      <label
+        className="emotion-0"
+        data-cy="textInput-label"
+        htmlFor="layers"
+      >
+        Atmosphere layer
+      </label>
+      <span
+        className="emotion-1"
+      >
+        <select
+          aria-describedby=""
+          aria-invalid={false}
+          className="emotion-2"
+          data-cy="selectInput-select selectInput-select.error"
+          id="layers"
+          onBlur={[Function]}
+          onFocus={[Function]}
+        >
+          <option
+            key="0"
+            value="exosphere"
+          >
+            Exosphere
+          </option>
+          <option
+            key="1"
+            value="thermosphere"
+          >
+            Thermosphere
+          </option>
+          <option
+            key="2"
+            value="mesosphere"
+          >
+            Mesosphere
+          </option>
+          <option
+            key="3"
+            value="stratosphere"
+          >
+            Stratosphere
+          </option>
+          <option
+            key="4"
+            value="troposphere"
+          >
+            Troposphere
+          </option>
+          <option
+            disabled={true}
+            key="5"
+            value="disabled"
+          >
+            Can't touch this
+          </option>
+        </select>
+        <span
+          className="emotion-3"
+        >
+          <Icon
+            color="inherit"
+            shape="system-triangle-down"
+            size="xs"
+          >
+            <svg
+              aria-label="system-triangle-down icon"
+              className="emotion-4"
+              data-cy="icon"
+              height={16}
+              preserveAspectRatio="xMinYMin meet"
+              role="img"
+              viewBox="0 0 16 16"
+              width={16}
+            >
+              <use
+                xlinkHref="#system-triangle-down"
+              />
+            </svg>
+          </Icon>
+        </span>
+      </span>
+      <div
+        data-cy="selectInput-hintContent"
+      />
+    </div>
+  </FormFieldWrapper>
+</Memo()>
+`;
+
+exports[`SelectInput should render all appearances focus 3`] = `
+.emotion-0 {
+  display: block;
+  padding-top: 0;
+  margin-top: 0;
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+
+.emotion-1 {
+  position: relative;
+  border: 1px solid;
+  border-radius: 4px;
+  color: inherit;
+  height: 36px;
+  font-size: inherit;
+  padding-left: 16px;
+  padding-right: 16px;
+  background-color: rgba(20,198,132,0.05);
+  border-color: var(--themeSuccess, #14C684);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1::-moz-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1::placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input {
+  font-size: inherit;
+  color: inherit;
+}
+
+.emotion-1 input::-webkit-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input::-moz-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input:-ms-input-placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-1 input::placeholder {
+  color: var(--themeTextColorPrimary, #1B2029);
+  opacity: 0.4;
+}
+
+.emotion-2 {
+  background: none;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  color: inherit;
+  font-size: inherit;
+  padding-right: 32px;
+  width: 100%;
+  display: block;
+}
+
+.emotion-2:focus {
+  outline: 0;
+}
+
+.emotion-2:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 var(--themeTextColorPrimary, #1B2029);
+}
+
+.emotion-2::-ms-expand {
+  display: none;
+}
+
+.emotion-3 {
+  font-size: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
+.emotion-3 svg {
+  fill: var(--themeSuccess, #14C684);
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: inherit;
+}
+
+.emotion-4 use {
+  pointer-events: none;
+}
+
+<Memo()
+  appearance="success"
+  id="layers"
+  inputLabel="Atmosphere layer"
+  options={
+    Array [
+      Object {
+        "label": "Exosphere",
+        "value": "exosphere",
+      },
+      Object {
+        "label": "Thermosphere",
+        "value": "thermosphere",
+      },
+      Object {
+        "label": "Mesosphere",
+        "value": "mesosphere",
+      },
+      Object {
+        "label": "Stratosphere",
+        "value": "stratosphere",
+      },
+      Object {
+        "label": "Troposphere",
+        "value": "troposphere",
+      },
+      Object {
+        "disabled": true,
+        "label": "Can't touch this",
+        "value": "disabled",
+      },
+    ]
+  }
+>
+  <FormFieldWrapper
+    id="layers"
+  >
+    <div
+      data-cy="selectInput selectInput.success"
+    >
+      <label
+        className="emotion-0"
+        data-cy="textInput-label"
+        htmlFor="layers"
+      >
+        Atmosphere layer
+      </label>
+      <span
+        className="emotion-1"
+      >
+        <select
+          aria-describedby=""
+          aria-invalid={false}
+          className="emotion-2"
+          data-cy="selectInput-select selectInput-select.success"
+          id="layers"
+          onBlur={[Function]}
+          onFocus={[Function]}
+        >
+          <option
+            key="0"
+            value="exosphere"
+          >
+            Exosphere
+          </option>
+          <option
+            key="1"
+            value="thermosphere"
+          >
+            Thermosphere
+          </option>
+          <option
+            key="2"
+            value="mesosphere"
+          >
+            Mesosphere
+          </option>
+          <option
+            key="3"
+            value="stratosphere"
+          >
+            Stratosphere
+          </option>
+          <option
+            key="4"
+            value="troposphere"
+          >
+            Troposphere
+          </option>
+          <option
+            disabled={true}
+            key="5"
+            value="disabled"
+          >
+            Can't touch this
+          </option>
+        </select>
+        <span
+          className="emotion-3"
+        >
+          <Icon
+            color="inherit"
+            shape="system-triangle-down"
+            size="xs"
+          >
+            <svg
+              aria-label="system-triangle-down icon"
+              className="emotion-4"
+              data-cy="icon"
+              height={16}
+              preserveAspectRatio="xMinYMin meet"
+              role="img"
+              viewBox="0 0 16 16"
+              width={16}
+            >
+              <use
+                xlinkHref="#system-triangle-down"
+              />
+            </svg>
+          </Icon>
+        </span>
+      </span>
+    </div>
+  </FormFieldWrapper>
+</Memo()>
 `;


### PR DESCRIPTION
Refactoring some form PureComponents to be functions instead. One thing
that tripped me up was that the refactor of SelectInput threw warnings
if appearance was a required prop. Not sure how this wasn't throwing
    warnings before. Either way though, because it is defaulted, making
    it an optional prop is still backwards compatible.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
