### PR TITLE
Refactor TextInput related components from classes to functional components

### DIFF
--- a/packages/textInput/components/TextInput.tsx
+++ b/packages/textInput/components/TextInput.tsx
@@ -1,4 +1,3 @@
-import { cx } from "@emotion/css";
 import * as React from "react";
 import nextId from "react-id-generator";
 
@@ -7,10 +6,15 @@ import {
   getInputAppearanceStyle,
   inputContainer
 } from "../../shared/styles/formStyles";
-import { inputReset, padding } from "../../shared/styles/styleUtils";
+import { padding } from "../../shared/styles/styleUtils";
 import { flex, flexItem } from "../../shared/styles/styleUtils/layout/flexbox";
 import { InputAppearance } from "../../shared/types/inputAppearance";
 import { renderLabel } from "../../utilities/label";
+import {
+  getInputAppearance,
+  getInputElement,
+  getInputElementProps
+} from "./utils";
 
 export interface TextInputProps extends React.HTMLProps<HTMLInputElement> {
   /**
@@ -43,62 +47,33 @@ export interface TextInputProps extends React.HTMLProps<HTMLInputElement> {
   tooltipContent?: React.ReactNode;
 }
 
-export class TextInput<P extends TextInputProps> extends React.Component<P> {
-  public static defaultProps = {
-    type: "text",
-    appearance: InputAppearance.Standard,
-    showInputLabel: true
-  };
-  placeholderId = nextId("textInput-");
+const TextInput = (props: TextInputProps) => {
+  const placeholderId = nextId("textInput-");
 
-  public render() {
-    const containerProps: { className?: string } = {};
-    const appearance = this.getInputAppearance();
-    const dataCy = `textInput textInput.${appearance}`;
-
-    if (this.props.className) {
-      containerProps.className = this.props.className;
-    }
-    return (
-      <div {...containerProps} data-cy={dataCy}>
-        {renderLabel({
-          appearance,
-          hidden: !this.props.showInputLabel,
-          id: this.getId(),
-          label: this.props.inputLabel,
-          required: this.props.required,
-          tooltipContent: this.props.tooltipContent
-        })}
-        {this.getInputContent()}
-      </div>
-    );
-  }
-
-  protected getInputAppearance(): string {
-    return this.props.disabled ? "disabled" : this.props.appearance;
-  }
-
-  protected getInputContent(): React.ReactNode {
-    const appearance = this.getInputAppearance();
+  const getInputContent = (): React.ReactNode => {
+    const appearance = getInputAppearance(props);
 
     return (
       <FormFieldWrapper
-        id={this.getId()}
-        errors={this.props.errors}
-        hintContent={this.props.hintContent}
+        id={getId()}
+        errors={props.errors}
+        hintContent={props.hintContent}
       >
         {({ getValidationErrors, getHintContent, isValid, describedByIds }) => (
           <div>
             <div className={flex()}>
-              {this.getInputElement(
+              {getInputElement(
                 [
                   padding("horiz", "m"),
                   flexItem("grow"),
                   inputContainer,
-                  getInputAppearanceStyle(this.getInputAppearance())
+                  getInputAppearanceStyle(getInputAppearance(props))
                 ],
                 isValid,
-                describedByIds
+                describedByIds,
+                props,
+                getInputAppearance,
+                getInputElementProps
               )}
             </div>
             <div data-cy="textInput-hintContent">
@@ -109,69 +84,42 @@ export class TextInput<P extends TextInputProps> extends React.Component<P> {
         )}
       </FormFieldWrapper>
     );
-  }
-  protected getInputElementProps(): TextInputProps {
-    // omit props for container and that we override, otherwise pass through
-    // TextInput props to input element
-    const {
-      className,
-      hintContent,
-      inputLabel,
-      errors,
-      id = this.placeholderId,
-      ...inputElementProps
-    } = this.props;
+  };
 
-    return { ...inputElementProps, id };
-  }
-
-  protected getInputElement(
-    additionalClasses: string[] = [],
-    isValid: boolean,
-    describedBy: string
-  ) {
-    const {
-      value,
-      showInputLabel,
-      appearance,
-      tooltipContent,
-      ...inputElementProps
-    } = this.getInputElementProps();
-    const textInputAppearance = this.getInputAppearance();
-    const dataCy = [
-      "textInput-input",
-      ...(textInputAppearance &&
-      textInputAppearance !== InputAppearance.Standard
-        ? [`textInput-input.${textInputAppearance}`]
-        : [])
-    ].join(" ");
-    let { onChange } = inputElementProps;
-    if (onChange == null && value != null) {
-      onChange = Function.prototype as (
-        event: React.FormEvent<HTMLInputElement>
-      ) => void;
-    }
-    const additionalProps = {
-      ...{ ...inputElementProps, onChange, value, type: this.props.type }
-    };
-    return (
-      <input
-        className={cx(inputReset, ...additionalClasses)}
-        aria-invalid={!isValid}
-        aria-describedby={describedBy}
-        data-cy={dataCy}
-        {...additionalProps}
-      />
-    );
-  }
-
-  private getId(): string {
-    if (typeof this.props.id === "string") {
-      return this.props.id;
+  const getId = (): string => {
+    if (typeof props.id === "string") {
+      return props.id;
     }
 
-    return this.placeholderId;
+    return placeholderId;
+  };
+
+  const containerProps: { className?: string } = {};
+  const appearance = getInputAppearance(props);
+  const dataCy = `textInput textInput.${appearance}`;
+
+  if (props.className) {
+    containerProps.className = props.className;
   }
-}
+  return (
+    <div {...containerProps} data-cy={dataCy}>
+      {renderLabel({
+        appearance,
+        hidden: !props.showInputLabel,
+        id: getId(),
+        label: props.inputLabel,
+        required: props.required,
+        tooltipContent: props.tooltipContent
+      })}
+      {getInputContent()}
+    </div>
+  );
+};
+
+TextInput.defaultProps = {
+  type: "text",
+  appearance: InputAppearance.Standard,
+  showInputLabel: true
+};
 
 export default TextInput;

--- a/packages/textInput/components/TextInputWithButtons.tsx
+++ b/packages/textInput/components/TextInputWithButtons.tsx
@@ -53,9 +53,11 @@ const TextInputWithButtons = (props: TextInputWithButtonsProps) => {
     }
     return props.appearance;
   };
+
   const getInputElementProps = () => {
     const baseProps = getBaseInputElementProps(props);
-    const { buttons, ...inputProps } = baseProps as TextInputWithButtonsProps;
+    const { buttons, iconStart, ...inputProps } =
+      baseProps as TextInputWithButtonsProps;
     inputProps.onFocus = inputOnFocus;
     inputProps.onBlur = inputOnBlur;
 

--- a/packages/textInput/components/utils.tsx
+++ b/packages/textInput/components/utils.tsx
@@ -1,0 +1,143 @@
+import * as React from "react";
+import { TextInputProps } from "./TextInput";
+import nextId from "react-id-generator";
+import { InputAppearance } from "../../shared/types/inputAppearance";
+import {
+  flex,
+  flexItem,
+  flush,
+  inputReset,
+  padding
+} from "../../shared/styles/styleUtils";
+import { cx } from "@emotion/css";
+import { TextInputWithIconProps } from "./TextInputWithIcon";
+import IconPropAdapter from "../../icon/components/IconPropAdapter";
+import {
+  getIconAppearanceStyle,
+  inputIconWrapper
+} from "../../shared/styles/formStyles";
+
+const getInputElementProps = (props: TextInputProps): TextInputProps => {
+  const placeholderId = nextId("textInput-");
+
+  // omit props for container and that we override, otherwise pass through
+  // TextInput props to input element
+  const {
+    className,
+    hintContent,
+    inputLabel,
+    errors,
+    id = placeholderId,
+    ...inputElementProps
+  } = props;
+
+  return { ...inputElementProps, id };
+};
+
+const getInputElement = (
+  additionalClasses: string[] = [],
+  isValid: boolean,
+  describedBy: string,
+  textInputProps: TextInputProps,
+  getInputAppearance: (props: TextInputProps) => string,
+  getInputElementProps: (textInputProps: TextInputProps) => TextInputProps
+) => {
+  const {
+    value,
+    showInputLabel,
+    appearance,
+    tooltipContent,
+    type,
+    ...inputElementProps
+  } = getInputElementProps(textInputProps);
+  const textInputAppearance = getInputAppearance(textInputProps);
+  const dataCy = [
+    "textInput-input",
+    ...(textInputAppearance && textInputAppearance !== InputAppearance.Standard
+      ? [`textInput-input.${textInputAppearance}`]
+      : [])
+  ].join(" ");
+  let { onChange } = inputElementProps;
+  if (onChange == null && value != null) {
+    onChange = Function.prototype as (
+      event: React.FormEvent<HTMLInputElement>
+    ) => void;
+  }
+  const additionalProps = {
+    ...{ ...inputElementProps, onChange, value, type }
+  };
+  return (
+    <input
+      className={cx(inputReset, ...additionalClasses)}
+      aria-invalid={!isValid}
+      aria-describedby={describedBy}
+      data-cy={dataCy}
+      {...additionalProps}
+    />
+  );
+};
+
+const getInputAppearance = (props: TextInputProps): string => {
+  return props.disabled ? "disabled" : props.appearance;
+};
+
+const getIconStartContent = (
+  props: TextInputWithIconProps,
+  appearance: string
+) => {
+  if (!props.iconStart) {
+    return null;
+  }
+  return (
+    <span
+      className={cx(
+        padding("right", "xs"),
+        flex({ align: "center", justify: "center" }),
+        flexItem("shrink"),
+        getIconAppearanceStyle(appearance),
+        inputIconWrapper
+      )}
+    >
+      <IconPropAdapter icon={props.iconStart!} size="xs" color="inherit" />
+    </span>
+  );
+};
+
+const getIconEndContent = (
+  props: TextInputWithIconProps,
+  appearance: string
+) => {
+  if (!props.iconEnd) {
+    return null;
+  }
+  return (
+    <span
+      className={cx(
+        flex({ align: "center", justify: "center" }),
+        flexItem("shrink"),
+        flush("left"),
+        getIconAppearanceStyle(appearance),
+        inputIconWrapper
+      )}
+    >
+      <IconPropAdapter icon={props.iconEnd!} size="xs" color="inherit" />
+    </span>
+  );
+};
+
+const getId = (props: TextInputProps): string => {
+  if (typeof props.id === "string") {
+    return props.id;
+  }
+
+  return nextId("textInput-");
+};
+
+export {
+  getInputElementProps,
+  getInputElement,
+  getInputAppearance,
+  getIconStartContent,
+  getIconEndContent,
+  getId
+};


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

This PR changes the following components from being class based ones, to be functional ones:
 - `TextInput`
 - `TextInputWithIcon`
 - `TextInputWithBadges`
 - `TextInputWithButton`
 
 As a side effect of changing the paradigm (ineritance within components), we've created a new file called `utils.ts`, where some shared logic among these components is placed.
 
## Which issue(s) does this PR relate to?
closes #800 

## Testing

A single regression test of the 4 elements mentioned above should be enough for it.

## Trade-offs

There are still some duplicated code between components, such as the following functions:
`getInputAppearance`, we might need to refactor these as well, but since these depends on a state (`hasFocus`) didn't feel in the mood to refactor them.

## Screenshots

Same as before 🙂 

## Checklist

- [x] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
