### PR TITLE
refactor: indeterminate definition and prop typing

### DIFF
--- a/packages/checkboxInput/components/CheckboxInput.tsx
+++ b/packages/checkboxInput/components/CheckboxInput.tsx
@@ -10,17 +10,17 @@ import { ToggleInputProps } from "../../toggleInput/components/ToggleInput";
 
 export interface CheckboxInputProps extends ToggleInputProps {
   /**
-   * Whether the checkbox is neither checked or unchecked
+   * Whether the checkbox is indeterminate or not. Use an indeterminate checkbox to indicate that there are both selected and unselected checkboxes nested under the indeterminate checkbox.
    */
   indeterminate?: boolean;
 }
 
-const CheckboxInput: React.FC<React.PropsWithRef<CheckboxInputProps>> = ({
+const CheckboxInput = ({
   checked,
   indeterminate,
   ref,
   ...other
-}) => {
+}: React.PropsWithRef<CheckboxInputProps>) => {
   const isIndeterminate = indeterminate && !checked;
 
   return (


### PR DESCRIPTION
Closes D2IQ-92602

<!-- PR Checklist -->

# Description
This change is a request from the product design team. We should clarify the usage of the indeterminate prop. 
Changes include a quick update to the definition of indeterminate, and a refactor to remove React.FC. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->
https://jira.d2iq.com/browse/D2IQ-92602

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [x] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
