### PR TITLE
refactor: remove statelesscomponent use

### DIFF
--- a/packages/popover/components/Popover.tsx
+++ b/packages/popover/components/Popover.tsx
@@ -36,7 +36,7 @@ export interface PopoverProps
   ["data-cy"]?: string;
 }
 
-const Popover: React.StatelessComponent<PopoverProps> = ({
+const Popover = ({
   children,
   "data-cy": dataCy,
   id,
@@ -46,7 +46,7 @@ const Popover: React.StatelessComponent<PopoverProps> = ({
   overlayRoot,
   preferredDirections,
   trigger
-}) => {
+}: PopoverProps) => {
   const [generatedDropdownId] = useId(1, "dropdown");
   const containerRef = React.useRef<HTMLDivElement>(null);
   const triggerRef = React.useRef<HTMLDivElement>(null);

--- a/packages/progressbar/components/ProgressBar.tsx
+++ b/packages/progressbar/components/ProgressBar.tsx
@@ -43,14 +43,14 @@ export interface ProgressBarProps {
   size?: ProgressBarSizes;
 }
 
-const ProgressBar: React.StatelessComponent<ProgressBarProps> = ({
+const ProgressBar = ({
   caption,
   data,
   value,
   size,
   isProcessing,
   isCondensedLayout
-}) => {
+}: ProgressBarProps) => {
   const renderProgressBar = () => (
     <svg
       className={cx(progressBar(size), {

--- a/packages/promo/components/PromoInline.tsx
+++ b/packages/promo/components/PromoInline.tsx
@@ -3,7 +3,7 @@ import { Card, SpacingBox } from "../../";
 import { PromoProps } from "../types";
 import PromoContent from "./PromoContent";
 
-const PromoInline: React.StatelessComponent<PromoProps> = props => (
+const PromoInline = (props: PromoProps) => (
   <Card paddingSize="none">
     <SpacingBox side="horiz" spacingSize="m">
       <PromoContent {...props} />

--- a/packages/styleUtils/layout/stack/components/Stack.tsx
+++ b/packages/styleUtils/layout/stack/components/Stack.tsx
@@ -19,15 +19,16 @@ export interface StackProps {
    * Which HTML tag to render the component with
    */
   tag?: keyof React.ReactHTML;
+  children?: React.ReactNode;
 }
 
-const Stack: React.StatelessComponent<StackProps> = ({
+const Stack = ({
   children,
   className,
-  "data-cy": dataCy,
-  spacingSize,
+  "data-cy": dataCy = "stack",
+  spacingSize = "m",
   tag: Tag = "div"
-}) => (
+}: StackProps) => (
   <Tag
     className={cx(
       { [listReset]: Tag === "ul" || Tag === "ol" },
@@ -40,11 +41,5 @@ const Stack: React.StatelessComponent<StackProps> = ({
     {children}
   </Tag>
 );
-
-Stack.defaultProps = {
-  spacingSize: "m",
-  tag: "div",
-  ["data-cy"]: "stack"
-};
 
 export default Stack;

--- a/packages/styleUtils/typography/components/TextBlock.tsx
+++ b/packages/styleUtils/typography/components/TextBlock.tsx
@@ -5,10 +5,12 @@ import { Stack } from "../../layout";
 
 const SPACE_BETWEEN_ELS = "l";
 
-const TextBlock: React.StatelessComponent<{ className?: string }> = ({
-  children,
-  className
-}) => {
+export interface TextBlockProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+const TextBlock = ({ children, className }: TextBlockProps) => {
   return (
     <Stack spacingSize={SPACE_BETWEEN_ELS} className={cx(textBlock, className)}>
       {children}

--- a/packages/tablev2/DropdownMenuCell.tsx
+++ b/packages/tablev2/DropdownMenuCell.tsx
@@ -18,9 +18,9 @@ const trigger = (
   </ResetButton>
 );
 
-export const DropdownMenuCell: React.StatelessComponent<
-  Omit<DropdownMenuProps, "trigger">
-> = props => (
+type PopoverProps = Omit<DropdownMenuProps, "trigger">;
+
+export const DropdownMenuCell = (props: PopoverProps) => (
   <div className={style}>
     <DropdownMenu trigger={trigger} {...props} />
   </div>

--- a/packages/tablev2/TooltipHeaderCell.tsx
+++ b/packages/tablev2/TooltipHeaderCell.tsx
@@ -13,12 +13,18 @@ export const iconAlign = css`
   margin-bottom: 1px;
 `;
 
-export const TooltipHeaderCell: React.StatelessComponent<{
+export interface TooltipHeaderCellProps {
   /**
    * Helper content that explains the content in the column.
    */
   tooltipContent?: React.ReactNode;
-}> = ({ children, tooltipContent }) => {
+  children?: React.ReactNode;
+}
+
+export const TooltipHeaderCell = ({
+  children,
+  tooltipContent
+}: TooltipHeaderCellProps) => {
   const [generatedId] = useId(1, "colTooltip");
   return (
     <Flex gutterSize="xxs" className={style.cellFlexWrapper}>


### PR DESCRIPTION
React.StatelessComponent is deprecated.

<!-- PR Checklist -->

# Description

React.StatelessComponent is deprecated and should not be used. We will need to make this change before we're able to update to React 18. 



<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
