### PR TITLE
fix: contain FullscreenView with classname

### DIFF
--- a/packages/fullscreenView/components/FullscreenView.tsx
+++ b/packages/fullscreenView/components/FullscreenView.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cx, css } from "@emotion/css";
+import { cx } from "@emotion/css";
 import { ButtonProps } from "../../button/components/ButtonBase";
 import { flex, padding, flexItem } from "../../shared/styles/styleUtils";
 import { modalContent, fullscreenModalHeader } from "../style";
@@ -24,8 +24,8 @@ export interface FullscreenViewProps {
   onClose: (event?: React.SyntheticEvent<HTMLElement>) => void;
   /** The base of the `data-cy` value. This is used for writing selectors in Cypress. */
   cypressSelectorBase?: string;
-  /** The css max width around the header contents  */
-  containerMaxWidth?: string;
+  /** Optional classname around header contents  */
+  headerClassName?: string;
   children?: React.ReactNode;
 }
 
@@ -40,20 +40,9 @@ const FullscreenView = ({
   bannerComponent,
   headerComponent,
   cypressSelectorBase = "fullscreenView",
-  containerMaxWidth
+  headerClassName = ""
 }: FullscreenViewProps) => {
   const HeaderComponent = headerComponent ?? FullscreenViewHeader;
-
-  let container: string = "";
-  if (containerMaxWidth) {
-    // add border-box to account for any left and right padding
-    container = css`
-      margin-left: auto;
-      margin-right: auto;
-      max-width: ${containerMaxWidth};
-      box-sizing: border-box;
-    `;
-  }
 
   return (
     <div className={flex({ direction: "column" })}>
@@ -64,7 +53,7 @@ const FullscreenView = ({
         {bannerComponent && (
           <div data-cy={`${cypressSelectorBase}-banner`}>{bannerComponent}</div>
         )}
-        <div className={cx(padding("all", "xl"), container)}>
+        <div className={cx(padding("all", "xl"), headerClassName)}>
           <HeaderComponent
             title={title}
             subtitle={subtitle}

--- a/packages/fullscreenView/stories/fullscreenView.stories.tsx
+++ b/packages/fullscreenView/stories/fullscreenView.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import FullscreenView from "../components/FullscreenView";
 import { Meta } from "@storybook/react";
+import { cx } from "@emotion/css";
+
 import {
   flex,
   flexItem,
@@ -8,8 +10,7 @@ import {
   tintContentSecondary,
   padding
 } from "../../shared/styles/styleUtils";
-import { containerWidthDefault } from "../../design-tokens/build/js/designTokens";
-import { cx } from "@emotion/css";
+import { Container } from "../../styleUtils/layout";
 import { fullscreenModalTitle } from "../style";
 import { SecondaryButton, PrimaryButton } from "../../button";
 import { action } from "@storybook/addon-actions";
@@ -18,6 +19,7 @@ import {
   BorderedModalContent
 } from "../../modal/stories/helpers/modalContents";
 import { InfoBoxBanner } from "../../infobox/index";
+import { container } from "../../styleUtils/layout/container/style";
 
 const onClose = () => {
   alert("calling onClose");
@@ -130,16 +132,18 @@ export const WithBanner = () => (
   </div>
 );
 
-export const WithContainer = () => (
+export const WithHeaderClassName = () => (
   <div style={{ height: "500px" }}>
     <FullscreenView
       closeText="Close"
       title="Title"
       onClose={onClose}
       ctaButton={<PrimaryButton type="button">Click</PrimaryButton>}
-      containerMaxWidth={containerWidthDefault}
+      headerClassName={container}
     >
-      <ModalContent />
+      <Container>
+        <ModalContent />
+      </Container>
     </FullscreenView>
   </div>
 );


### PR DESCRIPTION
In order to support responsive layouts and different container sizes at various widths, this really should just take a classname so that a client has total control. I tried to borrow the container classname from the container component and go with a boolean argument like "contained" but I found that our usage in DKP needed to change the box-sizing anyway to get it to be consistent. Rather than have both props, just went with one, more versatile prop.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
