### PR TITLE
fix: forwardrefs to FocusStyleManager children

### DIFF
--- a/packages/button/components/ButtonBase.tsx
+++ b/packages/button/components/ButtonBase.tsx
@@ -91,56 +91,24 @@ export interface ButtonBaseProps extends ButtonProps {
   className?: string;
 }
 
-const ButtonBase = (props: ButtonBaseProps) => {
-  const {
-    appearance,
-    children,
-    className,
-    disabled,
-    iconStart,
-    iconEnd,
-    isInverse,
-    isProcessing,
-    isFullWidth,
-    onClick,
-    type = "button",
-    url,
-    openInNewTab,
-    ...other
-  } = props;
-
-  const buttonClassName = cx(
-    buttonReset,
-    button(appearance),
-    buttonBase,
-    textWeight("medium"),
-    className,
-    {
-      [fullWidthButton]: isFullWidth,
-      [buttonInverse(appearance)]: isInverse,
-      [getMutedButtonStyles(appearance)]: disabled || isProcessing,
-      [getInverseMutedButtonStyles(appearance)]:
-        (disabled || isProcessing) && isInverse
-    }
-  );
-
-  const handleClick = (e: React.SyntheticEvent<HTMLElement>) => {
-    if (!disabled && onClick) {
-      onClick(e);
-    }
-  };
-
-  const getIconStart = icon => {
-    return (
-      <span className={cx(flexItem("shrink"), display("inherit"))}>
-        <IconPropAdapter icon={icon} size="xs" color="inherit" />
-      </span>
-    );
-  };
-
-  const getIconEnd = icon => {
-    return (
-      Boolean(icon) && (
+const ButtonContent = ({ iconStart, iconEnd, isProcessing, children }) => {
+  return iconStart || iconEnd ? (
+    <span className={flex({ align: "center", justify: "center" })}>
+      {iconStart && (
+        <span className={cx(flexItem("shrink"), display("inherit"))}>
+          <IconPropAdapter icon={iconStart} size="xs" color="inherit" />
+        </span>
+      )}
+      {children && (
+        <span
+          className={cx(flexItem("shrink"), padding("left", "xs"), {
+            [processingTextStyle]: isProcessing
+          })}
+        >
+          {children}
+        </span>
+      )}
+      {iconEnd && (
         <span
           className={cx(
             flexItem("shrink"),
@@ -148,58 +116,77 @@ const ButtonBase = (props: ButtonBaseProps) => {
             padding("left", "xxs")
           )}
         >
-          <IconPropAdapter icon={icon} size="xs" color="inherit" />
+          <IconPropAdapter icon={iconEnd} size="xs" color="inherit" />
         </span>
-      )
+      )}
+    </span>
+  ) : (
+    <span className={isProcessing ? processingTextStyle : ""}>{children}</span>
+  );
+};
+
+const ButtonNode = React.forwardRef(
+  (
+    {
+      appearance,
+      children,
+      className,
+      disabled,
+      iconStart,
+      iconEnd,
+      isInverse,
+      isProcessing,
+      isFullWidth,
+      onClick,
+      type = "button",
+      url,
+      openInNewTab,
+      ariaHaspopup,
+      ...other
+    }: ButtonBaseProps,
+    ref
+  ) => {
+    const buttonClassName = cx(
+      buttonReset,
+      button(appearance),
+      buttonBase,
+      textWeight("medium"),
+      className,
+      {
+        [fullWidthButton]: isFullWidth,
+        [buttonInverse(appearance)]: isInverse,
+        [getMutedButtonStyles(appearance)]: disabled || isProcessing,
+        [getInverseMutedButtonStyles(appearance)]:
+          (disabled || isProcessing) && isInverse
+      }
     );
-  };
 
-  const getButtonContent = () => {
-    const { iconStart, iconEnd, isProcessing, children } = props;
+    const handleClick = (e: React.SyntheticEvent<HTMLElement>) => {
+      if (!disabled && onClick) {
+        onClick(e);
+      }
+    };
 
-    return iconStart || iconEnd ? (
-      <span className={flex({ align: "center", justify: "center" })}>
-        {iconStart && getIconStart(iconStart)}
-        {children && (
-          <span
-            className={cx(flexItem("shrink"), padding("left", "xs"), {
-              [processingTextStyle]: isProcessing
-            })}
-          >
-            {children}
-          </span>
-        )}
-        {iconEnd && getIconEnd(iconEnd)}
-      </span>
-    ) : (
-      <span className={isProcessing ? processingTextStyle : ""}>
-        {children}
-      </span>
-    );
-  };
-
-  const getButtonNode = () => {
     if (url) {
-      return !disabled && !isProcessing ? (
+      const enabled = !disabled && !isProcessing;
+      return (
         <UnstyledLink
-          href={url}
+          href={enabled ? url : undefined}
+          aria-disabled={!enabled}
           className={buttonClassName}
           onClick={handleClick}
-          tabIndex={0}
+          tabIndex={enabled ? 0 : -1}
           openInNewTab={openInNewTab}
+          ref={ref}
           {...other}
         >
-          {getButtonContent()}
-        </UnstyledLink>
-      ) : (
-        <UnstyledLink
-          className={buttonClassName}
-          aria-disabled="true"
-          tabIndex={-1}
-          openInNewTab={openInNewTab}
-          {...other}
-        >
-          {getButtonContent()}
+          <ButtonContent
+            iconStart={iconStart}
+            iconEnd={iconEnd}
+            isProcessing={isProcessing}
+          >
+            {children}
+          </ButtonContent>
         </UnstyledLink>
       );
     }
@@ -211,18 +198,31 @@ const ButtonBase = (props: ButtonBaseProps) => {
         onClick={handleClick}
         tabIndex={0}
         type={type}
+        ref={ref as React.ForwardedRef<HTMLButtonElement>}
+        aria-haspopup={ariaHaspopup}
         {...other}
       >
-        {getButtonContent()}
+        <ButtonContent
+          iconStart={iconStart}
+          iconEnd={iconEnd}
+          isProcessing={isProcessing}
+        >
+          {children}
+        </ButtonContent>
       </button>
     );
-  };
+  }
+);
 
+const ButtonBase = (props: ButtonBaseProps) => {
   return (
     <FocusStyleManager
-      focusEnabledClass={focusStyleByAppearance(appearance, isInverse)}
+      focusEnabledClass={focusStyleByAppearance(
+        props.appearance,
+        props.isInverse
+      )}
     >
-      {getButtonNode()}
+      <ButtonNode {...props} />
     </FocusStyleManager>
   );
 };

--- a/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
+++ b/packages/button/tests/__snapshots__/ButtonBase.test.tsx.snap
@@ -168,6 +168,7 @@ exports[`ButtonBase renders all appearances with props 1`] = `
 }
 
 <button
+    aria-haspopup="true"
     class="emotion-0 emotion-1"
     disabled=""
     tabindex="0"
@@ -389,6 +390,7 @@ exports[`ButtonBase renders all appearances with props 2`] = `
 }
 
 <button
+    aria-haspopup="true"
     class="emotion-0 emotion-1"
     disabled=""
     tabindex="0"
@@ -611,6 +613,7 @@ exports[`ButtonBase renders all appearances with props 3`] = `
 }
 
 <button
+    aria-haspopup="true"
     class="emotion-0 emotion-1"
     disabled=""
     tabindex="0"
@@ -833,6 +836,7 @@ exports[`ButtonBase renders all appearances with props 4`] = `
 }
 
 <button
+    aria-haspopup="true"
     class="emotion-0 emotion-1"
     disabled=""
     tabindex="0"
@@ -1055,6 +1059,7 @@ exports[`ButtonBase renders all appearances with props 5`] = `
 }
 
 <button
+    aria-haspopup="true"
     class="emotion-0 emotion-1"
     disabled=""
     tabindex="0"

--- a/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
+++ b/packages/dropdownable/tests/__snapshots__/Dropdownable.test.tsx.snap
@@ -59,17 +59,24 @@ exports[`Dropdownable is visible after opening 1`] = `
         <Memo(FocusStyleManager)
           focusEnabledClass="css-xcotv6"
         >
-          <button
-            className="emotion-0"
+          <ForwardRef
+            appearance="primary"
             data-cy="primaryButton"
-            onClick={[Function]}
-            tabIndex={0}
-            type="button"
           >
-            <span>
-              Click me
-            </span>
-          </button>
+            <button
+              className="emotion-0"
+              data-cy="primaryButton"
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              <ButtonContent>
+                <span>
+                  Click me
+                </span>
+              </ButtonContent>
+            </button>
+          </ForwardRef>
         </Memo(FocusStyleManager)>
       </Memo(ButtonBase)>
     </PrimaryButton>
@@ -136,17 +143,24 @@ exports[`Dropdownable is visible after opening 2`] = `
         <Memo(FocusStyleManager)
           focusEnabledClass="css-xcotv6"
         >
-          <button
-            className="emotion-0"
+          <ForwardRef
+            appearance="primary"
             data-cy="primaryButton"
-            onClick={[Function]}
-            tabIndex={0}
-            type="button"
           >
-            <span>
-              Click me
-            </span>
-          </button>
+            <button
+              className="emotion-0"
+              data-cy="primaryButton"
+              onClick={[Function]}
+              tabIndex={0}
+              type="button"
+            >
+              <ButtonContent>
+                <span>
+                  Click me
+                </span>
+              </ButtonContent>
+            </button>
+          </ForwardRef>
         </Memo(FocusStyleManager)>
       </Memo(ButtonBase)>
     </PrimaryButton>

--- a/packages/link/components/UnstyledLink.tsx
+++ b/packages/link/components/UnstyledLink.tsx
@@ -2,23 +2,29 @@ import React from "react";
 import { LinkComponentContext } from "../../uiKitProvider/link/context";
 import { ExpandedLinkProps } from "../types";
 
-const UnstyledLink = (props: ExpandedLinkProps) => {
+const UnstyledLink = (props: ExpandedLinkProps, ref) => {
   const { href, url, target, openInNewTab, children, ...rest } = props;
 
   // Context is used for `UIKitProvider` link delegation
   const LinkComponent = React.useContext(LinkComponentContext);
   if (LinkComponent) {
-    return <LinkComponent {...props} />;
+    return <LinkComponent ref={ref} {...props} />;
   }
 
   const rel = target === "_blank" || openInNewTab ? "noopener" : undefined;
   const blankTargetOrDefault = !target && openInNewTab ? "_blank" : target;
 
   return (
-    <a href={href || url} target={blankTargetOrDefault} rel={rel} {...rest}>
+    <a
+      ref={ref}
+      href={href || url}
+      target={blankTargetOrDefault}
+      rel={rel}
+      {...rest}
+    >
       {children}
     </a>
   );
 };
 
-export default UnstyledLink;
+export default React.forwardRef(UnstyledLink);

--- a/packages/link/types.ts
+++ b/packages/link/types.ts
@@ -15,4 +15,6 @@ export interface LinkProps {
 export type ExpandedLinkProps = LinkProps &
   Omit<React.HTMLProps<HTMLAnchorElement>, "ref">;
 
-export type LinkComponent = React.ComponentType<ExpandedLinkProps>;
+export type LinkComponent = React.ComponentType<
+  LinkProps & React.HTMLProps<HTMLAnchorElement>
+>;

--- a/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
+++ b/packages/modal/tests/__snapshots__/Modal.test.tsx.snap
@@ -2741,17 +2741,25 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         <Memo(FocusStyleManager)
                                           focusEnabledClass="css-1h85cd2"
                                         >
-                                          <button
-                                            className="emotion-14"
+                                          <ForwardRef
+                                            appearance="secondary"
                                             data-cy="secondaryButton"
-                                            onClick={[Function]}
-                                            tabIndex={0}
-                                            type="button"
+                                            onClick={[MockFunction]}
                                           >
-                                            <span>
-                                              Close
-                                            </span>
-                                          </button>
+                                            <button
+                                              className="emotion-14"
+                                              data-cy="secondaryButton"
+                                              onClick={[Function]}
+                                              tabIndex={0}
+                                              type="button"
+                                            >
+                                              <ButtonContent>
+                                                <span>
+                                                  Close
+                                                </span>
+                                              </ButtonContent>
+                                            </button>
+                                          </ForwardRef>
                                         </Memo(FocusStyleManager)>
                                       </Memo(ButtonBase)>
                                     </SecondaryButton>
@@ -2767,17 +2775,24 @@ exports[`Modal DialogModal renders DialogModal 1`] = `
                                         <Memo(FocusStyleManager)
                                           focusEnabledClass="css-xcotv6"
                                         >
-                                          <button
-                                            className="emotion-16"
+                                          <ForwardRef
+                                            appearance="primary"
                                             data-cy="primaryButton"
-                                            onClick={[Function]}
-                                            tabIndex={0}
-                                            type="button"
                                           >
-                                            <span>
-                                              CTA
-                                            </span>
-                                          </button>
+                                            <button
+                                              className="emotion-16"
+                                              data-cy="primaryButton"
+                                              onClick={[Function]}
+                                              tabIndex={0}
+                                              type="button"
+                                            >
+                                              <ButtonContent>
+                                                <span>
+                                                  CTA
+                                                </span>
+                                              </ButtonContent>
+                                            </button>
+                                          </ForwardRef>
                                         </Memo(FocusStyleManager)>
                                       </Memo(ButtonBase)>
                                     </PrimaryButton>
@@ -5634,17 +5649,25 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                               <Memo(FocusStyleManager)
                                                 focusEnabledClass="css-1h85cd2"
                                               >
-                                                <button
-                                                  className="emotion-9"
+                                                <ForwardRef
+                                                  appearance="secondary"
                                                   data-cy="secondaryButton"
-                                                  onClick={[Function]}
-                                                  tabIndex={0}
-                                                  type="button"
+                                                  onClick={[MockFunction]}
                                                 >
-                                                  <span>
-                                                    Close
-                                                  </span>
-                                                </button>
+                                                  <button
+                                                    className="emotion-9"
+                                                    data-cy="secondaryButton"
+                                                    onClick={[Function]}
+                                                    tabIndex={0}
+                                                    type="button"
+                                                  >
+                                                    <ButtonContent>
+                                                      <span>
+                                                        Close
+                                                      </span>
+                                                    </ButtonContent>
+                                                  </button>
+                                                </ForwardRef>
                                               </Memo(FocusStyleManager)>
                                             </Memo(ButtonBase)>
                                           </SecondaryButton>
@@ -5672,17 +5695,24 @@ exports[`Modal FullscreenModal renders FullscreenModal 1`] = `
                                               <Memo(FocusStyleManager)
                                                 focusEnabledClass="css-xcotv6"
                                               >
-                                                <button
-                                                  className="emotion-14"
+                                                <ForwardRef
+                                                  appearance="primary"
                                                   data-cy="primaryButton"
-                                                  onClick={[Function]}
-                                                  tabIndex={0}
-                                                  type="button"
                                                 >
-                                                  <span>
-                                                    CTA
-                                                  </span>
-                                                </button>
+                                                  <button
+                                                    className="emotion-14"
+                                                    data-cy="primaryButton"
+                                                    onClick={[Function]}
+                                                    tabIndex={0}
+                                                    type="button"
+                                                  >
+                                                    <ButtonContent>
+                                                      <span>
+                                                        CTA
+                                                      </span>
+                                                    </ButtonContent>
+                                                  </button>
+                                                </ForwardRef>
                                               </Memo(FocusStyleManager)>
                                             </Memo(ButtonBase)>
                                           </PrimaryButton>

--- a/packages/segmentedControl/components/SegmentedControlButton.tsx
+++ b/packages/segmentedControl/components/SegmentedControlButton.tsx
@@ -39,23 +39,27 @@ export interface SegmentedControlButtonProps {
   children?: React.ReactNode;
 }
 
-const SegmentedControlButton = ({
-  id = nextId("segmentedControlButton-"),
-  isActive,
-  onChange,
-  name,
-  value,
-  tooltipContent,
-  children
-}: SegmentedControlButtonProps) => {
-  return (
-    <FocusStyleManager focusEnabledClass={staticKeyboardFocusClassname}>
+const SegmentedControlLabel = React.forwardRef(
+  (
+    {
+      id = nextId("segmentedControlButton-"),
+      isActive,
+      onChange,
+      name,
+      value,
+      tooltipContent,
+      children
+    }: SegmentedControlButtonProps,
+    ref
+  ) => {
+    return (
       <label
         className={cx(segmentedControlButton, {
           [segmentedControlButtonActive]: isActive
         })}
         data-cy="segmentedControlButton"
         htmlFor={id}
+        ref={ref as React.ForwardedRef<HTMLLabelElement>}
       >
         <input
           className={visuallyHidden}
@@ -79,6 +83,14 @@ const SegmentedControlButton = ({
           <div className={segmentedControlButtonInner}>{children}</div>
         )}
       </label>
+    );
+  }
+);
+
+const SegmentedControlButton = (props: SegmentedControlButtonProps) => {
+  return (
+    <FocusStyleManager focusEnabledClass={staticKeyboardFocusClassname}>
+      <SegmentedControlLabel {...props}>{props.children}</SegmentedControlLabel>
     </FocusStyleManager>
   );
 };

--- a/packages/shared/components/FocusStyleManager.tsx
+++ b/packages/shared/components/FocusStyleManager.tsx
@@ -11,7 +11,7 @@ const FocusStyleManager = ({
   focusEnabledClass,
   children
 }: FocusStyleManagerProps) => {
-  const focusWrapperRef = React.useRef<HTMLDivElement>();
+  const focusWrapperRef = React.useRef();
 
   React.useEffect(() => {
     if (focusWrapperRef.current) {


### PR DESCRIPTION
I am not sure that I did this correctly. This is a tough then where the child component could literally be anything, so typing the ref is very difficult. In some cases its a button, others an a, sometimes a label. In any event, for the ui-kit components that are children of FocusStyleManager, I wrapped them in forwardRef. Resolves the console warning issues for the pages that use FocusStyleManager.

Closes D2IQ-93522

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
https://jira.d2iq.com/browse/D2IQ-93522

## Testing

Button stories and unstyled link stories should match production

## Trade-offs

I'd really like some other thoughts here. I am not sure if the change I made to the type of LinkComponent is breaking or not. 

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
