### PR TITLE
fix: make `inputLabel` optional

### DIFF
--- a/packages/selectInput/components/SelectInput.tsx
+++ b/packages/selectInput/components/SelectInput.tsx
@@ -51,7 +51,7 @@ export interface SelectInputProps extends React.HTMLProps<HTMLSelectElement> {
   /**
    * Sets the contents of the input label. This can be a `string` or any `ReactNode`.
    */
-  inputLabel: React.ReactNode;
+  inputLabel?: React.ReactNode;
   /**
    * An array of objects that describes the options the select input contains
    */
@@ -84,7 +84,7 @@ const SelectInput = React.memo(
     id = nextId("selectInput-"),
     options,
     showInputLabel = true,
-    inputLabel,
+    inputLabel = "",
     tooltipContent,
     hintContent,
     disabled,


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The property `inputLabel` was effectively optional before (I do not exactly know why, the types say otherwise).
The issue needs have to been introduced somewhere in this PR: https://github.com/dcos-labs/ui-kit/pull/756

When using storybook 11.0.0 everything is fine, but when updating to 11.0.1 I get type errors on components which are using the `SelectInput`.

As I do not want to touch all the places in kommander-ui where this is happening I think the best way is to make it optional here.

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
