### PR TITLE
feat: optional max-width for FullscreenView header

### DIFF
--- a/packages/fullscreenView/components/FullscreenView.tsx
+++ b/packages/fullscreenView/components/FullscreenView.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cx } from "@emotion/css";
+import { cx, css } from "@emotion/css";
 import { ButtonProps } from "../../button/components/ButtonBase";
 import { flex, padding, flexItem } from "../../shared/styles/styleUtils";
 import { modalContent, fullscreenModalHeader } from "../style";
@@ -24,56 +24,66 @@ export interface FullscreenViewProps {
   onClose: (event?: React.SyntheticEvent<HTMLElement>) => void;
   /** The base of the `data-cy` value. This is used for writing selectors in Cypress. */
   cypressSelectorBase?: string;
+  /** The css max width around the header contents  */
+  containerMaxWidth?: string;
   children?: React.ReactNode;
 }
 
-const FullscreenView = React.memo(
-  ({
-    children,
-    ctaButton,
-    closeText,
-    isContentFlush,
-    onClose,
-    title,
-    subtitle,
-    bannerComponent,
-    headerComponent,
-    cypressSelectorBase = "fullscreenView"
-  }: FullscreenViewProps) => {
-    const HeaderComponent = headerComponent ?? FullscreenViewHeader;
+const FullscreenView = ({
+  children,
+  ctaButton,
+  closeText,
+  isContentFlush,
+  onClose,
+  title,
+  subtitle,
+  bannerComponent,
+  headerComponent,
+  cypressSelectorBase = "fullscreenView",
+  containerMaxWidth
+}: FullscreenViewProps) => {
+  const HeaderComponent = headerComponent ?? FullscreenViewHeader;
 
-    return (
-      <div className={flex({ direction: "column" })}>
-        <div
-          className={cx(fullscreenModalHeader)}
-          data-cy={`${cypressSelectorBase}-header`}
-        >
-          {bannerComponent && (
-            <div data-cy={`${cypressSelectorBase}-banner`}>
-              {bannerComponent}
-            </div>
-          )}
-          <div className={cx(padding("all", "xl"))}>
-            <HeaderComponent
-              title={title}
-              subtitle={subtitle}
-              ctaButton={ctaButton}
-              closeText={closeText}
-              onClose={onClose}
-            />
-          </div>
-        </div>
-        <div
-          className={cx(modalContent, flexItem("grow"), {
-            [padding("all", "xl")]: !isContentFlush
-          })}
-          data-cy={`${cypressSelectorBase}-content`}
-        >
-          {children}
+  let container: string = "";
+  if (containerMaxWidth) {
+    // add border-box to account for any left and right padding
+    container = css`
+      margin-left: auto;
+      margin-right: auto;
+      max-width: ${containerMaxWidth};
+      box-sizing: border-box;
+    `;
+  }
+
+  return (
+    <div className={flex({ direction: "column" })}>
+      <div
+        className={cx(fullscreenModalHeader)}
+        data-cy={`${cypressSelectorBase}-header`}
+      >
+        {bannerComponent && (
+          <div data-cy={`${cypressSelectorBase}-banner`}>{bannerComponent}</div>
+        )}
+        <div className={cx(padding("all", "xl"), container)}>
+          <HeaderComponent
+            title={title}
+            subtitle={subtitle}
+            ctaButton={ctaButton}
+            closeText={closeText}
+            onClose={onClose}
+          />
         </div>
       </div>
-    );
-  }
-);
+      <div
+        className={cx(modalContent, flexItem("grow"), {
+          [padding("all", "xl")]: !isContentFlush
+        })}
+        data-cy={`${cypressSelectorBase}-content`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
 
-export default FullscreenView;
+export default React.memo(FullscreenView);

--- a/packages/fullscreenView/stories/fullscreenView.stories.tsx
+++ b/packages/fullscreenView/stories/fullscreenView.stories.tsx
@@ -8,6 +8,7 @@ import {
   tintContentSecondary,
   padding
 } from "../../shared/styles/styleUtils";
+import { containerWidthDefault } from "../../design-tokens/build/js/designTokens";
 import { cx } from "@emotion/css";
 import { fullscreenModalTitle } from "../style";
 import { SecondaryButton, PrimaryButton } from "../../button";
@@ -29,14 +30,7 @@ export default {
 
 export const Default = () => (
   <div style={{ height: "500px" }}>
-    <FullscreenView
-      closeText="Close"
-      title="Title"
-      onClose={onClose}
-      bannerComponent={
-        <InfoBoxBanner message="This is a message for the user." />
-      }
-    >
+    <FullscreenView closeText="Close" title="Title" onClose={onClose}>
       <ModalContent />
     </FullscreenView>
   </div>
@@ -73,7 +67,7 @@ export const WithAdditionalHeaderContent = () => {
         title="Title"
         closeText="Close"
         ctaButton={
-          <PrimaryButton onClick={action("handling CTA")} aria-haspopup={true}>
+          <PrimaryButton onClick={action("handling CTA")} aria-haspopup>
             Continue
           </PrimaryButton>
         }
@@ -91,9 +85,9 @@ export const WithFlushedContent = () => (
       onClose={onClose}
       title="Title"
       closeText="Close"
-      isContentFlush={true}
+      isContentFlush
       ctaButton={
-        <PrimaryButton onClick={action("handling CTA")} aria-haspopup={true}>
+        <PrimaryButton onClick={action("handling CTA")} aria-haspopup>
           Continue
         </PrimaryButton>
       }
@@ -132,6 +126,20 @@ export const WithBanner = () => (
       <BorderedModalContent horizPadding="32px" />
       <BorderedModalContent horizPadding="32px" />
       <BorderedModalContent horizPadding="32px" />
+    </FullscreenView>
+  </div>
+);
+
+export const WithContainer = () => (
+  <div style={{ height: "500px" }}>
+    <FullscreenView
+      closeText="Close"
+      title="Title"
+      onClose={onClose}
+      ctaButton={<PrimaryButton type="button">Click</PrimaryButton>}
+      containerMaxWidth={containerWidthDefault}
+    >
+      <ModalContent />
     </FullscreenView>
   </div>
 );

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -5587,7 +5587,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                             className="emotion-3"
                             data-cy="fullscreenModal"
                           >
-                            <Memo()
+                            <Memo(FullscreenView)
                               closeText="Close"
                               ctaButton={
                                 <PrimaryButton>
@@ -5703,7 +5703,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                   </div>
                                 </div>
                               </div>
-                            </Memo()>
+                            </Memo(FullscreenView)>
                           </div>
                         </ModalContents>
                       </div>


### PR DESCRIPTION
If child content of FullscreenView is wrapped in a container, it would be nice to be able to contain the header of this component also for visual consistency. Opted to keep the padding as is and just account for it in the max width so that consumers can pass in our design tokens as is without having to do the math themselves to account for the padding left and right.

Addresses D2IQ-92266

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

https://d2iq.atlassian.net/browse/D2IQ-92266

## Testing

Created a new story for this use case.

## Trade-offs

Accounting for padding from within the component. May be confusing to the user but border-box would be the alternative and I'm not sure if that would have fallout.

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
