### PR TITLE
refactor: DialogModal to Function Component

### DIFF
--- a/packages/modal/components/DialogModal.tsx
+++ b/packages/modal/components/DialogModal.tsx
@@ -25,73 +25,71 @@ export interface DialogModalProps extends ModalBaseProps {
   icon?: IconProps;
 }
 
-class DialogModal extends React.PureComponent<DialogModalProps, {}> {
-  public render() {
-    const { children, footerContent, isContentFlush, title, icon, ...other } =
-      this.props;
+const DialogModal = (props: DialogModalProps) => {
+  const { children, footerContent, isContentFlush, title, icon, ...other } =
+    props;
 
-    return (
-      <ModalBase data-cy="dialogModal" {...other}>
+  return (
+    <ModalBase data-cy="dialogModal" {...other}>
+      <div
+        className={cx(modalHeader, flexItem("shrink"))}
+        data-cy="dialogModal-header"
+      >
         <div
-          className={cx(modalHeader, flexItem("shrink"))}
-          data-cy="dialogModal-header"
+          className={cx(
+            flex({ align: "center", justify: "center" }),
+            padding("all", "l")
+          )}
         >
+          <div className={cx(flexItem("grow"), textSize("l"))}>
+            {icon ? (
+              <Flex gutterSize="xxs" justify="center" align="center">
+                <FlexItem flex="shrink">
+                  <Icon
+                    shape={icon.shape}
+                    size={icon.size ? icon.size : "xs"}
+                    color={icon.color ? icon.color : "inherit"}
+                  />
+                </FlexItem>
+                <FlexItem flex="grow">{title}</FlexItem>
+              </Flex>
+            ) : (
+              <>{title}</>
+            )}
+          </div>
           <div
             className={cx(
-              flex({ align: "center", justify: "center" }),
-              padding("all", "l")
+              modalCloseWrapper,
+              display("inherit"),
+              flexItem("shrink")
             )}
           >
-            <div className={cx(flexItem("grow"), textSize("l"))}>
-              {icon ? (
-                <Flex gutterSize="xxs" justify="center" align="center">
-                  <FlexItem flex="shrink">
-                    <Icon
-                      shape={icon.shape}
-                      size={icon.size ? icon.size : "xs"}
-                      color={icon.color ? icon.color : "inherit"}
-                    />
-                  </FlexItem>
-                  <FlexItem flex="grow">{title}</FlexItem>
-                </Flex>
-              ) : (
-                <>{title}</>
-              )}
-            </div>
-            <div
-              className={cx(
-                modalCloseWrapper,
-                display("inherit"),
-                flexItem("shrink")
-              )}
-            >
-              <Clickable tabIndex={0} action={this.props.onClose}>
-                <span className={display("inherit")}>
-                  <Icon shape={SystemIcons.Close} size="xs" />
-                </span>
-              </Clickable>
-            </div>
+            <Clickable tabIndex={0} action={props.onClose}>
+              <span className={display("inherit")}>
+                <Icon shape={SystemIcons.Close} size="xs" />
+              </span>
+            </Clickable>
           </div>
         </div>
+      </div>
+      <div
+        className={cx(modalContent, {
+          [padding("all", "l")]: !isContentFlush
+        })}
+        data-cy="dialogModal-content"
+      >
+        {children}
+      </div>
+      {footerContent && (
         <div
-          className={cx(modalContent, {
-            [padding("all", "l")]: !isContentFlush
-          })}
-          data-cy="dialogModal-content"
+          className={cx(flexItem("shrink"), padding("all", "l"))}
+          data-cy="dialogModal-footer"
         >
-          {children}
+          {footerContent}
         </div>
-        {footerContent && (
-          <div
-            className={cx(flexItem("shrink"), padding("all", "l"))}
-            data-cy="dialogModal-footer"
-          >
-            {footerContent}
-          </div>
-        )}
-      </ModalBase>
-    );
-  }
-}
+      )}
+    </ModalBase>
+  );
+};
 
 export default DialogModal;

--- a/packages/modal/components/DialogModal.tsx
+++ b/packages/modal/components/DialogModal.tsx
@@ -92,4 +92,4 @@ const DialogModal = (props: DialogModalProps) => {
   );
 };
 
-export default DialogModal;
+export default React.memo(DialogModal);

--- a/packages/modal/components/DialogModalWithFooter.tsx
+++ b/packages/modal/components/DialogModalWithFooter.tsx
@@ -12,30 +12,25 @@ export interface DialogModalWithFooterProps extends DialogModalProps {
   closeText?: React.ReactNode;
 }
 
-class DialogModalWithFooter extends React.PureComponent<
-  DialogModalWithFooterProps,
-  {}
-> {
-  public render() {
-    const { ctaButton, closeText, onClose, ...other } = this.props;
+const DialogModalWithFooter = (props: DialogModalWithFooterProps) => {
+  const { ctaButton, closeText, onClose, ...other } = props;
 
-    return (
-      <DialogModal
-        footerContent={
-          <div className={flex({ align: "center", justify: "space-between" })}>
-            {closeText !== "" || closeText != null ? (
-              <div className={flexItem("shrink")}>
-                <SecondaryButton onClick={onClose}>{closeText}</SecondaryButton>
-              </div>
-            ) : null}
-            <div className={flexItem("shrink")}>{ctaButton}</div>
-          </div>
-        }
-        onClose={onClose}
-        {...other}
-      />
-    );
-  }
-}
+  return (
+    <DialogModal
+      footerContent={
+        <div className={flex({ align: "center", justify: "space-between" })}>
+          {closeText !== "" || closeText != null ? (
+            <div className={flexItem("shrink")}>
+              <SecondaryButton onClick={onClose}>{closeText}</SecondaryButton>
+            </div>
+          ) : null}
+          <div className={flexItem("shrink")}>{ctaButton}</div>
+        </div>
+      }
+      onClose={onClose}
+      {...other}
+    />
+  );
+};
 
 export default DialogModalWithFooter;

--- a/packages/modal/components/DialogModalWithFooter.tsx
+++ b/packages/modal/components/DialogModalWithFooter.tsx
@@ -33,4 +33,4 @@ const DialogModalWithFooter = (props: DialogModalWithFooterProps) => {
   );
 };
 
-export default DialogModalWithFooter;
+export default React.memo(DialogModalWithFooter);

--- a/packages/modal/components/ModalBase.tsx
+++ b/packages/modal/components/ModalBase.tsx
@@ -75,7 +75,7 @@ const ModalBase = ({ isAnimated = true, ...props }: ModalBaseProps) => {
     if (props.initialFocus && props.isOpen) {
       setInitialFocus(props.initialFocus);
     }
-  }, []);
+  }, [props.isOpen]);
 
   return (
     <Transition

--- a/packages/modal/components/ModalBase.tsx
+++ b/packages/modal/components/ModalBase.tsx
@@ -124,4 +124,4 @@ const ModalBase = ({ isAnimated = true, ...props }: ModalBaseProps) => {
   );
 };
 
-export default ModalBase;
+export default React.memo(ModalBase);

--- a/packages/modal/components/ModalBase.tsx
+++ b/packages/modal/components/ModalBase.tsx
@@ -51,98 +51,77 @@ export interface ModalBaseProps {
 
 const animationDuration = 250;
 
-class ModalBase extends React.PureComponent<ModalBaseProps, {}> {
-  public static defaultProps: Partial<ModalBaseProps> = {
-    isAnimated: true
-  };
+const ModalBase = ({ isAnimated = true, ...props }: ModalBaseProps) => {
+  const { children, size, isOpen, "data-cy": dataCy, overlayRoot, id } = props;
+  const modalSize = size || ModalSizes.M;
 
-  constructor(props) {
-    super(props);
-
-    this.onKeyDown = this.onKeyDown.bind(this);
-    this.setInitialFocus = this.setInitialFocus.bind(this);
-  }
-
-  public componentDidUpdate() {
-    if (this.props.initialFocus && this.props.isOpen) {
-      this.setInitialFocus(this.props.initialFocus);
-    }
-  }
-
-  public onKeyDown(e) {
+  const onKeyDown = e => {
     if (e.key === "Escape") {
-      this.props.onClose(e);
+      props.onClose(e);
       e.stopPropagation();
     }
-  }
+  };
 
-  public render() {
-    const {
-      children,
-      isAnimated,
-      size,
-      isOpen,
-      "data-cy": dataCy,
-      overlayRoot,
-      id
-    } = this.props;
-    const modalSize = size || ModalSizes.M;
-
-    return (
-      <Transition
-        timeout={{ enter: 0, exit: animationDuration }}
-        in={isOpen}
-        unmountOnExit={true}
-      >
-        {state => {
-          return (
-            <Overlay overlayRoot={overlayRoot}>
-              <FocusLock>
-                <div
-                  role="button"
-                  tabIndex={-1}
-                  className={cx(scrim, {
-                    [scrimPreTransitionStyle(animationDuration)]: isAnimated,
-                    [scrimTransitionStyles[state]]: isAnimated
-                  })}
-                  onClick={this.props.onClose}
-                />
-                <div className={centerDialogWrapper}>
-                  <div
-                    className={cx(modal, modalWidth[modalSize], {
-                      [modalPreTransitionStyle(animationDuration)]: isAnimated,
-                      [modalTransitionStyles[state]]: isAnimated
-                    })}
-                    role="dialog"
-                    onKeyDown={this.onKeyDown}
-                    tabIndex={-1}
-                    id={id}
-                  >
-                    <ModalContents
-                      isOpen={isOpen}
-                      onClose={this.props.onClose}
-                      data-cy={dataCy}
-                    >
-                      {children}
-                    </ModalContents>
-                  </div>
-                </div>
-              </FocusLock>
-            </Overlay>
-          );
-        }}
-      </Transition>
-    );
-  }
-
-  private setInitialFocus(initialFocus) {
+  const setInitialFocus = initialFocus => {
     const domNodeToFind = document.querySelector(initialFocus);
 
     if (domNodeToFind) {
       const node = ReactDOM.findDOMNode(domNodeToFind) as Element;
       node.setAttribute("data-autofocus", "true");
     }
-  }
-}
+  };
+
+  React.useEffect(() => {
+    if (props.initialFocus && props.isOpen) {
+      setInitialFocus(props.initialFocus);
+    }
+  }, []);
+
+  return (
+    <Transition
+      timeout={{ enter: 0, exit: animationDuration }}
+      in={isOpen}
+      unmountOnExit={true}
+    >
+      {state => {
+        return (
+          <Overlay overlayRoot={overlayRoot}>
+            <FocusLock>
+              <div
+                role="button"
+                tabIndex={-1}
+                className={cx(scrim, {
+                  [scrimPreTransitionStyle(animationDuration)]: isAnimated,
+                  [scrimTransitionStyles[state]]: isAnimated
+                })}
+                onClick={props.onClose}
+              />
+              <div className={centerDialogWrapper}>
+                <div
+                  className={cx(modal, modalWidth[modalSize], {
+                    [modalPreTransitionStyle(animationDuration)]: isAnimated,
+                    [modalTransitionStyles[state]]: isAnimated
+                  })}
+                  role="dialog"
+                  onKeyDown={onKeyDown}
+                  tabIndex={-1}
+                  id={id}
+                >
+                  <ModalContents
+                    isOpen={isOpen}
+                    onClose={props.onClose}
+                    data-cy={dataCy}
+                  >
+                    {children}
+                  </ModalContents>
+                </div>
+              </div>
+            </FocusLock>
+          </Overlay>
+        );
+      }}
+    </Transition>
+  );
+};
 
 export default ModalBase;

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -327,7 +327,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   background-color: #6446cc;
 }
 
-<DialogModalWithFooter
+<Memo(DialogModalWithFooter)
   closeText="Close"
   ctaButton={
     <PrimaryButton>
@@ -338,7 +338,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   onClose={[MockFunction]}
   title="Title"
 >
-  <DialogModal
+  <Memo(DialogModal)
     footerContent={
       .emotion-0 {
   -webkit-align-items: center;
@@ -416,7 +416,7 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
     onClose={[MockFunction]}
     title="Title"
   >
-    <ModalBase
+    <Memo(ModalBase)
       data-cy="dialogModal"
       isOpen={true}
       onClose={[MockFunction]}
@@ -2811,9 +2811,9 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
           </Overlay>
         </ForwardRef>
       </Transition>
-    </ModalBase>
-  </DialogModal>
-</DialogModalWithFooter>
+    </Memo(ModalBase)>
+  </Memo(DialogModal)>
+</Memo(DialogModalWithFooter)>
 `;
 
 exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
@@ -3114,7 +3114,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
   onClose={[MockFunction]}
   title="Title"
 >
-  <ModalBase
+  <Memo(ModalBase)
     data-cy="fullscreenModal"
     isAnimated={false}
     isOpen={true}
@@ -5730,7 +5730,7 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
         </Overlay>
       </ForwardRef>
     </Transition>
-  </ModalBase>
+  </Memo(ModalBase)>
 </Memo(FullscreenModal)>
 `;
 
@@ -5837,7 +5837,7 @@ exports[`Modal ModalBase renders ModalBase 1`] = `
   width: 100%;
 }
 
-<ModalBase
+<Memo(ModalBase)
   isOpen={true}
   onClose={[MockFunction]}
 >
@@ -6560,5 +6560,5 @@ exports[`Modal ModalBase renders ModalBase 1`] = `
       </Overlay>
     </ForwardRef>
   </Transition>
-</ModalBase>
+</Memo(ModalBase)>
 `;

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -418,7 +418,6 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
   >
     <ModalBase
       data-cy="dialogModal"
-      isAnimated={true}
       isOpen={true}
       onClose={[MockFunction]}
     >
@@ -5839,7 +5838,6 @@ exports[`Modal ModalBase renders ModalBase 1`] = `
 }
 
 <ModalBase
-  isAnimated={true}
   isOpen={true}
   onClose={[MockFunction]}
 >


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Migrates DialogModal and related components to FunctionComponent.

Components:
- DialogModal
- DialogModalWithFooter
- ModalBase

## Which issue(s) does this PR relate to?
<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

#784
 
## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->
Run Jest Tests via `$ npm run test` and via Storybook.

Behaviours:
- Modal defaults to being animated
- Clicking outside does not close the Modal
- Clicking on X or pressing escape closes the Modal

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

N/A

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

N/A

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [X] I have reviewed the changes and provided detail to the sections above

## Other Findings
- [`modal/components/helpers/ModalExample.tsx` is an empty file ](https://github.com/dcos-labs/ui-kit/blob/main/packages/modal/components/helpers/ModalExample.tsx)
- Modal z-index is set to 1
    ![Untitled(1)](https://user-images.githubusercontent.com/8443215/196839770-2a0563cc-e684-4d07-9e9a-7647ea785f6e.png)
