### PR TITLE
fix: let `dist` command output transpiled js

### DIFF
--- a/tsconfig.designTokens.json
+++ b/tsconfig.designTokens.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "outDir": "./",
-    "declaration": true,
-    "allowJs": false
+    "allowJs": false,
+    "emitDeclarationOnly": false
   },
   "include": ["./packages/design-tokens/build/js/designTokens.ts"]
 }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "declaration": true,
-    "allowJs": false
+    "allowJs": false,
+    "emitDeclarationOnly": false
   }
 }


### PR DESCRIPTION
We have introduced type checks and therefore changed our tsconfig file to only emit types to be faster.
Our dist tsconfig file extends this other file so no javascript files were transpiled

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
