### PR TITLE
refactor: migration away from react.fc

### DIFF
--- a/packages/accordion/components/AccordionItemTitleInteractive.tsx
+++ b/packages/accordion/components/AccordionItemTitleInteractive.tsx
@@ -21,11 +21,15 @@ interface RenderProps {
   getHeading: (label: string) => React.ReactNode;
 }
 
-const AccordionItemTitleInteractive: React.FC<
-  Exclude<AccordionItemTitleProps, "children"> & {
-    children: (renderProps: RenderProps) => React.ReactNode;
-  }
-> = ({ appearance, children, "data-cy": dataCy, disabled, headingLevel }) => {
+const AccordionItemTitleInteractive = ({
+  appearance,
+  children,
+  "data-cy": dataCy,
+  disabled,
+  headingLevel
+}: Exclude<AccordionItemTitleProps, "children"> & {
+  children: (renderProps: RenderProps) => React.ReactNode;
+}) => {
   const HeadingTag: keyof React.ReactHTML = `h${headingLevel}` as
     | "h2"
     | "h3"

--- a/packages/clicktocopybutton/components/ClickToCopy.tsx
+++ b/packages/clicktocopybutton/components/ClickToCopy.tsx
@@ -42,13 +42,13 @@ interface ClickToCopyProps extends ClickToCopyBaseProps {
  * that takes a function parameter and returns a component that executes that function using
  * a trigger element such as a button with an onClick handler.
  */
-const ClickToCopy: React.FC<ClickToCopyProps> = ({
+const ClickToCopy = ({
   textToCopy,
   onCopy,
   children,
   tooltipId,
-  tooltipContent
-}) => {
+  tooltipContent = "Copied to clipboard"
+}: ClickToCopyProps) => {
   const [generatedTooltipId] = useId(1, "copyTooltip");
   const [isTooltipShown, setIsTooltipShown] = React.useState<boolean>(false);
   const onClick = () => {
@@ -74,10 +74,6 @@ const ClickToCopy: React.FC<ClickToCopyProps> = ({
       </Tooltip>
     </Box>
   );
-};
-
-ClickToCopy.defaultProps = {
-  tooltipContent: "Copied to clipboard"
 };
 
 export default ClickToCopy;

--- a/packages/clicktocopybutton/components/ClickToCopyButton.tsx
+++ b/packages/clicktocopybutton/components/ClickToCopyButton.tsx
@@ -25,14 +25,16 @@ interface ClickToCopyButtonProps extends ClickToCopyBaseProps {
    * Custom ID used for tooltip's id and aria attributes
    */
   tooltipId?: string;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
-const ClickToCopyButton: React.FC<ClickToCopyButtonProps> = ({
+const ClickToCopyButton = ({
   children,
   color,
   iconSize,
+  tooltipContent = "Copied to clipboard",
   ...other
-}) => {
+}: ClickToCopyButtonProps) => {
   return (
     <ClickToCopy {...other}>
       {({ onClick }) => (
@@ -52,10 +54,6 @@ const ClickToCopyButton: React.FC<ClickToCopyButtonProps> = ({
       )}
     </ClickToCopy>
   );
-};
-
-ClickToCopyButton.defaultProps = {
-  tooltipContent: "Copied to clipboard"
 };
 
 export default ClickToCopyButton;

--- a/packages/clicktocopybutton/tests/__snapshots__/ClickToCopyButton.test.tsx.snap
+++ b/packages/clicktocopybutton/tests/__snapshots__/ClickToCopyButton.test.tsx.snap
@@ -27,11 +27,9 @@ exports[`ClickToCopyButton renders default 1`] = `
 
 <ClickToCopyButton
   textToCopy="text to copy"
-  tooltipContent="Copied to clipboard"
 >
   <ClickToCopy
     textToCopy="text to copy"
-    tooltipContent="Copied to clipboard"
   >
     <Box
       bgImageOptions={
@@ -183,11 +181,9 @@ exports[`ClickToCopyButton renders with custom children 1`] = `
 
 <ClickToCopyButton
   textToCopy="text to copy"
-  tooltipContent="Copied to clipboard"
 >
   <ClickToCopy
     textToCopy="text to copy"
-    tooltipContent="Copied to clipboard"
   >
     <Box
       bgImageOptions={

--- a/packages/codesnippet/components/CodeSnippet.tsx
+++ b/packages/codesnippet/components/CodeSnippet.tsx
@@ -28,12 +28,12 @@ export interface CodeSnippetProps {
   copyTooltipContent?: React.ReactNode;
 }
 
-const CodeSnippet: React.FC<CodeSnippetProps> = ({
+const CodeSnippet = ({
   children,
   copyTooltipContent,
   textToCopy,
   onCopy
-}) => (
+}: CodeSnippetProps) => (
   <SpacingBox bgColor={greyDark} className={codeSnippet}>
     <Flex>
       <FlexItem>

--- a/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
+++ b/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
@@ -361,11 +361,9 @@ exports[`CodeSnippet renders with copy button 1`] = `
                 <ClickToCopyButton
                   color="var(--themeTextColorPrimaryInverted, #FFFFFF)"
                   textToCopy="snippet content"
-                  tooltipContent="Copied to clipboard"
                 >
                   <ClickToCopy
                     textToCopy="snippet content"
-                    tooltipContent="Copied to clipboard"
                   >
                     <Box
                       bgImageOptions={

--- a/packages/dropdownable/components/Dropdownable.tsx
+++ b/packages/dropdownable/components/Dropdownable.tsx
@@ -27,6 +27,7 @@ export interface DropdownableProps {
   overlayRoot?: HTMLElement;
   /** Whether the Dropdownable overlay should open in it's parent element instead of `overlayRoot` */
   disablePortal?: boolean;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
 const getPreferredDirection = (
@@ -57,7 +58,7 @@ const getFlipModifier = (preferredDirections?: Direction | Direction[]) => {
   return null;
 };
 
-const Dropdownable: React.FC<DropdownableProps> = ({
+const Dropdownable = ({
   isOpen,
   dropdown,
   preferredDirections,
@@ -65,7 +66,7 @@ const Dropdownable: React.FC<DropdownableProps> = ({
   overlayRoot,
   disablePortal,
   children
-}) => {
+}: DropdownableProps) => {
   const [referenceElement, setReferenceElement] =
     React.useState<HTMLDivElement | null>(null);
   const [popperElement, setPopperElement] =

--- a/packages/expandable/components/Expandable.tsx
+++ b/packages/expandable/components/Expandable.tsx
@@ -17,15 +17,15 @@ export interface ExpandableProps {
   onChange?: (open: boolean) => void;
 }
 
-const Expandable: React.FC<ExpandableProps> = ({
+const Expandable = ({
   labelClassName,
   children,
   label,
   isOpen,
   controlledIsOpen,
   onChange,
-  indicatorPosition
-}) => {
+  indicatorPosition = "left"
+}: ExpandableProps) => {
   const [open, setOpen] = React.useState(Boolean(isOpen));
 
   React.useEffect(() => {
@@ -77,10 +77,6 @@ const Expandable: React.FC<ExpandableProps> = ({
       </div>
     </div>
   );
-};
-
-Expandable.defaultProps = {
-  indicatorPosition: "left"
 };
 
 export default Expandable;

--- a/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
+++ b/packages/expandable/tests/__snapshots__/Expandable.test.tsx.snap
@@ -124,7 +124,6 @@ exports[`Sidebar renders 1`] = `
 }
 
 <Expandable
-  indicatorPosition="left"
   isOpen={true}
   label="Label"
 >

--- a/packages/formStructure/components/FieldList.tsx
+++ b/packages/formStructure/components/FieldList.tsx
@@ -49,6 +49,7 @@ export interface FieldListProps {
    * problems when the field value is changed
    */
   pathToUniqueKey?: string;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
 type FieldListColumn = React.ReactElement<
@@ -71,7 +72,7 @@ interface FieldListRowProps
 const isRowDisabled = (rowIndex, disabledRows) =>
   disabledRows && disabledRows.includes(rowIndex);
 
-const FieldListRow: React.FC<FieldListRowProps> = React.memo(
+const FieldListRow = React.memo(
   ({
     columns,
     data,
@@ -80,7 +81,7 @@ const FieldListRow: React.FC<FieldListRowProps> = React.memo(
     isLastRow,
     pathToUniqueKey,
     rowId
-  }) => {
+  }: FieldListRowProps) => {
     const fieldListContext = React.useContext(FieldListContext);
     const addEmptyRow = (e: React.KeyboardEvent) => {
       const rowHasData = Object.keys(data || {}).filter(
@@ -151,7 +152,7 @@ const FieldListRow: React.FC<FieldListRowProps> = React.memo(
   }
 );
 
-const FieldListHeader: React.FC<FieldListHeaderProps> = ({ columns }) => (
+const FieldListHeader = ({ columns }: FieldListHeaderProps) => (
   <SpacingBox
     side="bottom"
     spacingSize="xxs"
@@ -174,14 +175,14 @@ const FieldListHeader: React.FC<FieldListHeaderProps> = ({ columns }) => (
   </SpacingBox>
 );
 
-const FieldList: React.FC<FieldListProps> = ({
+const FieldList = ({
   children,
   data,
   disabledRows,
   onAddItem,
   onRemoveItem,
-  pathToUniqueKey
-}) => {
+  pathToUniqueKey = "id"
+}: FieldListProps) => {
   const columns = (
     React.Children.toArray(children) as Array<
       React.ReactElement<FieldListColumnProps & FieldListColumnWidthProps>
@@ -255,10 +256,6 @@ const FieldList: React.FC<FieldListProps> = ({
       </div>
     </FieldListProvider>
   );
-};
-
-FieldList.defaultProps = {
-  pathToUniqueKey: "id"
 };
 
 export default FieldList;

--- a/packages/formStructure/components/FieldListAddButton.tsx
+++ b/packages/formStructure/components/FieldListAddButton.tsx
@@ -4,7 +4,7 @@ import { SystemIcons } from "../../icons/dist/system-icons-enum";
 import { ButtonProps } from "../../button/components/ButtonBase";
 import { Context as FieldListContext } from "./FieldListContext";
 
-const FieldListAddButton: React.FC<ButtonProps> = ({ onClick, ...other }) => {
+const FieldListAddButton = ({ onClick, ...other }: ButtonProps) => {
   const fieldListContext = React.useContext(FieldListContext);
   const handleClick = fieldListContext
     ? () => fieldListContext.addListItem()

--- a/packages/formStructure/components/FieldListColumn.tsx
+++ b/packages/formStructure/components/FieldListColumn.tsx
@@ -26,6 +26,7 @@ export interface FieldListColumnWidthProps {
   /** The maximum width a column of fields can be. Accepts a number or any value that can be passed to CSS's `grid-template-columns` */
   maxWidth?: number | string;
   key: React.Key;
+  children?: React.ReactNode;
 }
 export interface FieldListColumnProps<
   T = string,
@@ -50,6 +51,11 @@ export const FieldListColumn: <
   FieldListColumnProps<T, E> & FieldListColumnWidthProps
 > = () => <React.Fragment />;
 
-export const FieldListColumnSeparator: React.FC<
-  FieldListColumnWidthProps
-> = () => <React.Fragment />;
+type FieldListColumnSeparatorProps = {
+  key?: string;
+  children?: React.ReactNode;
+};
+
+export const FieldListColumnSeparator = ({
+  children
+}: FieldListColumnSeparatorProps) => <>{children}</>;

--- a/packages/formStructure/components/FieldListContext.tsx
+++ b/packages/formStructure/components/FieldListContext.tsx
@@ -15,14 +15,14 @@ type FieldListContext = {
 
 export const Context = React.createContext<FieldListContext | null>(null);
 
-export const FieldListProvider: React.FC<FieldListProviderProps> = ({
+export const FieldListProvider = ({
   onAddItem,
   children,
   data,
   pathToUniqueKey,
   onRemoveItem,
   setData
-}) => {
+}: FieldListProviderProps) => {
   const addListItem = (
     rowId?: string | number,
     itemToAdd?: Record<string, any>

--- a/packages/formStructure/components/FormMessage.tsx
+++ b/packages/formStructure/components/FormMessage.tsx
@@ -5,7 +5,7 @@ import { SpacingBox } from "../../styleUtils/modifiers";
 
 type FormMessageProps = Omit<InfoBoxProps, "message">;
 
-const FormMessage: React.FC<FormMessageProps> = ({ children, ...other }) => (
+const FormMessage = ({ children, ...other }: FormMessageProps) => (
   <SpacingBox side="bottom" spacingSize="l" data-cy="formMessage">
     <InfoBoxInline message={children} {...other} />
   </SpacingBox>

--- a/packages/formStructure/components/FormSectionFooter.tsx
+++ b/packages/formStructure/components/FormSectionFooter.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { SpacingBox } from "../../styleUtils/modifiers";
 
-const FormSectionFooter: React.FC = ({ children }) => (
+export interface FormSectionFooterProps {
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+const FormSectionFooter = ({ children }: FormSectionFooterProps) => (
   <SpacingBox side="top" spacingSize="m" data-cy="formSectionFooter">
     {children}
   </SpacingBox>

--- a/packages/formStructure/components/FormTitle.tsx
+++ b/packages/formStructure/components/FormTitle.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 import { SpacingBox } from "../../styleUtils/modifiers";
 import { HeadingText1 } from "../../styleUtils/typography";
 
-const FormTitle: React.FC = ({ children }) => (
+export interface FormTitleProps {
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+const FormTitle = ({ children }: FormTitleProps) => (
   <SpacingBox side="bottom" spacingSize="l">
     <HeadingText1 data-cy="formTitle">{children}</HeadingText1>
   </SpacingBox>

--- a/packages/infobox/components/InfoBox.tsx
+++ b/packages/infobox/components/InfoBox.tsx
@@ -43,6 +43,7 @@ export interface InfoBoxProps {
    * an alternate action the user could take
    */
   secondaryAction?: React.ReactElement<HTMLElement>;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
 const InfoBox = ({

--- a/packages/inlineBorderedItems/components/InlineBorderedItems.tsx
+++ b/packages/inlineBorderedItems/components/InlineBorderedItems.tsx
@@ -9,13 +9,11 @@ export interface InlineBorderedItemsProps {
   gutterSize?: SpaceSize;
 }
 
-const InlineBorderedItems: React.FC<InlineBorderedItemsProps> = ({
+const InlineBorderedItems = ({
   children,
-  gutterSize
-}) => <div className={inlineBorderedItems(gutterSize!)}>{children}</div>;
-
-InlineBorderedItems.defaultProps = {
-  gutterSize: "s"
-};
+  gutterSize = "s"
+}: InlineBorderedItemsProps) => (
+  <div className={inlineBorderedItems(gutterSize!)}>{children}</div>
+);
 
 export default InlineBorderedItems;

--- a/packages/modal/components/ModalContents.tsx
+++ b/packages/modal/components/ModalContents.tsx
@@ -5,13 +5,11 @@ import { flex } from "../../shared/styles/styleUtils";
 export interface ModalContentsProps {
   isOpen: boolean;
   onClose: () => void;
-  ["data-cy"]?: string;
+  "data-cy"?: string;
+  children?: React.ReactNode | React.ReactNode[];
 }
 
-const ModalContents: React.FC<ModalContentsProps> = ({
-  children,
-  "data-cy": dataCy
-}) => (
+const ModalContents = ({ children, "data-cy": dataCy }: ModalContentsProps) => (
   <div
     className={cx(modalWrapper, flex({ direction: "column" }))}
     data-cy={dataCy}

--- a/packages/pagination/PaginationContainer.tsx
+++ b/packages/pagination/PaginationContainer.tsx
@@ -3,9 +3,15 @@ import { FlexboxProperties } from "../shared/styles/styleUtils/layout/flexbox";
 import { Flex, FlexItem } from "../styleUtils/layout";
 import Pagination from "./Pagination";
 
-const PaginationContainer: React.FC<{
+export interface PaginationContainerProps {
+  children?: React.ReactNode | React.ReactNode[];
   vertAlignChildren?: FlexboxProperties["align"];
-}> = ({ children, vertAlignChildren }) => {
+}
+
+const PaginationContainer = ({
+  children,
+  vertAlignChildren = "center"
+}: PaginationContainerProps) => {
   const paginationComponent = React.Children.toArray(children).find(
     child => React.isValidElement(child) && child.type === Pagination
   );
@@ -21,10 +27,6 @@ const PaginationContainer: React.FC<{
       <FlexItem flex="shrink">{paginationComponent}</FlexItem>
     </Flex>
   );
-};
-
-PaginationContainer.defaultProps = {
-  vertAlignChildren: "center"
 };
 
 export default PaginationContainer;

--- a/packages/pagination/pagination.stories.tsx
+++ b/packages/pagination/pagination.stories.tsx
@@ -6,6 +6,16 @@ import { BorderedList } from "../list";
 import usePageChange from "./usePageChange";
 import { mockPaginationData as initialData } from "./mockPaginationData.json";
 
+type ControlledPaginationWrapperProps = {
+  children: (renderProps: {
+    activePage: number;
+    pageLength: number;
+    itemEndIndex: number;
+    itemStartIndex: number;
+    onChange: (newPage, newPageLength) => void;
+  }) => React.ReactElement;
+};
+
 export default {
   title: "Navigation/Pagination",
   component: Pagination
@@ -20,17 +30,12 @@ const Template: Story<PaginationProps> = args => (
 export const Default = Template.bind({});
 
 export const ExampleWPagedListControlledComponent = args => {
-  const ControlledPaginationWrapper: React.FC<{
-    children: (renderProps: {
-      activePage: number;
-      pageLength: number;
-      itemEndIndex: number;
-      itemStartIndex: number;
-      onChange: (newPage, newPageLength) => void;
-    }) => React.ReactElement;
-  }> = ({ children }) => {
+  const ControlledPaginationWrapper = ({
+    children
+  }: ControlledPaginationWrapperProps) => {
     return children(usePageChange());
   };
+
   return (
     <ControlledPaginationWrapper>
       {({ activePage, itemEndIndex, itemStartIndex, pageLength, onChange }) => (

--- a/packages/promo/components/PromoBanner.tsx
+++ b/packages/promo/components/PromoBanner.tsx
@@ -12,12 +12,12 @@ interface PromoBannerProps extends PromoProps {
 
 const darkGradientStyles: GradientStyle[] = ["purple"];
 
-const PromoBanner: React.FunctionComponent<PromoBannerProps> = ({
-  bgColor = "",
+const PromoBanner = ({
+  bgColor = "themeBgSecondary",
   gradientStyle,
   isDarkBackground,
   ...other
-}) => (
+}: PromoBannerProps) => (
   <SpacingBox
     bgColor={gradientStyle ? gradientStyles[gradientStyle][0] : dt[bgColor]}
     className={cx({
@@ -35,9 +35,5 @@ const PromoBanner: React.FunctionComponent<PromoBannerProps> = ({
     />
   </SpacingBox>
 );
-
-PromoBanner.defaultProps = {
-  bgColor: "themeBgSecondary"
-};
 
 export default PromoBanner;

--- a/packages/promo/components/PromoContent.tsx
+++ b/packages/promo/components/PromoContent.tsx
@@ -21,24 +21,21 @@ import {
   heroImg
 } from "../style";
 
-const PromoContent: React.FC<PromoProps> = props => {
-  const {
-    bodyContent,
-    dismissHandler,
-    headingText,
-    isDarkBackground,
-    graphicSrc,
-    optOutBanner,
-    optOutHandler,
-    primaryAction,
-    secondaryAction
-  } = props;
+const PromoContent = ({
+  bodyContent,
+  dismissHandler,
+  headingText,
+  isDarkBackground,
+  graphicSrc,
+  optOutBanner,
+  optOutHandler,
+  primaryAction,
+  secondaryAction,
+  "data-cy": dataCy = "promoContent"
+}: PromoProps) => {
   const [dismissCheckboxId] = useId(1, "dismissPromoCheckbox");
   return (
-    <div
-      className={bannerContainer(isDarkBackground)}
-      data-cy={props["data-cy"]}
-    >
+    <div className={bannerContainer(isDarkBackground)} data-cy={dataCy}>
       {dismissHandler && (
         <ResetButton className={dismissButton} onClick={dismissHandler}>
           <Icon shape={SystemIcons.Close} size="xs" />
@@ -105,10 +102,6 @@ const PromoContent: React.FC<PromoProps> = props => {
       </Flex>
     </div>
   );
-};
-
-PromoContent.defaultProps = {
-  ["data-cy"]: "promoContent"
 };
 
 export default PromoContent;

--- a/packages/radioInput/RadioInput.tsx
+++ b/packages/radioInput/RadioInput.tsx
@@ -10,7 +10,7 @@ export interface RadioInputProps extends ToggleInputProps {
   name: string;
 }
 
-const RadioInput: React.FC<React.PropsWithRef<RadioInputProps>> = props => (
+const RadioInput = (props: React.PropsWithRef<RadioInputProps>) => (
   <ToggleInput inputType="radio" {...props} />
 );
 

--- a/packages/slideToggle/components/SlideToggle.tsx
+++ b/packages/slideToggle/components/SlideToggle.tsx
@@ -69,16 +69,16 @@ export interface SlideToggleProps extends React.HTMLProps<HTMLInputElement> {
   errors?: React.ReactNode[];
 }
 
-const SlideToggle: React.FC<React.PropsWithRef<SlideToggleProps>> = props => {
+const SlideToggle = (props: React.PropsWithRef<SlideToggleProps>) => {
   const {
-    appearance,
+    appearance = InputAppearance.Standard,
     children,
     disabled,
     hintContent,
     id = nextId("slideToggle-"),
     inputLabel,
-    showInputLabel,
-    vertAlign,
+    showInputLabel = "true",
+    vertAlign = "center",
     checked,
     value,
     errors,
@@ -191,12 +191,6 @@ const SlideToggle: React.FC<React.PropsWithRef<SlideToggleProps>> = props => {
       )}
     </FormFieldWrapper>
   );
-};
-
-SlideToggle.defaultProps = {
-  appearance: InputAppearance.Standard,
-  showInputLabel: true,
-  vertAlign: "center"
 };
 
 export default SlideToggle;

--- a/packages/tablev2/MutedCell.tsx
+++ b/packages/tablev2/MutedCell.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 import { Text } from "../styleUtils/typography";
 import { themeTextColorSecondary } from "../design-tokens/build/js/designTokens";
 
-export const MutedCell: React.FC = ({ children }) => (
+export interface MutedCellProps {
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+export const MutedCell = ({ children }: MutedCellProps) => (
   <Text tag="div" color={themeTextColorSecondary} wrap="truncate">
     {children}
   </Text>

--- a/packages/utilities/label.tsx
+++ b/packages/utilities/label.tsx
@@ -22,21 +22,23 @@ const trigger = (
 );
 const reqStar = <span className={cx(tintText(themeError))}> *</span>;
 
-export const renderLabel: React.FC<{
+export interface RenderLabelProps {
   appearance?: string;
   hidden?: boolean;
   id?: string;
   label?: React.ReactNode;
   required?: boolean;
   tooltipContent?: React.ReactNode;
-}> = ({
+}
+
+export const renderLabel = ({
   appearance,
   hidden,
   label,
   id = nextId(),
   required,
   tooltipContent
-}) => {
+}: RenderLabelProps) => {
   const hasError = appearance === InputAppearance.Error;
   const labelClassName = hidden ? cx(visuallyHidden) : getLabelStyle(hasError);
   const labelNode = (

--- a/scripts/templates/component/Component.tsx
+++ b/scripts/templates/component/Component.tsx
@@ -5,7 +5,7 @@ export interface ${Component}Props {
   children?: React.ReactNode | string;
 }
 
-const ${Component}: React.FC<${Component}Props> = ({children}) => {
+const ${Component} = ({children}: ${Component}Props) => {
   return <span className={style}>{children}</span>;
 }
 


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

Due to the issues with implicit children with React.FC we have decided to migrate components away from using this. 
This causes some interfaces to now include a prop-type definition for children. I wanted to isolate this refactor. This should take care of every last reference to React.FC or React.FunctionComponent. 
These changes will pave the way for our full migration to React 18.
I've also included a select few refactors for `defaultProps` when I noticed them. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing


<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
