### PR TITLE
feat: add message control to infobox stories

### DIFF
--- a/packages/infobox/stories/InfoBox.stories.tsx
+++ b/packages/infobox/stories/InfoBox.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Story, Meta } from "@storybook/react";
 import { InfoBox } from "../index";
 import { PrimaryAction, SecondaryAction } from "./helpers/actions";
+import { InfoBoxProps } from "../components/InfoBox";
 
 export default {
   title: "Feedback/InfoBox",
@@ -15,20 +16,19 @@ export default {
     },
     className: {
       control: { disable: true }
+    },
+    message: {
+      control: { type: "text" },
+      defaultValue:
+        "This is message is an example of how we might inform the user."
     }
   },
   args: {
-    message: "This message is an example of how we might inform the user.",
     appearance: "default"
   }
 } as Meta;
 
-const Template: Story = args => (
-  <InfoBox
-    message="This is message is an example of how we might inform the user."
-    {...args}
-  />
-);
+const Template: Story<InfoBoxProps> = args => <InfoBox {...args} />;
 
 export const Default = Template.bind({});
 

--- a/packages/infobox/stories/InfoBoxBanner.stories.tsx
+++ b/packages/infobox/stories/InfoBoxBanner.stories.tsx
@@ -15,7 +15,8 @@ export default {
       control: { type: "select" }
     },
     message: {
-      control: { type: "text" }
+      control: { type: "text" },
+      defaultValue: "This is a message for the user."
     },
     primaryAction: {
       control: { disable: true }
@@ -34,11 +35,7 @@ export default {
 
 const Template: Story<InfoBoxProps> = args => (
   <InfoBoxStoryContainer>
-    <InfoBoxBanner
-      message="This is a message for the user."
-      onDismiss={action("dismissed")}
-      {...args}
-    />
+    <InfoBoxBanner onDismiss={action("dismissed")} {...args} />
   </InfoBoxStoryContainer>
 );
 


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

This PR adds a control for the message property to the `InfoBox` and `InfoBoxBanner` stories, and also adds a type to the template so we can remove the message prop where the `InfoBox` is used.

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

Go to `InfoBox` and `InfoBoxBanner` stories in Storybook and confirm that they message control works

## Trade-offs

I haven't added the message control to the `InfoBoxInline` stories because one of the stories uses custom markup and I'm not sure what's the best way to allow users to control this in a way that is intuitive, and I'm not sure if it's even possible. 

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
