### PR TITLE
fix: rollback ref on unstyled link

### DIFF
--- a/packages/button/components/ButtonBase.tsx
+++ b/packages/button/components/ButtonBase.tsx
@@ -125,7 +125,7 @@ const ButtonContent = ({ iconStart, iconEnd, isProcessing, children }) => {
   );
 };
 
-const ButtonNode = React.forwardRef(
+const ButtonNode = React.forwardRef<HTMLButtonElement, ButtonBaseProps>(
   (
     {
       appearance,
@@ -178,7 +178,6 @@ const ButtonNode = React.forwardRef(
           onClick={handleClick}
           tabIndex={enabled ? 0 : -1}
           openInNewTab={openInNewTab}
-          ref={ref}
           {...other}
         >
           <ButtonContent
@@ -199,7 +198,7 @@ const ButtonNode = React.forwardRef(
         onClick={handleClick}
         tabIndex={0}
         type={type}
-        ref={ref as React.ForwardedRef<HTMLButtonElement>}
+        ref={ref}
         aria-haspopup={ariaHaspopup}
         aria-label={ariaLabel}
         {...other}

--- a/packages/link/components/UnstyledLink.tsx
+++ b/packages/link/components/UnstyledLink.tsx
@@ -2,29 +2,23 @@ import React from "react";
 import { LinkComponentContext } from "../../uiKitProvider/link/context";
 import { ExpandedLinkProps } from "../types";
 
-const UnstyledLink = (props: ExpandedLinkProps, ref) => {
+const UnstyledLink = (props: ExpandedLinkProps) => {
   const { href, url, target, openInNewTab, children, ...rest } = props;
 
   // Context is used for `UIKitProvider` link delegation
   const LinkComponent = React.useContext(LinkComponentContext);
   if (LinkComponent) {
-    return <LinkComponent ref={ref} {...props} />;
+    return <LinkComponent {...props} />;
   }
 
   const rel = target === "_blank" || openInNewTab ? "noopener" : undefined;
   const blankTargetOrDefault = !target && openInNewTab ? "_blank" : target;
 
   return (
-    <a
-      ref={ref}
-      href={href || url}
-      target={blankTargetOrDefault}
-      rel={rel}
-      {...rest}
-    >
+    <a href={href || url} target={blankTargetOrDefault} rel={rel} {...rest}>
       {children}
     </a>
   );
 };
 
-export default React.forwardRef(UnstyledLink);
+export default UnstyledLink;

--- a/packages/link/types.ts
+++ b/packages/link/types.ts
@@ -15,6 +15,4 @@ export interface LinkProps {
 export type ExpandedLinkProps = LinkProps &
   Omit<React.HTMLProps<HTMLAnchorElement>, "ref">;
 
-export type LinkComponent = React.ComponentType<
-  LinkProps & React.HTMLProps<HTMLAnchorElement>
->;
+export type LinkComponent = React.ComponentType<ExpandedLinkProps>;

--- a/packages/pagination/__snapshots__/pagination.test.tsx.snap
+++ b/packages/pagination/__snapshots__/pagination.test.tsx.snap
@@ -335,6 +335,7 @@ exports[`Pagination rendering renders default 1`] = `
               class="emotion-8"
               data-cy="textInput-label"
               for="textInput-2"
+              hidden=""
             />
             <div>
               <div
@@ -701,6 +702,7 @@ exports[`Pagination rendering renders prev and next buttons as links 1`] = `
               class="emotion-8"
               data-cy="textInput-label"
               for="textInput-17"
+              hidden=""
             />
             <div>
               <div
@@ -1091,6 +1093,7 @@ exports[`Pagination rendering renders w/ custom item label 1`] = `
               class="emotion-8"
               data-cy="textInput-label"
               for="textInput-8"
+              hidden=""
             />
             <div>
               <div
@@ -1615,6 +1618,7 @@ exports[`Pagination rendering renders w/ page length menu 1`] = `
             class="emotion-4"
             data-cy="textInput-label"
             for="pageLengthMenu19"
+            hidden=""
           >
             Items per page
           </label>
@@ -1725,6 +1729,7 @@ exports[`Pagination rendering renders w/ page length menu 1`] = `
               class="emotion-4"
               data-cy="textInput-label"
               for="textInput-20"
+              hidden=""
             />
             <div>
               <div
@@ -2118,6 +2123,7 @@ exports[`Pagination rendering renders w/ totalItems set 1`] = `
               class="emotion-8"
               data-cy="textInput-label"
               for="textInput-11"
+              hidden=""
             />
             <div>
               <div
@@ -2513,6 +2519,7 @@ exports[`Pagination rendering renders w/ totalPages, pageLength, and totalItems 
               class="emotion-8"
               data-cy="textInput-label"
               for="textInput-14"
+              hidden=""
             />
             <div>
               <div
@@ -2958,6 +2965,7 @@ exports[`Pagination rendering renders wrapped in a PaginationContainer 1`] = `
                   class="emotion-10"
                   data-cy="textInput-label"
                   for="textInput-5"
+                  hidden=""
                 />
                 <div>
                   <div


### PR DESCRIPTION
Consuming LinkComponent has been a challenge downstream. We don't actually need the focus style manager to handle unstyled links as far as I can tell, so the console warnings should be resolved without having to keep drilling down into child Link components.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
