### PR TITLE
refactor: typeahead component and stories

### DIFF
--- a/packages/typeahead/stories/helpers/FilteredListTypeahead.tsx
+++ b/packages/typeahead/stories/helpers/FilteredListTypeahead.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import Typeahead, { TypeaheadProps, Item } from "../../components/Typeahead";
+import Typeahead, { Item } from "../../components/Typeahead";
 import { TextInput } from "../../../textInput";
 
 interface FilteredListProps {
@@ -7,63 +7,40 @@ interface FilteredListProps {
   menuEmptyState?: React.ReactElement<any>;
 }
 
-interface FilteredListState {
-  items: Item[];
-}
+const FilteredList = React.memo((props: FilteredListProps) => {
+  const [items, setItems] = React.useState<Item[]>(props.items || []);
 
-class FilteredList extends React.PureComponent<
-  FilteredListProps,
-  FilteredListState
-> {
-  constructor(props) {
-    super(props);
-
-    this.filterList = this.filterList.bind(this);
-
-    this.state = {
-      items: props.items || []
-    };
-  }
-
-  filterList(e) {
+  const filterList = e => {
     const val = e.target.value;
 
     if (!val) {
-      this.setState({ items: this.props.items });
+      setItems(props.items);
     } else {
-      this.setState({
-        items: this.props.items.filter(item =>
-          item.value.match(new RegExp(val, "i"))
-        )
-      });
+      setItems(
+        props.items.filter(item => item.value.match(new RegExp(val, "i")))
+      );
     }
-  }
+  };
 
-  render() {
-    return (
-      <div>
-        <Typeahead
-          items={this.state.items}
-          textField={
-            <TextInput
-              id="filter"
-              inputLabel="Filtering"
-              placeholder="Placeholder"
-              hintContent={
-                this.props.menuEmptyState
-                  ? "Type something with no matches"
-                  : ""
-              }
-              onChange={this.filterList}
-            />
-          }
-          menuEmptyState={this.props.menuEmptyState}
-        >
-          default
-        </Typeahead>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <Typeahead
+        items={items}
+        textField={
+          <TextInput
+            id="filter"
+            inputLabel="Filtering"
+            placeholder="Placeholder"
+            hintContent={
+              props.menuEmptyState ? "Type something with no matches" : ""
+            }
+            onChange={filterList}
+          />
+        }
+        menuEmptyState={props.menuEmptyState}
+      />
+    </div>
+  );
+});
 
 export default FilteredList;

--- a/packages/typeahead/tests/Typeahead.test.tsx
+++ b/packages/typeahead/tests/Typeahead.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
 import { createSerializer } from "@emotion/jest";
-import toJson from "enzyme-to-json";
+import { create } from "react-test-renderer";
 import { Typeahead, TextInput } from "../../index";
 import DropdownContents from "../../dropdownable/components/DropdownContents";
 
@@ -15,7 +15,7 @@ const items = [
 
 describe("Typeahead", () => {
   it("renders", () => {
-    const component = mount(
+    const component = create(
       <Typeahead
         items={items}
         textField={
@@ -28,11 +28,11 @@ describe("Typeahead", () => {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component.toJSON()).toMatchSnapshot();
   });
 
   it("renders a menu with a max height", () => {
-    const component = mount(
+    const component = create(
       <Typeahead
         items={items}
         menuMaxHeight={100}
@@ -46,7 +46,7 @@ describe("Typeahead", () => {
       />
     );
 
-    expect(toJson(component)).toMatchSnapshot();
+    expect(component.toJSON()).toMatchSnapshot();
   });
 
   it("opens the menu on focus", () => {

--- a/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
+++ b/packages/typeahead/tests/__snapshots__/Typeahead.test.tsx.snap
@@ -120,201 +120,60 @@ exports[`Typeahead renders 1`] = `
   border-color: var(--themeBrandPrimary, #7D58FF);
 }
 
-<Typeahead
-  items={
-    [
-      {
-        "label": "Exosphere",
-        "value": "Exosphere",
-      },
-      {
-        "label": "Thermosphere",
-        "value": "Thermosphere",
-      },
-      {
-        "label": "Stratosphere",
-        "value": "Stratosphere",
-      },
-    ]
-  }
-  menuMaxHeight={300}
-  textField={
-    <TextInput
-      appearance="standard"
-      id="standard.input"
-      inputLabel="Standard"
-      placeholder="Placeholder"
-      showInputLabel={true}
-      type="text"
-    />
-  }
+<div
+  data-cy="typeahead"
 >
   <div
-    data-cy="typeahead"
+    aria-expanded={false}
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-0-label"
+    aria-owns={null}
+    role="combobox"
   >
-    <Downshift
-      defaultHighlightedIndex={null}
-      defaultIsOpen={false}
-      environment={[Window]}
-      getA11yStatusMessage={[Function]}
-      itemToString={[Function]}
-      onChange={[Function]}
-      onInputValueChange={[Function]}
-      onOuterClick={[Function]}
-      onSelect={[Function]}
-      onStateChange={[Function]}
-      onUserAction={[Function]}
-      scrollIntoView={[Function]}
-      selectedItemChanged={[Function]}
-      stateReducer={[Function]}
-      suppressRefError={false}
-    >
+    <div>
       <div
-        aria-expanded={false}
-        aria-haspopup="listbox"
-        aria-labelledby="downshift-0-label"
-        aria-owns={null}
-        role="combobox"
+        data-cy="textInput textInput.standard"
       >
-        <Dropdownable
-          dropdown={
-            <div
-              data-cy="typeahead-dropdown"
-            >
-              .emotion-0 {
-  margin-top: 4px;
-}
-
-<div
-                className="emotion-0"
-              >
-                <Popover
-                  aria-labelledby="downshift-0-label"
-                  id="downshift-0-menu"
-                  maxHeight={300}
-                  menuRef={[Function]}
-                  role="listbox"
-                  width={null}
-                >
-                  <PopoverListItem
-                    aria-selected={false}
-                    id="downshift-0-item-0"
-                    index={0}
-                    isActive={false}
-                    isSelected={null}
-                    listLength={3}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseMove={[Function]}
-                    role="option"
-                  >
-                    Exosphere
-                  </PopoverListItem>
-                  <PopoverListItem
-                    aria-selected={false}
-                    id="downshift-0-item-1"
-                    index={1}
-                    isActive={false}
-                    isSelected={null}
-                    listLength={3}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseMove={[Function]}
-                    role="option"
-                  >
-                    Thermosphere
-                  </PopoverListItem>
-                  <PopoverListItem
-                    aria-selected={false}
-                    id="downshift-0-item-2"
-                    index={2}
-                    isActive={false}
-                    isSelected={null}
-                    listLength={3}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseMove={[Function]}
-                    role="option"
-                  >
-                    Stratosphere
-                  </PopoverListItem>
-                </Popover>
-              </div>
-            </div>
-          }
-          isOpen={false}
+        <label
+          className="emotion-0"
+          data-cy="textInput-label"
+          htmlFor="standard.input"
         >
-          <div>
-            <TextInput
-              appearance="standard"
+          Standard
+        </label>
+        <div>
+          <div
+            className="emotion-1"
+          >
+            <input
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls={null}
+              aria-describedby=""
+              aria-invalid={false}
               aria-labelledby="downshift-0-label"
               autoComplete="off"
+              className="emotion-2"
+              data-cy="textInput-input"
               id="standard.input"
-              inputLabel="Standard"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
               placeholder="Placeholder"
-              showInputLabel={true}
               type="text"
               value=""
-            >
-              <div
-                data-cy="textInput textInput.standard"
-              >
-                <label
-                  className="emotion-0"
-                  data-cy="textInput-label"
-                  htmlFor="standard.input"
-                >
-                  Standard
-                </label>
-                <FormFieldWrapper
-                  id="standard.input"
-                >
-                  <div>
-                    <div
-                      className="emotion-1"
-                    >
-                      <input
-                        aria-activedescendant={null}
-                        aria-autocomplete="list"
-                        aria-controls={null}
-                        aria-describedby=""
-                        aria-invalid={false}
-                        aria-labelledby="downshift-0-label"
-                        autoComplete="off"
-                        className="emotion-2"
-                        data-cy="textInput-input"
-                        id="standard.input"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        placeholder="Placeholder"
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                    <div
-                      data-cy="textInput-hintContent"
-                    />
-                  </div>
-                </FormFieldWrapper>
-              </div>
-            </TextInput>
+            />
           </div>
-        </Dropdownable>
+          <div
+            data-cy="textInput-hintContent"
+          />
+        </div>
       </div>
-    </Downshift>
+    </div>
   </div>
-</Typeahead>
+</div>
 `;
 
 exports[`Typeahead renders a menu with a max height 1`] = `
@@ -437,199 +296,58 @@ exports[`Typeahead renders a menu with a max height 1`] = `
   border-color: var(--themeBrandPrimary, #7D58FF);
 }
 
-<Typeahead
-  items={
-    [
-      {
-        "label": "Exosphere",
-        "value": "Exosphere",
-      },
-      {
-        "label": "Thermosphere",
-        "value": "Thermosphere",
-      },
-      {
-        "label": "Stratosphere",
-        "value": "Stratosphere",
-      },
-    ]
-  }
-  menuMaxHeight={100}
-  textField={
-    <TextInput
-      appearance="standard"
-      id="standard.input"
-      inputLabel="Standard"
-      placeholder="Placeholder"
-      showInputLabel={true}
-      type="text"
-    />
-  }
+<div
+  data-cy="typeahead"
 >
   <div
-    data-cy="typeahead"
+    aria-expanded={false}
+    aria-haspopup="listbox"
+    aria-labelledby="downshift-1-label"
+    aria-owns={null}
+    role="combobox"
   >
-    <Downshift
-      defaultHighlightedIndex={null}
-      defaultIsOpen={false}
-      environment={[Window]}
-      getA11yStatusMessage={[Function]}
-      itemToString={[Function]}
-      onChange={[Function]}
-      onInputValueChange={[Function]}
-      onOuterClick={[Function]}
-      onSelect={[Function]}
-      onStateChange={[Function]}
-      onUserAction={[Function]}
-      scrollIntoView={[Function]}
-      selectedItemChanged={[Function]}
-      stateReducer={[Function]}
-      suppressRefError={false}
-    >
+    <div>
       <div
-        aria-expanded={false}
-        aria-haspopup="listbox"
-        aria-labelledby="downshift-1-label"
-        aria-owns={null}
-        role="combobox"
+        data-cy="textInput textInput.standard"
       >
-        <Dropdownable
-          dropdown={
-            <div
-              data-cy="typeahead-dropdown"
-            >
-              .emotion-0 {
-  margin-top: 4px;
-}
-
-<div
-                className="emotion-0"
-              >
-                <Popover
-                  aria-labelledby="downshift-1-label"
-                  id="downshift-1-menu"
-                  maxHeight={100}
-                  menuRef={[Function]}
-                  role="listbox"
-                  width={null}
-                >
-                  <PopoverListItem
-                    aria-selected={false}
-                    id="downshift-1-item-0"
-                    index={0}
-                    isActive={false}
-                    isSelected={null}
-                    listLength={3}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseMove={[Function]}
-                    role="option"
-                  >
-                    Exosphere
-                  </PopoverListItem>
-                  <PopoverListItem
-                    aria-selected={false}
-                    id="downshift-1-item-1"
-                    index={1}
-                    isActive={false}
-                    isSelected={null}
-                    listLength={3}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseMove={[Function]}
-                    role="option"
-                  >
-                    Thermosphere
-                  </PopoverListItem>
-                  <PopoverListItem
-                    aria-selected={false}
-                    id="downshift-1-item-2"
-                    index={2}
-                    isActive={false}
-                    isSelected={null}
-                    listLength={3}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseMove={[Function]}
-                    role="option"
-                  >
-                    Stratosphere
-                  </PopoverListItem>
-                </Popover>
-              </div>
-            </div>
-          }
-          isOpen={false}
+        <label
+          className="emotion-0"
+          data-cy="textInput-label"
+          htmlFor="standard.input"
         >
-          <div>
-            <TextInput
-              appearance="standard"
+          Standard
+        </label>
+        <div>
+          <div
+            className="emotion-1"
+          >
+            <input
               aria-activedescendant={null}
               aria-autocomplete="list"
               aria-controls={null}
+              aria-describedby=""
+              aria-invalid={false}
               aria-labelledby="downshift-1-label"
               autoComplete="off"
+              className="emotion-2"
+              data-cy="textInput-input"
               id="standard.input"
-              inputLabel="Standard"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
               placeholder="Placeholder"
-              showInputLabel={true}
               type="text"
               value=""
-            >
-              <div
-                data-cy="textInput textInput.standard"
-              >
-                <label
-                  className="emotion-0"
-                  data-cy="textInput-label"
-                  htmlFor="standard.input"
-                >
-                  Standard
-                </label>
-                <FormFieldWrapper
-                  id="standard.input"
-                >
-                  <div>
-                    <div
-                      className="emotion-1"
-                    >
-                      <input
-                        aria-activedescendant={null}
-                        aria-autocomplete="list"
-                        aria-controls={null}
-                        aria-describedby=""
-                        aria-invalid={false}
-                        aria-labelledby="downshift-1-label"
-                        autoComplete="off"
-                        className="emotion-2"
-                        data-cy="textInput-input"
-                        id="standard.input"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        placeholder="Placeholder"
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                    <div
-                      data-cy="textInput-hintContent"
-                    />
-                  </div>
-                </FormFieldWrapper>
-              </div>
-            </TextInput>
+            />
           </div>
-        </Dropdownable>
+          <div
+            data-cy="textInput-hintContent"
+          />
+        </div>
       </div>
-    </Downshift>
+    </div>
   </div>
-</Typeahead>
+</div>
 `;


### PR DESCRIPTION
This one was more complicated but converted Typeahead from a class component to a functional component. All functionality should be preserved, but I did find that the CustomMenuEmptyState story did not work as expected because the empty state should be shown when there are no items. Also made a decision to remove the filteredlist typeahead because it didn't really demonstrate any functionality of the component itself, just of how a wrapping component could control its state. It seemed superfluous.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

This one had pretty good unit test coverage, but a regression of the typeahead stories against prod would be good

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
