### PR TITLE
refactor: move wrapping react.memo to export

### DIFF
--- a/packages/breadcrumb/components/Breadcrumb.tsx
+++ b/packages/breadcrumb/components/Breadcrumb.tsx
@@ -18,7 +18,7 @@ function intersperse<A>(list: A[], sep: JSX.Element) {
   return Array.prototype.concat(...list.map(e => [sep, e])).slice(1);
 }
 
-const Breadcrumb = React.memo(({ children }: BreadcrumbProps) => {
+const Breadcrumb = ({ children }: BreadcrumbProps) => {
   const breadcrumbSeparator = <Icon shape={SystemIcons.CaretRight} size="xs" />;
   const crumbsArr = intersperse(
     React.Children.toArray(children),
@@ -40,6 +40,6 @@ const Breadcrumb = React.memo(({ children }: BreadcrumbProps) => {
       ))}
     </nav>
   );
-});
+};
 
-export default Breadcrumb;
+export default React.memo(Breadcrumb);

--- a/packages/card/components/ButtonCard.tsx
+++ b/packages/card/components/ButtonCard.tsx
@@ -29,55 +29,53 @@ export interface ButtonCardProps extends CardProps {
   hasFocus?: boolean;
 }
 
-const ButtonCard = React.memo(
-  ({
-    isActive,
-    isInput,
-    disabled,
-    hasFocus,
-    onClick,
-    onKeyPress,
-    ...other
-  }: ButtonCardProps) => {
-    const tabIndex = disabled ? -1 : 0;
-    // mimic native <button> keyboard behavior without using a <button>
-    const keyPressClick = e => {
-      if (onClick && (e.key === " " || e.key === "Enter")) {
-        onClick(e);
+const ButtonCard = ({
+  isActive,
+  isInput,
+  disabled,
+  hasFocus,
+  onClick,
+  onKeyPress,
+  ...other
+}: ButtonCardProps) => {
+  const tabIndex = disabled ? -1 : 0;
+  // mimic native <button> keyboard behavior without using a <button>
+  const keyPressClick = e => {
+    if (onClick && (e.key === " " || e.key === "Enter")) {
+      onClick(e);
+    }
+  };
+  const handleKeyPress = e => {
+    keyPressClick(e);
+    if (onKeyPress) {
+      onKeyPress(e);
+    }
+  };
+  const buttonProps = !isInput
+    ? {
+        tabIndex,
+        onKeyPress: handleKeyPress,
+        onClick,
+        role: "button",
+        "aria-disabled": disabled,
+        "aria-pressed": isActive
       }
-    };
-    const handleKeyPress = e => {
-      keyPressClick(e);
-      if (onKeyPress) {
-        onKeyPress(e);
-      }
-    };
-    const buttonProps = !isInput
-      ? {
-          tabIndex,
-          onKeyPress: handleKeyPress,
-          onClick,
-          role: "button",
-          "aria-disabled": disabled,
-          "aria-pressed": isActive
-        }
-      : {};
+    : {};
 
-    return (
-      <Card
-        className={cx(buttonCard, {
-          [buttonCardActive]: isActive,
-          [buttonCardDisabled]: disabled,
-          [buttonCardDisabledActive]: disabled && isActive,
-          [buttonCardFocused]: hasFocus,
-          [buttonCardFocusedActive]: hasFocus && isActive
-        })}
-        {...buttonProps}
-        data-cy="buttonCard"
-        {...other}
-      />
-    );
-  }
-);
+  return (
+    <Card
+      className={cx(buttonCard, {
+        [buttonCardActive]: isActive,
+        [buttonCardDisabled]: disabled,
+        [buttonCardDisabledActive]: disabled && isActive,
+        [buttonCardFocused]: hasFocus,
+        [buttonCardFocusedActive]: hasFocus && isActive
+      })}
+      {...buttonProps}
+      data-cy="buttonCard"
+      {...other}
+    />
+  );
+};
 
-export default ButtonCard;
+export default React.memo(ButtonCard);

--- a/packages/card/components/Card.tsx
+++ b/packages/card/components/Card.tsx
@@ -41,38 +41,36 @@ export interface CardProps extends React.HTMLProps<HTMLDivElement> {
   className?: string;
 }
 
-const Card = React.memo(
-  ({
-    className,
-    children,
-    aspectRatio,
-    paddingSize = "m",
-    header,
-    ...other
-  }: CardProps) => {
-    const headerSize = header?.size || HeaderSizes.M;
+const Card = ({
+  className,
+  children,
+  aspectRatio,
+  paddingSize = "m",
+  header,
+  ...other
+}: CardProps) => {
+  const headerSize = header?.size || HeaderSizes.M;
 
-    const aspectRatioStyle = aspectRatio
-      ? preserveAspectRatio(aspectRatio[0], aspectRatio[1])
-      : null;
+  const aspectRatioStyle = aspectRatio
+    ? preserveAspectRatio(aspectRatio[0], aspectRatio[1])
+    : null;
 
-    return (
-      <div
-        className={cx(cardBase, aspectRatioStyle, className)}
-        data-cy="card"
-        {...other}
-      >
-        {header?.headerImg && (
-          <div className={cx(cardHeaderImage, headerHeight[headerSize])}>
-            <img src={header.headerImg} alt={header.headerImgAltText ?? ""} />
-          </div>
-        )}
-        <div className={cx(padding("all", paddingSize), cardContent)}>
-          {children}
+  return (
+    <div
+      className={cx(cardBase, aspectRatioStyle, className)}
+      data-cy="card"
+      {...other}
+    >
+      {header?.headerImg && (
+        <div className={cx(cardHeaderImage, headerHeight[headerSize])}>
+          <img src={header.headerImg} alt={header.headerImgAltText ?? ""} />
         </div>
+      )}
+      <div className={cx(padding("all", paddingSize), cardContent)}>
+        {children}
       </div>
-    );
-  }
-);
+    </div>
+  );
+};
 
-export default Card;
+export default React.memo(Card);

--- a/packages/card/components/LinkCard.tsx
+++ b/packages/card/components/LinkCard.tsx
@@ -13,35 +13,33 @@ export interface ButtonCardProps extends CardProps {
   linkDescription: string;
 }
 
-const LinkCard = React.memo(
-  ({
-    openInNewTab,
-    linkDescription,
-    url,
-    children,
-    ...other
-  }: ButtonCardProps & LinkProps) => {
-    return (
-      <Card
-        className={cx(buttonCard, cardWithLink)}
-        data-cy="linkCard"
-        {...other}
-      >
-        <>
-          <UnstyledLink
-            url={url}
-            className={cardLink}
-            openInNewTab={openInNewTab}
-          >
-            <Box tag="span" isVisuallyHidden={true}>
-              {linkDescription}
-            </Box>
-          </UnstyledLink>
-          {children}
-        </>
-      </Card>
-    );
-  }
-);
+const LinkCard = ({
+  openInNewTab,
+  linkDescription,
+  url,
+  children,
+  ...other
+}: ButtonCardProps & LinkProps) => {
+  return (
+    <Card
+      className={cx(buttonCard, cardWithLink)}
+      data-cy="linkCard"
+      {...other}
+    >
+      <>
+        <UnstyledLink
+          url={url}
+          className={cardLink}
+          openInNewTab={openInNewTab}
+        >
+          <Box tag="span" isVisuallyHidden={true}>
+            {linkDescription}
+          </Box>
+        </UnstyledLink>
+        {children}
+      </>
+    </Card>
+  );
+};
 
-export default LinkCard;
+export default React.memo(LinkCard);

--- a/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
+++ b/packages/codesnippet/tests/__snapshots__/CodeSnippet.test.tsx.snap
@@ -419,13 +419,13 @@ exports[`CodeSnippet renders with copy button 1`] = `
                           >
                             <Dropdownable
                               dropdown={
-                                <Memo
+                                <Memo(TooltipContent)
                                   id="copyTooltip1"
                                   isOpen={false}
                                   maxWidth={300}
                                 >
                                   Copied to clipboard
-                                </Memo>
+                                </Memo(TooltipContent)>
                               }
                               isOpen={false}
                               preferredDirections={

--- a/packages/configurationmap/components/HashMap.tsx
+++ b/packages/configurationmap/components/HashMap.tsx
@@ -63,57 +63,55 @@ function formatValue(value, defaultValue) {
   return value;
 }
 
-const HashMap = React.memo(
-  ({
-    hash,
-    headline,
-    headingLevel = 1,
-    renderKeys,
-    defaultValue = "-"
-  }: HashMapProps) => {
-    if (!hash || Object.keys(hash).length === 0) {
-      return null;
-    }
-
-    return (
-      <ConfigurationMapSection>
-        {headline && (
-          <ConfigurationMapHeading headingLevel={headingLevel}>
-            {headline}
-          </ConfigurationMapHeading>
-        )}
-        {Object.entries(hash).map(([key, value]) => {
-          if (value && isHashMap(value)) {
-            return (
-              <HashMap
-                hash={value as Hash}
-                headingLevel={Math.min(headingLevel + 1, 6) as HeadingLevel}
-                key={`hash-map-${key}`}
-                headline={key}
-              />
-            );
-          }
-
-          // I think this is verifying that it is an object
-          if (
-            renderKeys &&
-            Object.prototype.hasOwnProperty.call(renderKeys, key)
-          ) {
-            key = renderKeys[key];
-          }
-
-          return (
-            <ConfigurationMapRow key={`hash-map-value-${key}`}>
-              <ConfigurationMapLabel>{key}</ConfigurationMapLabel>
-              <ConfigurationMapValue>
-                {formatValue(value, defaultValue)}
-              </ConfigurationMapValue>
-            </ConfigurationMapRow>
-          );
-        })}
-      </ConfigurationMapSection>
-    );
+const HashMap = ({
+  hash,
+  headline,
+  headingLevel = 1,
+  renderKeys,
+  defaultValue = "-"
+}: HashMapProps) => {
+  if (!hash || Object.keys(hash).length === 0) {
+    return null;
   }
-);
 
-export default HashMap;
+  return (
+    <ConfigurationMapSection>
+      {headline && (
+        <ConfigurationMapHeading headingLevel={headingLevel}>
+          {headline}
+        </ConfigurationMapHeading>
+      )}
+      {Object.entries(hash).map(([key, value]) => {
+        if (value && isHashMap(value)) {
+          return (
+            <HashMap
+              hash={value as Hash}
+              headingLevel={Math.min(headingLevel + 1, 6) as HeadingLevel}
+              key={`hash-map-${key}`}
+              headline={key}
+            />
+          );
+        }
+
+        // I think this is verifying that it is an object
+        if (
+          renderKeys &&
+          Object.prototype.hasOwnProperty.call(renderKeys, key)
+        ) {
+          key = renderKeys[key];
+        }
+
+        return (
+          <ConfigurationMapRow key={`hash-map-value-${key}`}>
+            <ConfigurationMapLabel>{key}</ConfigurationMapLabel>
+            <ConfigurationMapValue>
+              {formatValue(value, defaultValue)}
+            </ConfigurationMapValue>
+          </ConfigurationMapRow>
+        );
+      })}
+    </ConfigurationMapSection>
+  );
+};
+
+export default React.memo(HashMap);

--- a/packages/donutChart/components/DonutChart.tsx
+++ b/packages/donutChart/components/DonutChart.tsx
@@ -27,7 +27,7 @@ export interface DonutChartProps {
   text?: string;
 }
 
-const DonutChart = React.memo(({ data, label, text }: DonutChartProps) => {
+const DonutChart = ({ data, label, text }: DonutChartProps) => {
   const strokeWidth = 1.5;
   const radius = 100 / (Math.PI * 2);
   const diameter = radius * 2 + strokeWidth;
@@ -88,6 +88,6 @@ const DonutChart = React.memo(({ data, label, text }: DonutChartProps) => {
       </text>
     </svg>
   );
-});
+};
 
-export default DonutChart;
+export default React.memo(DonutChart);

--- a/packages/formStructure/components/FieldList.tsx
+++ b/packages/formStructure/components/FieldList.tsx
@@ -72,85 +72,80 @@ interface FieldListRowProps
 const isRowDisabled = (rowIndex, disabledRows) =>
   disabledRows && disabledRows.includes(rowIndex);
 
-const FieldListRow = React.memo(
-  ({
-    columns,
-    data,
-    rowIndex,
-    disabledRows,
-    isLastRow,
-    pathToUniqueKey,
-    rowId
-  }: FieldListRowProps) => {
-    const fieldListContext = React.useContext(FieldListContext);
-    const addEmptyRow = (e: React.KeyboardEvent) => {
-      const rowHasData = Object.keys(data || {}).filter(
-        dataKey => Boolean(data[dataKey]) && dataKey !== pathToUniqueKey
-      ).length;
-      if (e.key === "Tab" && isLastRow && rowHasData) {
-        fieldListContext?.addListItem(rowId);
-      }
-    };
+const FieldListRow = ({
+  columns,
+  data,
+  rowIndex,
+  disabledRows,
+  isLastRow,
+  pathToUniqueKey,
+  rowId
+}: FieldListRowProps) => {
+  const fieldListContext = React.useContext(FieldListContext);
+  const addEmptyRow = (e: React.KeyboardEvent) => {
+    const rowHasData = Object.keys(data || {}).filter(
+      dataKey => Boolean(data[dataKey]) && dataKey !== pathToUniqueKey
+    ).length;
+    if (e.key === "Tab" && isLastRow && rowHasData) {
+      fieldListContext?.addListItem(rowId);
+    }
+  };
 
-    const handleRowClick = () => {
-      fieldListContext?.removeListItem(rowIndex);
-    };
+  const handleRowClick = () => {
+    fieldListContext?.removeListItem(rowIndex);
+  };
 
-    return (
-      <div className={getFieldRowGrid(columns, iconSizes[REMOVE_ICON_SIZE])}>
-        {columns.map((col, i) => {
-          return (
-            <div data-cy="fieldList-cell" key={i} className={fieldWrapper}>
-              {col.type === FieldListColumn &&
-                col.props.children({
-                  ...(col.props.onChange && col.props.pathToValue
-                    ? {
-                        onChange: col.props.onChange(
-                          rowIndex,
-                          col.props.pathToValue
-                        )
-                      }
-                    : {}),
-                  fieldData: data,
-                  rowIndex,
-                  value: findNestedPropertyInObject(
-                    data,
-                    col.props.pathToValue
-                  ),
-                  disabled: isRowDisabled(rowIndex, disabledRows),
-                  defaultProps: {
-                    key: `${col.props.pathToValue}-${rowIndex}`,
-                    id: `${col.props.pathToValue}-${rowIndex}`,
-                    inputLabel: `${col.props.header} ${rowIndex}`
-                  }
-                })}
-              {col.type === FieldListColumnSeparator && col.props.children}
-            </div>
-          );
-        })}
-        {/* this wrapper div is needed to fix a vertical centering bug in Firefox with <button> elements that are children of display: grid */}
-        <div>
-          <ResetButton
-            onClick={handleRowClick}
-            disabled={isRowDisabled(rowIndex, disabledRows)}
-            onKeyUp={addEmptyRow}
-            data-cy="fieldList-removeButton"
-          >
-            <Icon
-              shape={SystemIcons.Close}
-              size={REMOVE_ICON_SIZE}
-              color={
-                isRowDisabled(rowIndex, disabledRows)
-                  ? themeTextColorDisabled
-                  : themeTextColorPrimary
-              }
-            />
-          </ResetButton>
-        </div>
+  return (
+    <div className={getFieldRowGrid(columns, iconSizes[REMOVE_ICON_SIZE])}>
+      {columns.map((col, i) => {
+        return (
+          <div data-cy="fieldList-cell" key={i} className={fieldWrapper}>
+            {col.type === FieldListColumn &&
+              col.props.children({
+                ...(col.props.onChange && col.props.pathToValue
+                  ? {
+                      onChange: col.props.onChange(
+                        rowIndex,
+                        col.props.pathToValue
+                      )
+                    }
+                  : {}),
+                fieldData: data,
+                rowIndex,
+                value: findNestedPropertyInObject(data, col.props.pathToValue),
+                disabled: isRowDisabled(rowIndex, disabledRows),
+                defaultProps: {
+                  key: `${col.props.pathToValue}-${rowIndex}`,
+                  id: `${col.props.pathToValue}-${rowIndex}`,
+                  inputLabel: `${col.props.header} ${rowIndex}`
+                }
+              })}
+            {col.type === FieldListColumnSeparator && col.props.children}
+          </div>
+        );
+      })}
+      {/* this wrapper div is needed to fix a vertical centering bug in Firefox with <button> elements that are children of display: grid */}
+      <div>
+        <ResetButton
+          onClick={handleRowClick}
+          disabled={isRowDisabled(rowIndex, disabledRows)}
+          onKeyUp={addEmptyRow}
+          data-cy="fieldList-removeButton"
+        >
+          <Icon
+            shape={SystemIcons.Close}
+            size={REMOVE_ICON_SIZE}
+            color={
+              isRowDisabled(rowIndex, disabledRows)
+                ? themeTextColorDisabled
+                : themeTextColorPrimary
+            }
+          />
+        </ResetButton>
       </div>
-    );
-  }
-);
+    </div>
+  );
+};
 
 const FieldListHeader = ({ columns }: FieldListHeaderProps) => (
   <SpacingBox
@@ -258,4 +253,4 @@ const FieldList = ({
   );
 };
 
-export default FieldList;
+export default React.memo(FieldList);

--- a/packages/formStructure/stories/helpers/FieldListStoryHelper.tsx
+++ b/packages/formStructure/stories/helpers/FieldListStoryHelper.tsx
@@ -14,7 +14,7 @@ interface FieldListHelperProps {
 const updateIndex = (ts, i, obj) =>
   ts.map((t, j) => (i === j ? { ...t, ...obj } : t));
 
-const FieldListHelper = React.memo((props: FieldListHelperProps) => {
+const FieldListHelper = (props: FieldListHelperProps) => {
   const [items, setItems] = React.useState<any[]>(props.items);
 
   const handleFieldUpdate = (rowIndex, valueKey) => {
@@ -43,6 +43,6 @@ const FieldListHelper = React.memo((props: FieldListHelperProps) => {
     onRemoveItem: handleRemoveItem,
     onAddItem: handleAddItem
   });
-});
+};
 
-export default FieldListHelper;
+export default React.memo(FieldListHelper);

--- a/packages/modal/components/FullscreenModal.tsx
+++ b/packages/modal/components/FullscreenModal.tsx
@@ -19,41 +19,39 @@ interface FullscreenModalProps extends ModalBaseProps {
   headerComponent?: React.JSXElementConstructor<any>;
 }
 
-const FullscreenModal = React.memo(
-  ({
-    children,
-    ctaButton,
-    closeText,
-    isContentFlush,
-    onClose,
-    title,
-    subtitle,
-    headerComponent,
-    ...other
-  }: FullscreenModalProps) => {
-    return (
-      <ModalBase
-        size={ModalSizes.Fullscreen}
+const FullscreenModal = ({
+  children,
+  ctaButton,
+  closeText,
+  isContentFlush,
+  onClose,
+  title,
+  subtitle,
+  headerComponent,
+  ...other
+}: FullscreenModalProps) => {
+  return (
+    <ModalBase
+      size={ModalSizes.Fullscreen}
+      onClose={onClose}
+      isAnimated={false}
+      data-cy="fullscreenModal"
+      {...other}
+    >
+      <FullscreenView
+        ctaButton={ctaButton}
+        closeText={closeText}
+        isContentFlush={isContentFlush}
         onClose={onClose}
-        isAnimated={false}
-        data-cy="fullscreenModal"
-        {...other}
+        title={title}
+        subtitle={subtitle}
+        headerComponent={headerComponent}
+        cypressSelectorBase="fullscreenModal"
       >
-        <FullscreenView
-          ctaButton={ctaButton}
-          closeText={closeText}
-          isContentFlush={isContentFlush}
-          onClose={onClose}
-          title={title}
-          subtitle={subtitle}
-          headerComponent={headerComponent}
-          cypressSelectorBase="fullscreenModal"
-        >
-          {children}
-        </FullscreenView>
-      </ModalBase>
-    );
-  }
-);
+        {children}
+      </FullscreenView>
+    </ModalBase>
+  );
+};
 
-export default FullscreenModal;
+export default React.memo(FullscreenModal);

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -3104,7 +3104,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   padding: 32px;
 }
 
-<Memo()
+<Memo(FullscreenModal)
   closeText="Close"
   ctaButton={
     <PrimaryButton>
@@ -5732,7 +5732,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
       </ForwardRef>
     </Transition>
   </ModalBase>
-</Memo()>
+</Memo(FullscreenModal)>
 `;
 
 exports[`Modal ModalBase renders ModalBase 1`] = `

--- a/packages/pageheader/components/PageHeader.tsx
+++ b/packages/pageheader/components/PageHeader.tsx
@@ -21,45 +21,47 @@ export interface PageHeaderProps {
 
 export const pageHeaderPaddingSize: SpaceSizes = "l";
 
-const PageHeader = React.memo(
-  ({ breadcrumbElements, actions = [], children }: PageHeaderProps) => {
-    const hasTabsChild = React.Children.toArray(children).some(
-      child => React.isValidElement(child) && child.type === PageHeaderTabs
-    );
+const PageHeader = ({
+  breadcrumbElements,
+  actions = [],
+  children
+}: PageHeaderProps) => {
+  const hasTabsChild = React.Children.toArray(children).some(
+    child => React.isValidElement(child) && child.type === PageHeaderTabs
+  );
 
-    return (
-      <div
-        className={cx(padding("all", pageHeaderPaddingSize), {
-          [border("bottom")]: !hasTabsChild,
-          [fillHeight]: hasTabsChild
-        })}
-      >
-        <div className={cx(flex({ align: "center" }))} data-cy="pageHeader">
-          <div className={flexItem("grow")}>
-            <Breadcrumb>{breadcrumbElements}</Breadcrumb>
-          </div>
-          <div className={flexItem("shrink")}>
-            <ul
-              className={cx(listReset, flex({ align: "center" }))}
-              data-cy="pageHeader-actions"
-            >
-              {actions.map((action, i) => {
-                return (
-                  <li
-                    key={action.key ? `${action.key}` : `action-${i}`}
-                    className={cx(padding("left", "s"), display("inherit"))}
-                  >
-                    {action}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
+  return (
+    <div
+      className={cx(padding("all", pageHeaderPaddingSize), {
+        [border("bottom")]: !hasTabsChild,
+        [fillHeight]: hasTabsChild
+      })}
+    >
+      <div className={cx(flex({ align: "center" }))} data-cy="pageHeader">
+        <div className={flexItem("grow")}>
+          <Breadcrumb>{breadcrumbElements}</Breadcrumb>
         </div>
-        {children}
+        <div className={flexItem("shrink")}>
+          <ul
+            className={cx(listReset, flex({ align: "center" }))}
+            data-cy="pageHeader-actions"
+          >
+            {actions.map((action, i) => {
+              return (
+                <li
+                  key={action.key ? `${action.key}` : `action-${i}`}
+                  className={cx(padding("left", "s"), display("inherit"))}
+                >
+                  {action}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       </div>
-    );
-  }
-);
+      {children}
+    </div>
+  );
+};
 
-export default PageHeader;
+export default React.memo(PageHeader);

--- a/packages/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/packages/pagination/__snapshots__/pagination.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`Pagination rendering renders w/ page length menu 1`] = `
     <FlexItem
       flex="shrink"
     >
-      <Memo()
+      <Memo(SelectInput)
         id="pageLengthMenu6"
         inputLabel="Items per page"
         onChange={[Function]}

--- a/packages/segmentedControl/components/SegmentedControlButton.tsx
+++ b/packages/segmentedControl/components/SegmentedControlButton.tsx
@@ -39,50 +39,48 @@ export interface SegmentedControlButtonProps {
   children?: React.ReactNode;
 }
 
-const SegmentedControlButton = React.memo(
-  ({
-    id = nextId("segmentedControlButton-"),
-    isActive,
-    onChange,
-    name,
-    value,
-    tooltipContent,
-    children
-  }: SegmentedControlButtonProps) => {
-    return (
-      <FocusStyleManager focusEnabledClass={staticKeyboardFocusClassname}>
-        <label
-          className={cx(segmentedControlButton, {
-            [segmentedControlButtonActive]: isActive
-          })}
-          data-cy="segmentedControlButton"
-          htmlFor={id}
-        >
-          <input
-            className={visuallyHidden}
-            id={id}
-            type="radio"
-            name={name}
-            value={value}
-            checked={isActive}
-            onChange={onChange}
-          />
-          {tooltipContent ? (
-            <Tooltip
-              id={`${id}-tooltip`}
-              trigger={
-                <div className={segmentedControlButtonInner}>{children}</div>
-              }
-            >
-              {tooltipContent}
-            </Tooltip>
-          ) : (
-            <div className={segmentedControlButtonInner}>{children}</div>
-          )}
-        </label>
-      </FocusStyleManager>
-    );
-  }
-);
+const SegmentedControlButton = ({
+  id = nextId("segmentedControlButton-"),
+  isActive,
+  onChange,
+  name,
+  value,
+  tooltipContent,
+  children
+}: SegmentedControlButtonProps) => {
+  return (
+    <FocusStyleManager focusEnabledClass={staticKeyboardFocusClassname}>
+      <label
+        className={cx(segmentedControlButton, {
+          [segmentedControlButtonActive]: isActive
+        })}
+        data-cy="segmentedControlButton"
+        htmlFor={id}
+      >
+        <input
+          className={visuallyHidden}
+          id={id}
+          type="radio"
+          name={name}
+          value={value}
+          checked={isActive}
+          onChange={onChange}
+        />
+        {tooltipContent ? (
+          <Tooltip
+            id={`${id}-tooltip`}
+            trigger={
+              <div className={segmentedControlButtonInner}>{children}</div>
+            }
+          >
+            {tooltipContent}
+          </Tooltip>
+        ) : (
+          <div className={segmentedControlButtonInner}>{children}</div>
+        )}
+      </label>
+    </FocusStyleManager>
+  );
+};
 
-export default SegmentedControlButton;
+export default React.memo(SegmentedControlButton);

--- a/packages/segmentedControl/stories/helpers/SegmentedControlStoryHelper.tsx
+++ b/packages/segmentedControl/stories/helpers/SegmentedControlStoryHelper.tsx
@@ -9,21 +9,21 @@ interface SegmentedControlStoryHelperProps {
   selectedSegment?: string;
 }
 
-const SegmentedControlStoryHelper = React.memo(
-  (props: SegmentedControlStoryHelperProps) => {
-    const [selectedSegment, setSelectedSegment] = React.useState<string>(
-      props.selectedSegment || ""
-    );
+const SegmentedControlStoryHelper = (
+  props: SegmentedControlStoryHelperProps
+) => {
+  const [selectedSegment, setSelectedSegment] = React.useState<string>(
+    props.selectedSegment || ""
+  );
 
-    const handleChange = value => {
-      setSelectedSegment(value);
-    };
+  const handleChange = value => {
+    setSelectedSegment(value);
+  };
 
-    return props.children({
-      changeHandler: handleChange,
-      selectedSegment
-    });
-  }
-);
+  return props.children({
+    changeHandler: handleChange,
+    selectedSegment
+  });
+};
 
-export default SegmentedControlStoryHelper;
+export default React.memo(SegmentedControlStoryHelper);

--- a/packages/segmentedControl/tests/__snapshots__/SegmentedControl.test.tsx.snap
+++ b/packages/segmentedControl/tests/__snapshots__/SegmentedControl.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SegmentedControl renders default 1`] = `
   className="emotion-0"
   data-cy="segmentedControl"
 >
-  <Memo()
+  <Memo(SegmentedControlButton)
     isActive={false}
     key="0"
     name="controlId"
@@ -22,8 +22,8 @@ exports[`SegmentedControl renders default 1`] = `
     value="one"
   >
     One
-  </Memo()>
-  <Memo()
+  </Memo(SegmentedControlButton)>
+  <Memo(SegmentedControlButton)
     isActive={false}
     key="1"
     name="controlId"
@@ -31,8 +31,8 @@ exports[`SegmentedControl renders default 1`] = `
     value="two"
   >
     Two
-  </Memo()>
-  <Memo()
+  </Memo(SegmentedControlButton)>
+  <Memo(SegmentedControlButton)
     isActive={false}
     key="2"
     name="controlId"
@@ -40,7 +40,7 @@ exports[`SegmentedControl renders default 1`] = `
     value="three"
   >
     Three
-  </Memo()>
+  </Memo(SegmentedControlButton)>
 </div>
 `;
 
@@ -58,7 +58,7 @@ exports[`SegmentedControl renders with selected 1`] = `
   className="emotion-0"
   data-cy="segmentedControl"
 >
-  <Memo()
+  <Memo(SegmentedControlButton)
     isActive={true}
     key="0"
     name="controlId"
@@ -66,8 +66,8 @@ exports[`SegmentedControl renders with selected 1`] = `
     value="one"
   >
     One
-  </Memo()>
-  <Memo()
+  </Memo(SegmentedControlButton)>
+  <Memo(SegmentedControlButton)
     isActive={false}
     key="1"
     name="controlId"
@@ -75,8 +75,8 @@ exports[`SegmentedControl renders with selected 1`] = `
     value="two"
   >
     Two
-  </Memo()>
-  <Memo()
+  </Memo(SegmentedControlButton)>
+  <Memo(SegmentedControlButton)
     isActive={false}
     key="2"
     name="controlId"
@@ -84,6 +84,6 @@ exports[`SegmentedControl renders with selected 1`] = `
     value="three"
   >
     Three
-  </Memo()>
+  </Memo(SegmentedControlButton)>
 </div>
 `;

--- a/packages/selectInput/components/SelectInput.tsx
+++ b/packages/selectInput/components/SelectInput.tsx
@@ -76,124 +76,122 @@ function getInputAppearance(disabled, hasFocus, appearance) {
   return appearance;
 }
 
-const SelectInput = React.memo(
-  ({
-    appearance = InputAppearance.Standard,
-    errors,
-    iconStart,
-    id = nextId("selectInput-"),
-    options,
-    showInputLabel = true,
-    inputLabel = "",
-    tooltipContent,
-    hintContent,
-    disabled,
-    required,
-    onFocus,
-    onBlur,
-    ...other
-  }: SelectInputProps) => {
-    const [hasFocus, setHasFocus] = React.useState<boolean>(false);
-    const hasError = appearance === InputAppearance.Error;
-    const parentDataCy = `selectInput selectInput.${appearance}`;
-    const selectDataCy = `selectInput-select selectInput-select.${appearance}`;
+const SelectInput = ({
+  appearance = InputAppearance.Standard,
+  errors,
+  iconStart,
+  id = nextId("selectInput-"),
+  options,
+  showInputLabel = true,
+  inputLabel = "",
+  tooltipContent,
+  hintContent,
+  disabled,
+  required,
+  onFocus,
+  onBlur,
+  ...other
+}: SelectInputProps) => {
+  const [hasFocus, setHasFocus] = React.useState<boolean>(false);
+  const hasError = appearance === InputAppearance.Error;
+  const parentDataCy = `selectInput selectInput.${appearance}`;
+  const selectDataCy = `selectInput-select selectInput-select.${appearance}`;
 
-    const handleFocus = e => {
-      setHasFocus(true);
+  const handleFocus = e => {
+    setHasFocus(true);
 
-      if (onFocus) {
-        onFocus(e);
-      }
-    };
+    if (onFocus) {
+      onFocus(e);
+    }
+  };
 
-    const handleBlur = e => {
-      setHasFocus(false);
+  const handleBlur = e => {
+    setHasFocus(false);
 
-      if (onBlur) {
-        onBlur(e);
-      }
-    };
+    if (onBlur) {
+      onBlur(e);
+    }
+  };
 
-    const inputAppearance = getInputAppearance(disabled, hasFocus, appearance);
+  const inputAppearance = getInputAppearance(disabled, hasFocus, appearance);
 
-    return (
-      <FormFieldWrapper id={id} errors={errors} hintContent={hintContent}>
-        {({ getValidationErrors, isValid, getHintContent, describedByIds }) => (
-          <div data-cy={parentDataCy}>
-            {renderLabel({
-              appearance,
-              hidden: !showInputLabel,
-              id,
-              label: inputLabel,
-              required,
-              tooltipContent
-            })}
+  return (
+    <FormFieldWrapper id={id} errors={errors} hintContent={hintContent}>
+      {({ getValidationErrors, isValid, getHintContent, describedByIds }) => (
+        <div data-cy={parentDataCy}>
+          {renderLabel({
+            appearance,
+            hidden: !showInputLabel,
+            id,
+            label: inputLabel,
+            required,
+            tooltipContent
+          })}
 
-            <span
-              className={cx(
-                selectContainer,
-                inputContainer,
-                getInputAppearanceStyle(inputAppearance),
-                display("flex")
-              )}
-            >
-              {iconStart ? (
-                <span className={cx(optionalIcon)}>
-                  <IconPropAdapter
-                    icon={iconStart}
-                    size={DROPDOWN_ARROW_ICON_SIZE}
-                    color="inherit"
-                  />
-                </span>
-              ) : null}
-              <select
-                className={cx(inputReset, select, display("block"))}
-                aria-invalid={!isValid}
-                aria-describedby={describedByIds}
-                id={id}
-                onFocus={handleFocus}
-                onBlur={handleBlur}
-                data-cy={selectDataCy}
-                {...other}
-              >
-                {options.map((option, key) => (
-                  /* eslint-disable jsx-a11y/role-has-required-aria-props */
-                  /* <option> tag doesn't need additional aria markup */
-                  <option
-                    key={key}
-                    value={option.value}
-                    disabled={option.disabled}
-                  >
-                    {option.label}
-                  </option>
-                  /* eslint-enable jsx-a11y/role-has-required-aria-props */
-                ))}
-              </select>
-              <span
-                className={cx(
-                  selectIcon,
-                  padding("horiz", "m"),
-                  getIconAppearanceStyle(inputAppearance)
-                )}
-              >
-                <Icon
-                  shape={SystemIcons.TriangleDown}
+          <span
+            className={cx(
+              selectContainer,
+              inputContainer,
+              getInputAppearanceStyle(inputAppearance),
+              display("flex")
+            )}
+          >
+            {iconStart ? (
+              <span className={cx(optionalIcon)}>
+                <IconPropAdapter
+                  icon={iconStart}
                   size={DROPDOWN_ARROW_ICON_SIZE}
                   color="inherit"
                 />
               </span>
-            </span>
-            {Boolean(getHintContent) || hasError ? (
-              <div data-cy="selectInput-hintContent">
-                {getHintContent}
-                {hasError && getValidationErrors}
-              </div>
             ) : null}
-          </div>
-        )}
-      </FormFieldWrapper>
-    );
-  }
-);
+            <select
+              className={cx(inputReset, select, display("block"))}
+              aria-invalid={!isValid}
+              aria-describedby={describedByIds}
+              id={id}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              data-cy={selectDataCy}
+              {...other}
+            >
+              {options.map((option, key) => (
+                /* eslint-disable jsx-a11y/role-has-required-aria-props */
+                /* <option> tag doesn't need additional aria markup */
+                <option
+                  key={key}
+                  value={option.value}
+                  disabled={option.disabled}
+                >
+                  {option.label}
+                </option>
+                /* eslint-enable jsx-a11y/role-has-required-aria-props */
+              ))}
+            </select>
+            <span
+              className={cx(
+                selectIcon,
+                padding("horiz", "m"),
+                getIconAppearanceStyle(inputAppearance)
+              )}
+            >
+              <Icon
+                shape={SystemIcons.TriangleDown}
+                size={DROPDOWN_ARROW_ICON_SIZE}
+                color="inherit"
+              />
+            </span>
+          </span>
+          {Boolean(getHintContent) || hasError ? (
+            <div data-cy="selectInput-hintContent">
+              {getHintContent}
+              {hasError && getValidationErrors}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </FormFieldWrapper>
+  );
+};
 
-export default SelectInput;
+export default React.memo(SelectInput);

--- a/packages/selectInput/tests/__snapshots__/SelectInput.test.tsx.snap
+++ b/packages/selectInput/tests/__snapshots__/SelectInput.test.tsx.snap
@@ -181,7 +181,7 @@ exports[`SelectInput should render all appearances focus 1`] = `
   pointer-events: none;
 }
 
-<Memo()
+<Memo(SelectInput)
   appearance="standard"
   id="layers"
   inputLabel="Atmosphere layer"
@@ -305,7 +305,7 @@ exports[`SelectInput should render all appearances focus 1`] = `
       </span>
     </div>
   </Memo(FormFieldWrapper)>
-</Memo()>
+</Memo(SelectInput)>
 `;
 
 exports[`SelectInput should render all appearances focus 2`] = `
@@ -437,7 +437,7 @@ exports[`SelectInput should render all appearances focus 2`] = `
   pointer-events: none;
 }
 
-<Memo()
+<Memo(SelectInput)
   appearance="error"
   id="layers"
   inputLabel="Atmosphere layer"
@@ -564,7 +564,7 @@ exports[`SelectInput should render all appearances focus 2`] = `
       />
     </div>
   </Memo(FormFieldWrapper)>
-</Memo()>
+</Memo(SelectInput)>
 `;
 
 exports[`SelectInput should render all appearances focus 3`] = `
@@ -694,7 +694,7 @@ exports[`SelectInput should render all appearances focus 3`] = `
   pointer-events: none;
 }
 
-<Memo()
+<Memo(SelectInput)
   appearance="success"
   id="layers"
   inputLabel="Atmosphere layer"
@@ -818,5 +818,5 @@ exports[`SelectInput should render all appearances focus 3`] = `
       </span>
     </div>
   </Memo(FormFieldWrapper)>
-</Memo()>
+</Memo(SelectInput)>
 `;

--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -484,13 +484,13 @@ exports[`Table v2 rendering renders default 1`] = `
                         >
                           <Dropdownable
                             dropdown={
-                              <Memo
+                              <Memo(TooltipContent)
                                 id="colTooltip1-tooltip"
                                 isOpen={false}
                                 maxWidth={300}
                               >
                                 test
-                              </Memo>
+                              </Memo(TooltipContent)>
                             }
                             isOpen={false}
                             preferredDirections={
@@ -3769,13 +3769,13 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
                         >
                           <Dropdownable
                             dropdown={
-                              <Memo
+                              <Memo(TooltipContent)
                                 id="colTooltip2-tooltip"
                                 isOpen={false}
                                 maxWidth={300}
                               >
                                 test
-                              </Memo>
+                              </Memo(TooltipContent)>
                             }
                             isOpen={false}
                             preferredDirections={

--- a/packages/textInput/stories/helpers/TextInputWithBadgesStoryHelper.tsx
+++ b/packages/textInput/stories/helpers/TextInputWithBadgesStoryHelper.tsx
@@ -11,20 +11,19 @@ interface TextInputWithBadgesStoryHelperProps {
   children: (renderProps: RenderProps) => React.ReactElement;
 }
 
-const TextInputWithBadgesStoryHelper = React.memo(
-  (props: TextInputWithBadgesStoryHelperProps) => {
-    const [badges, setBadges] = React.useState<BadgeDatum[]>(
-      props.badges || []
-    );
+const TextInputWithBadgesStoryHelper = (
+  props: TextInputWithBadgesStoryHelperProps
+) => {
+  const [badges, setBadges] = React.useState<BadgeDatum[]>(props.badges || []);
 
-    const handleBadgeChange = badgesNext => {
-      setBadges(badgesNext);
-    };
+  const handleBadgeChange = badgesNext => {
+    setBadges(badgesNext);
+  };
 
-    return props.children({
-      badges,
-      badgeChangeHandler: handleBadgeChange
-    });
-  }
-);
-export default TextInputWithBadgesStoryHelper;
+  return props.children({
+    badges,
+    badgeChangeHandler: handleBadgeChange
+  });
+};
+
+export default React.memo(TextInputWithBadgesStoryHelper);

--- a/packages/tooltip/components/TooltipContent.tsx
+++ b/packages/tooltip/components/TooltipContent.tsx
@@ -11,40 +11,38 @@ export interface TooltipContentProps extends BaseTooltipProps {
   isOpen: boolean;
 }
 
-const TooltipContent = React.memo(
-  ({
-    direction = Direction.TopCenter,
-    children,
-    id,
-    maxWidth,
-    minWidth,
-    isOpen
-  }: TooltipContentProps) => {
-    return (
-      <>
-        <div
-          aria-hidden={!isOpen}
-          id={id}
-          className={cx(
-            tooltip,
-            alignContainerWithCaretStyles(direction),
-            inverseColorMode,
-            padding("horiz", "s"),
-            padding("vert", "xs")
-          )}
-          role="tooltip"
-          style={{
-            minWidth,
-            maxWidth: maxWidth || undefined
-          }}
-          data-cy="tooltipContent"
-        >
-          {children}
-        </div>
-        <div className={getTooltipArrow(direction)} />
-      </>
-    );
-  }
-);
+const TooltipContent = ({
+  direction = Direction.TopCenter,
+  children,
+  id,
+  maxWidth,
+  minWidth,
+  isOpen
+}: TooltipContentProps) => {
+  return (
+    <>
+      <div
+        aria-hidden={!isOpen}
+        id={id}
+        className={cx(
+          tooltip,
+          alignContainerWithCaretStyles(direction),
+          inverseColorMode,
+          padding("horiz", "s"),
+          padding("vert", "xs")
+        )}
+        role="tooltip"
+        style={{
+          minWidth,
+          maxWidth: maxWidth || undefined
+        }}
+        data-cy="tooltipContent"
+      >
+        {children}
+      </div>
+      <div className={getTooltipArrow(direction)} />
+    </>
+  );
+};
 
-export default TooltipContent;
+export default React.memo(TooltipContent);

--- a/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/tooltip/tests/__snapshots__/Tooltip.test.tsx.snap
@@ -14,13 +14,13 @@ exports[`Tooltip renders 1`] = `
   >
     <Dropdownable
       dropdown={
-        <Memo
+        <Memo(TooltipContent)
           id="renders"
           isOpen={false}
           maxWidth={300}
         >
           content
-        </Memo>
+        </Memo(TooltipContent)>
       }
       isOpen={false}
       preferredDirections={
@@ -94,13 +94,13 @@ exports[`Tooltip renders open tooltip 1`] = `
   >
     <Dropdownable
       dropdown={
-        <Memo
+        <Memo(TooltipContent)
           id="opened"
           isOpen={true}
           maxWidth={300}
         >
           content
-        </Memo>
+        </Memo(TooltipContent)>
       }
       isOpen={true}
       preferredDirections={
@@ -272,7 +272,7 @@ exports[`Tooltip renders open tooltip 1`] = `
                     }
                   }
                 >
-                  <Memo()
+                  <Memo(TooltipContent)
                     id="opened"
                     isOpen={true}
                     maxWidth={300}
@@ -295,7 +295,7 @@ exports[`Tooltip renders open tooltip 1`] = `
                     <div
                       className="emotion-1"
                     />
-                  </Memo()>
+                  </Memo(TooltipContent)>
                 </div>
               </Portal>
             </Overlay>
@@ -364,13 +364,13 @@ exports[`Tooltip renders with preferred directions 1`] = `
   >
     <Dropdownable
       dropdown={
-        <Memo
+        <Memo(TooltipContent)
           id="customDir"
           isOpen={true}
           maxWidth={300}
         >
           content
-        </Memo>
+        </Memo(TooltipContent)>
       }
       isOpen={true}
       preferredDirections={
@@ -559,7 +559,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
                     }
                   }
                 >
-                  <Memo()
+                  <Memo(TooltipContent)
                     id="customDir"
                     isOpen={true}
                     maxWidth={300}
@@ -582,7 +582,7 @@ exports[`Tooltip renders with preferred directions 1`] = `
                     <div
                       className="emotion-1"
                     />
-                  </Memo()>
+                  </Memo(TooltipContent)>
                 </div>
               </Portal>
             </Overlay>

--- a/packages/typeahead/components/Typeahead.tsx
+++ b/packages/typeahead/components/Typeahead.tsx
@@ -70,214 +70,212 @@ const getSelectedItems = (value, checked, selectedItems) => {
   return selectedItems.filter(selectedItem => selectedItem !== value);
 };
 
-const Typeahead = React.memo(
-  ({
-    disablePortal,
-    items,
-    menuEmptyState,
-    menuMaxHeight = 300,
-    overlayRoot,
-    textField,
-    selectedItems,
-    multiSelect,
-    keepOpenOnSelect,
-    resetInputOnSelect,
-    onSelect
-  }: TypeaheadProps) => {
-    const { value, ...textFieldProps } = textField.props;
-    delete textFieldProps.onFocus;
-    delete textFieldProps.onClick;
+const Typeahead = ({
+  disablePortal,
+  items,
+  menuEmptyState,
+  menuMaxHeight = 300,
+  overlayRoot,
+  textField,
+  selectedItems,
+  multiSelect,
+  keepOpenOnSelect,
+  resetInputOnSelect,
+  onSelect
+}: TypeaheadProps) => {
+  const { value, ...textFieldProps } = textField.props;
+  delete textFieldProps.onFocus;
+  delete textFieldProps.onClick;
 
-    const [menuWidth, setMenuWidth] = React.useState<number | null>(null);
+  const [menuWidth, setMenuWidth] = React.useState<number | null>(null);
 
-    const containerRef = React.createRef<HTMLDivElement>();
+  const containerRef = React.createRef<HTMLDivElement>();
 
-    const setContainerWidth = () => {
-      const container = containerRef.current;
+  const setContainerWidth = () => {
+    const container = containerRef.current;
 
-      if (container && container.getBoundingClientRect().width) {
-        setMenuWidth(container.getBoundingClientRect().width);
-      }
+    if (container && container.getBoundingClientRect().width) {
+      setMenuWidth(container.getBoundingClientRect().width);
+    }
+  };
+
+  React.useEffect(() => {
+    resizeEventManager.add(setContainerWidth);
+
+    return () => {
+      resizeEventManager.remove(setContainerWidth);
     };
+  }, []);
 
-    React.useEffect(() => {
-      resizeEventManager.add(setContainerWidth);
+  function handleSelection(selectedItem) {
+    const isItemSelected =
+      selectedItems && selectedItems.includes(selectedItem.value);
 
-      return () => {
-        resizeEventManager.remove(setContainerWidth);
-      };
-    }, []);
-
-    function handleSelection(selectedItem) {
-      const isItemSelected =
-        selectedItems && selectedItems.includes(selectedItem.value);
-
-      if (onSelect) {
-        onSelect(
-          getSelectedItems(
-            selectedItem.value,
-            !isItemSelected,
-            selectedItems ?? []
-          ),
-          selectedItem.value
-        );
-      }
+    if (onSelect) {
+      onSelect(
+        getSelectedItems(
+          selectedItem.value,
+          !isItemSelected,
+          selectedItems ?? []
+        ),
+        selectedItem.value
+      );
     }
-
-    function stateReducer(state, changes) {
-      switch (changes.type) {
-        case Downshift.stateChangeTypes.keyDownEnter:
-        case Downshift.stateChangeTypes.clickItem:
-          handleSelection(changes.selectedItem);
-
-          return {
-            ...changes,
-            selectedItem: [changes.selectedItem.value],
-            isOpen: multiSelect && !(keepOpenOnSelect === false),
-            inputValue:
-              multiSelect || resetInputOnSelect ? "" : changes.inputValue
-          };
-
-        case Downshift.stateChangeTypes.changeInput:
-          return {
-            ...changes,
-            // Manually setting `isOpen` to make sure the menu closes after the user has made a selection
-            //
-            // By default, Downshift changes it's internal `isOpen` state to `false` when an input changes,
-            // but there are cases where we need the <input> to dispatch an `onChange` event on item selection
-            // so that `onChange` bubbles up to the parent <form> element's `onChange` event
-            isOpen:
-              multiSelect ||
-              ((state.inputValue || changes.inputValue) &&
-                changes.inputValue !== state.inputValue),
-            selectedItem:
-              changes.inputValue === state.inputValue ? state.selectedItem : ""
-          };
-
-        case Downshift.stateChangeTypes.blurInput:
-        case Downshift.stateChangeTypes.mouseUp:
-          return {
-            ...changes,
-            inputValue: state.inputValue
-          };
-
-        default:
-          return changes;
-      }
-    }
-
-    function handleInputActivation(
-      stateAndHelpers: {
-        openMenu: (cb?: () => void) => void;
-        isOpen: boolean;
-      },
-      e
-    ) {
-      const { openMenu, isOpen } = stateAndHelpers;
-
-      if (textField.props.onFocus && e.nativeEvent.type === "focus") {
-        textField.props.onFocus(e);
-      } else if (textField.props.onClick && e.nativeEvent.type === "click") {
-        textField.props.onClick(e);
-      }
-
-      if (!isOpen) {
-        setContainerWidth();
-        openMenu();
-      }
-    }
-
-    return (
-      <div ref={containerRef} data-cy="typeahead">
-        <Downshift
-          itemToString={defaultItemToString}
-          selectedItem={selectedItems}
-          stateReducer={stateReducer}
-        >
-          {({
-            getInputProps,
-            getItemProps,
-            getMenuProps,
-            isOpen,
-            highlightedIndex,
-            openMenu,
-            selectedItem,
-            inputValue,
-            ...other
-          }) => {
-            return (
-              <div>
-                <Dropdownable
-                  isOpen={isOpen}
-                  overlayRoot={overlayRoot}
-                  dropdown={
-                    <div data-cy="typeahead-dropdown">
-                      {!items.length && !menuEmptyState ? null : (
-                        <div className={margin("top", "xxs")}>
-                          <PopoverBox
-                            width={menuWidth}
-                            maxHeight={menuMaxHeight}
-                            {...getMenuProps(
-                              { refKey: "menuRef" },
-                              // The menu is not mounted when `isOpen` is false, so Downshift's ref check fails incorrectly
-                              // The menu behaves as expected, and has all the correct attributes
-                              { suppressRefError: true }
-                            )}
-                          >
-                            {items.length ? (
-                              items.map((item: Item, index: number) => (
-                                <PopoverListItem
-                                  key={item.value}
-                                  listLength={items.length}
-                                  isActive={highlightedIndex === index}
-                                  isSelected={
-                                    selectedItem &&
-                                    selectedItem.includes(item.value)
-                                  }
-                                  index={index}
-                                  {...getItemProps({
-                                    // results from upstream bug in downshift typings (https://github.com/downshift-js/downshift/pull/1382)
-                                    item: item as any,
-                                    disabled: item.disabled
-                                  })}
-                                >
-                                  {item.label}
-                                </PopoverListItem>
-                              ))
-                            ) : (
-                              <div>{menuEmptyState}</div>
-                            )}
-                          </PopoverBox>
-                        </div>
-                      )}
-                    </div>
-                  }
-                  disablePortal={disablePortal}
-                >
-                  {React.cloneElement(
-                    textField,
-                    getInputProps({
-                      onFocus: e => {
-                        handleInputActivation({ isOpen, openMenu }, e);
-                      },
-                      onClick: e => {
-                        handleInputActivation({ isOpen, openMenu }, e);
-                      },
-                      value: value ?? inputValue ?? "",
-                      ...(textField.type === TextInputWithBadges && {
-                        downshiftReset: other.reset
-                      }),
-                      ...textFieldProps
-                    })
-                  )}
-                </Dropdownable>
-              </div>
-            );
-          }}
-        </Downshift>
-      </div>
-    );
   }
-);
 
-export default Typeahead;
+  function stateReducer(state, changes) {
+    switch (changes.type) {
+      case Downshift.stateChangeTypes.keyDownEnter:
+      case Downshift.stateChangeTypes.clickItem:
+        handleSelection(changes.selectedItem);
+
+        return {
+          ...changes,
+          selectedItem: [changes.selectedItem.value],
+          isOpen: multiSelect && !(keepOpenOnSelect === false),
+          inputValue:
+            multiSelect || resetInputOnSelect ? "" : changes.inputValue
+        };
+
+      case Downshift.stateChangeTypes.changeInput:
+        return {
+          ...changes,
+          // Manually setting `isOpen` to make sure the menu closes after the user has made a selection
+          //
+          // By default, Downshift changes it's internal `isOpen` state to `false` when an input changes,
+          // but there are cases where we need the <input> to dispatch an `onChange` event on item selection
+          // so that `onChange` bubbles up to the parent <form> element's `onChange` event
+          isOpen:
+            multiSelect ||
+            ((state.inputValue || changes.inputValue) &&
+              changes.inputValue !== state.inputValue),
+          selectedItem:
+            changes.inputValue === state.inputValue ? state.selectedItem : ""
+        };
+
+      case Downshift.stateChangeTypes.blurInput:
+      case Downshift.stateChangeTypes.mouseUp:
+        return {
+          ...changes,
+          inputValue: state.inputValue
+        };
+
+      default:
+        return changes;
+    }
+  }
+
+  function handleInputActivation(
+    stateAndHelpers: {
+      openMenu: (cb?: () => void) => void;
+      isOpen: boolean;
+    },
+    e
+  ) {
+    const { openMenu, isOpen } = stateAndHelpers;
+
+    if (textField.props.onFocus && e.nativeEvent.type === "focus") {
+      textField.props.onFocus(e);
+    } else if (textField.props.onClick && e.nativeEvent.type === "click") {
+      textField.props.onClick(e);
+    }
+
+    if (!isOpen) {
+      setContainerWidth();
+      openMenu();
+    }
+  }
+
+  return (
+    <div ref={containerRef} data-cy="typeahead">
+      <Downshift
+        itemToString={defaultItemToString}
+        selectedItem={selectedItems}
+        stateReducer={stateReducer}
+      >
+        {({
+          getInputProps,
+          getItemProps,
+          getMenuProps,
+          isOpen,
+          highlightedIndex,
+          openMenu,
+          selectedItem,
+          inputValue,
+          ...other
+        }) => {
+          return (
+            <div>
+              <Dropdownable
+                isOpen={isOpen}
+                overlayRoot={overlayRoot}
+                dropdown={
+                  <div data-cy="typeahead-dropdown">
+                    {!items.length && !menuEmptyState ? null : (
+                      <div className={margin("top", "xxs")}>
+                        <PopoverBox
+                          width={menuWidth}
+                          maxHeight={menuMaxHeight}
+                          {...getMenuProps(
+                            { refKey: "menuRef" },
+                            // The menu is not mounted when `isOpen` is false, so Downshift's ref check fails incorrectly
+                            // The menu behaves as expected, and has all the correct attributes
+                            { suppressRefError: true }
+                          )}
+                        >
+                          {items.length ? (
+                            items.map((item: Item, index: number) => (
+                              <PopoverListItem
+                                key={item.value}
+                                listLength={items.length}
+                                isActive={highlightedIndex === index}
+                                isSelected={
+                                  selectedItem &&
+                                  selectedItem.includes(item.value)
+                                }
+                                index={index}
+                                {...getItemProps({
+                                  // results from upstream bug in downshift typings (https://github.com/downshift-js/downshift/pull/1382)
+                                  item: item as any,
+                                  disabled: item.disabled
+                                })}
+                              >
+                                {item.label}
+                              </PopoverListItem>
+                            ))
+                          ) : (
+                            <div>{menuEmptyState}</div>
+                          )}
+                        </PopoverBox>
+                      </div>
+                    )}
+                  </div>
+                }
+                disablePortal={disablePortal}
+              >
+                {React.cloneElement(
+                  textField,
+                  getInputProps({
+                    onFocus: e => {
+                      handleInputActivation({ isOpen, openMenu }, e);
+                    },
+                    onClick: e => {
+                      handleInputActivation({ isOpen, openMenu }, e);
+                    },
+                    value: value ?? inputValue ?? "",
+                    ...(textField.type === TextInputWithBadges && {
+                      downshiftReset: other.reset
+                    }),
+                    ...textFieldProps
+                  })
+                )}
+              </Dropdownable>
+            </div>
+          );
+        }}
+      </Downshift>
+    </div>
+  );
+};
+
+export default React.memo(Typeahead);

--- a/packages/typeahead/stories/helpers/FilteredListTypeahead.tsx
+++ b/packages/typeahead/stories/helpers/FilteredListTypeahead.tsx
@@ -7,7 +7,7 @@ interface FilteredListProps {
   menuEmptyState?: React.ReactElement<any>;
 }
 
-const FilteredList = React.memo((props: FilteredListProps) => {
+const FilteredList = (props: FilteredListProps) => {
   const [items, setItems] = React.useState<Item[]>(props.items || []);
 
   const filterList = e => {
@@ -41,6 +41,6 @@ const FilteredList = React.memo((props: FilteredListProps) => {
       />
     </div>
   );
-});
+};
 
-export default FilteredList;
+export default React.memo(FilteredList);


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

When we memoize components, we should set `React.memo()` around the component export so that it does not affect the storybook code snippets under the Docs tab.
This will keep our use of React.memo consistent throughout the project. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
before
<img width="1194" alt="Screen Shot 2022-10-18 at 4 36 11 PM" src="https://user-images.githubusercontent.com/34781875/196552517-7a3763a2-52fc-489c-a864-8ca319dd6a7c.png">

after
<img width="1105" alt="Screen Shot 2022-10-18 at 4 38 14 PM" src="https://user-images.githubusercontent.com/34781875/196552515-bb06f408-59b6-4c3c-89f2-455dd1cb1a28.png">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
