### PR TITLE
refactor: make onSelect and selectedIndex props optional

### DIFF
--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -75,16 +75,21 @@ export type TabDirections = "horiz" | "vert";
 export type TabDirection = BreakpointConfig<TabDirections>;
 export type TabSelected = string;
 export interface TabsProps {
-  children: Array<React.ReactElement<TabItemProps>>;
-  selectedIndex: number;
-  onSelect: (tabIndex: number) => void;
+  children:
+    | Array<React.ReactElement<TabItemProps>>
+    | React.ReactElement<TabItemProps>;
+  selectedIndex?: number;
+  onSelect?: (tabIndex: number) => void;
   direction?: TabDirection;
 }
 
 const Tabs = ({
   children,
-  selectedIndex,
-  onSelect,
+  selectedIndex = 0,
+  // react-tabs needs this function but we have a linting rule which forbids
+  // empty arrow functions, so I disable this rule for this line
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onSelect = () => {},
   direction = defaultTabDirection
 }: TabsProps) => {
   const { tabs, tabsContent } = React.Children.toArray(children)


### PR DESCRIPTION


<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This is a PR that results contains the changes for the tab component to be more usable: https://github.com/mesosphere/kommander-ui/pull/4367#discussion_r966883739

* Make `onSelect` optional
* Make `selectedIndex` optional
* Let the children be an array or a single element

I did not create a separate story for this but tested that it works on the existing story by temporarily removing these props.


## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
