### PR TITLE
fix: allow more space for header titles

### DIFF
--- a/packages/fullscreenView/components/FullscreenViewHeader.tsx
+++ b/packages/fullscreenView/components/FullscreenViewHeader.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { cx } from "@emotion/css";
-import { fullscreenModalAction, fullscreenModalTitle } from "../style";
+import {
+  fullscreenModalAction,
+  fullscreenModalTitleContainer,
+  fullscreenModalTitle
+} from "../style";
 import {
   flex,
   flexItem,
@@ -24,7 +28,7 @@ const FullscreenModalHeader = ({
     <div className={cx(fullscreenModalAction.dismiss, flexItem("grow"))}>
       <SecondaryButton onClick={onClose}>{closeText}</SecondaryButton>
     </div>
-    <div className={flexItem("grow")}>
+    <div className={cx(flexItem("grow"), fullscreenModalTitleContainer)}>
       <h2
         className={cx(
           fullscreenModalTitle,

--- a/packages/fullscreenView/stories/fullscreenView.stories.tsx
+++ b/packages/fullscreenView/stories/fullscreenView.stories.tsx
@@ -139,6 +139,16 @@ export const WithHeaderClassName = () => (
       title="Title"
       onClose={onClose}
       ctaButton={<PrimaryButton type="button">Click</PrimaryButton>}
+      subtitle={
+        <>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur.
+        </>
+      }
       headerClassName={container}
     >
       <Container>

--- a/packages/fullscreenView/style.ts
+++ b/packages/fullscreenView/style.ts
@@ -28,3 +28,8 @@ export const modalContent = css`
   position: relative;
   overflow: auto;
 `;
+
+export const fullscreenModalTitleContainer = css`
+  // allot more space for the title and subtitle section
+  flex-grow: 2;
+`;

--- a/packages/fullscreenView/tests/__snapshots__/fullscreenView.test.tsx.snap
+++ b/packages/fullscreenView/tests/__snapshots__/fullscreenView.test.tsx.snap
@@ -151,6 +151,10 @@ exports[`FullscreenView renders FullscreenView 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
 }
 
 .emotion-8 {

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -3011,6 +3011,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
 }
 
 .emotion-11 {
@@ -3631,6 +3635,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
 }
 
 .emotion-62 {
@@ -4398,6 +4406,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
 }
 
 .emotion-12 {
@@ -4877,6 +4889,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
 }
 
 .emotion-12 {
@@ -5330,6 +5346,10 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   flex-grow: 1;
   min-width: 0;
   width: auto;
+  -webkit-box-flex: 2;
+  -webkit-flex-grow: 2;
+  -ms-flex-positive: 2;
+  flex-grow: 2;
 }
 
 .emotion-12 {


### PR DESCRIPTION
Allows the container around header title and subtitle to take up more space.

The header has responsiveness issues when sizing down to mobile. The contents will spill off and not stay contained in the header.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots
before:

<img width="663" alt="Screen Shot 2022-10-19 at 2 41 39 PM" src="https://user-images.githubusercontent.com/34781875/196788990-83f4e6fe-a5ba-427f-b8c2-a79e4d58a434.png">
<img width="1156" alt="Screen Shot 2022-10-19 at 2 41 58 PM" src="https://user-images.githubusercontent.com/34781875/196789019-baacfefe-7d24-416a-84c7-3bbd147f9cb4.png">


after

<img width="1384" alt="Screen Shot 2022-10-19 at 2 46 56 PM" src="https://user-images.githubusercontent.com/34781875/196789311-5a0470e8-ee0c-4694-9169-920a0adb5aed.png">



<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
