### PR TITLE
fix: dont use default props for `selectedIndex` and `onSelect`

### DIFF
--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -85,11 +85,8 @@ export interface TabsProps {
 
 const Tabs = ({
   children,
-  selectedIndex = 0,
-  // react-tabs needs this function but we have a linting rule which forbids
-  // empty arrow functions, so I disable this rule for this line
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onSelect = () => {},
+  selectedIndex,
+  onSelect,
   direction = defaultTabDirection
 }: TabsProps) => {
   const { tabs, tabsContent } = React.Children.toArray(children)
@@ -135,7 +132,10 @@ const Tabs = ({
         [getTabLayout(direction)]: Boolean(direction)
       })}
       selectedIndex={selectedIndex}
-      onSelect={onSelect}
+      // react-tabs needs this function but we have a linting rule which forbids
+      // empty arrow functions, so I disable this rule for this line
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onSelect={onSelect ? onSelect : () => {}}
       data-cy="tabs"
     >
       <TabList>{tabs}</TabList>


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This removes the default values from the function definition and is a `fix` commit to trigger a release.

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
