### PR TITLE
test: clean up toast test suite

### DIFF
--- a/packages/toaster/components/Toast.tsx
+++ b/packages/toaster/components/Toast.tsx
@@ -26,7 +26,7 @@ export interface ToastProps {
   title: React.ReactElement<HTMLElement> | string;
   description?: React.ReactElement<HTMLElement> | string;
   id: ToastId;
-  appearance: "default" | "success" | "warning" | "danger";
+  appearance?: "default" | "success" | "warning" | "danger";
   autodismiss?: boolean;
   onDismiss?: (event?: React.SyntheticEvent<HTMLElement>) => void;
   dismissToast?: (dismissedToastId: ToastId) => void;
@@ -54,100 +54,93 @@ const getIconForAppearance = (appearance: ToastProps["appearance"]) => {
   }
 };
 
-class Toast extends React.PureComponent<ToastProps, {}> {
-  public static defaultProps: Partial<ToastProps> = {
-    appearance: "default",
-    autodismiss: false
-  };
+const Toast = ({
+  title,
+  description,
+  appearance = "default",
+  primaryAction,
+  secondaryAction,
+  dismissToast,
+  onDismiss,
+  id
+}: ToastProps) => {
+  const isUrgentMessage = appearance === "danger" || appearance === "warning";
+  const dataCy = `toast toast.${appearance}`;
 
-  constructor(props) {
-    super(props);
-
-    this.handleDismiss = this.handleDismiss.bind(this);
-  }
-
-  public render() {
-    const { title, description, appearance, primaryAction, secondaryAction } =
-      this.props;
-    const isUrgentMessage = appearance === "danger" || appearance === "warning";
-    const dataCy = `toast toast.${appearance}`;
-
-    return (
-      <div
-        className={cx(
-          toast,
-          inverseColorMode,
-          margin("bottom", "xxs"),
-          padding("top", "xs"),
-          padding("right", "xs"),
-          padding("left", "xs"),
-          display("grid")
-        )}
-        role={isUrgentMessage ? "alert" : "log"}
-        aria-relevant="all"
-        aria-atomic="true"
-        data-cy={dataCy}
-      >
-        <div
-          className={cx(
-            toastTitle,
-            flex({ align: "center" }),
-            padding("bottom", "xs")
-          )}
-        >
-          {appearance !== "default" && (
-            <div
-              className={cx(
-                display("inherit"),
-                flexItem("shrink"),
-                padding("right", "s")
-              )}
-            >
-              {getIconForAppearance(appearance)}
-            </div>
-          )}
-          <div className={flexItem("grow")}>{title}</div>
-        </div>
-        {description && (
-          <div
-            className={cx(toastDesc, padding("bottom", "xs"))}
-            data-cy="toast-description"
-          >
-            {description}
-          </div>
-        )}
-        {(primaryAction || secondaryAction) && (
-          <div
-            className={cx(
-              toastActions,
-              flex({ direction: "row-reverse" }),
-              padding("bottom", "xs")
-            )}
-            data-cy="toast-actions"
-          >
-            {primaryAction && (
-              <span className={padding("left")}>{primaryAction}</span>
-            )}
-            {secondaryAction && <span>{secondaryAction}</span>}
-          </div>
-        )}
-        <Clickable tabIndex={0} action={this.handleDismiss}>
-          <span className={toastDismiss}>
-            <Icon shape={SystemIcons.Close} color="inherit" size="xs" />
-          </span>
-        </Clickable>
-      </div>
-    );
-  }
-
-  private handleDismiss(e) {
-    const { dismissToast, onDismiss, id } = this.props;
+  const handleDismiss = e => {
     if (dismissToast) {
       dismissToast(id);
     } else if (onDismiss) {
       onDismiss(e);
     }
-  }
-}
+  };
 
-export default Toast;
+  return (
+    <div
+      className={cx(
+        toast,
+        inverseColorMode,
+        margin("bottom", "xxs"),
+        padding("top", "xs"),
+        padding("right", "xs"),
+        padding("left", "xs"),
+        display("grid")
+      )}
+      role={isUrgentMessage ? "alert" : "log"}
+      aria-relevant="all"
+      aria-atomic="true"
+      data-cy={dataCy}
+    >
+      <div
+        className={cx(
+          toastTitle,
+          flex({ align: "center" }),
+          padding("bottom", "xs")
+        )}
+      >
+        {appearance !== "default" && (
+          <div
+            className={cx(
+              display("inherit"),
+              flexItem("shrink"),
+              padding("right", "s")
+            )}
+          >
+            {getIconForAppearance(appearance)}
+          </div>
+        )}
+        <div className={flexItem("grow")}>{title}</div>
+      </div>
+      {description && (
+        <div
+          className={cx(toastDesc, padding("bottom", "xs"))}
+          data-cy="toast-description"
+        >
+          {description}
+        </div>
+      )}
+      {(primaryAction || secondaryAction) && (
+        <div
+          className={cx(
+            toastActions,
+            flex({ direction: "row-reverse" }),
+            padding("bottom", "xs")
+          )}
+          data-cy="toast-actions"
+        >
+          {primaryAction && (
+            <span className={padding("left")}>{primaryAction}</span>
+          )}
+          {secondaryAction && <span>{secondaryAction}</span>}
+        </div>
+      )}
+      <Clickable tabIndex={0} action={handleDismiss}>
+        <span className={toastDismiss}>
+          <Icon shape={SystemIcons.Close} color="inherit" size="xs" />
+        </span>
+      </Clickable>
+    </div>
+  );
+};
+
+export default React.memo(Toast);

--- a/packages/toaster/tests/Toast.test.tsx
+++ b/packages/toaster/tests/Toast.test.tsx
@@ -1,92 +1,48 @@
 import * as React from "react";
-import { shallow, mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { createSerializer } from "@emotion/jest";
-import toJson from "enzyme-to-json";
-import { Toaster, Toast } from "../";
+import { Toast } from "../";
+import userEvent from "@testing-library/user-event";
 
 expect.addSnapshotSerializer(createSerializer());
 
 describe("Toast", () => {
   it("renders default", () => {
-    const component = shallow(
-      <Toaster>
-        <Toast title="I Am Toast" key={0} id={0} />
-      </Toaster>
-    );
-    expect(toJson(component)).toMatchSnapshot();
+    const { asFragment } = render(<Toast title="I Am Toast" key={0} id={0} />);
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it("renders with description", () => {
-    const component = shallow(
-      <Toaster>
-        <Toast title="I Am Toast" description="Description" key={0} id={0} />
-      </Toaster>
+    const { asFragment } = render(
+      <Toast title="I Am Toast" description="Description" key={0} id={0} />
     );
-    expect(toJson(component)).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
   it("renders with actions", () => {
-    const component = shallow(
-      <Toaster>
-        <Toast
-          primaryAction={<button>primaryAction</button>}
-          secondaryAction={<button>secondaryAction</button>}
-          title="I Am Toast"
-          key={0}
-          id={0}
-        />
-      </Toaster>
+    const { asFragment } = render(
+      <Toast
+        primaryAction={<button>primaryAction</button>}
+        secondaryAction={<button>secondaryAction</button>}
+        title="I Am Toast"
+        key={0}
+        id={0}
+      />
     );
-    expect(toJson(component)).toMatchSnapshot();
+    expect(asFragment()).toMatchSnapshot();
   });
 
-  it("should call the function in the action when clicked", () => {
-    const action = jest.fn();
-    const component = mount(
-      <Toaster>
-        <Toast
-          primaryAction={<button onClick={action}>primaryAction</button>}
-          title="I Am Toast"
-          key={0}
-          id={0}
-        />
-      </Toaster>
-    );
-    const primaryActionBtn = component.find(`button`);
+  it("calls dismissToast when the dismiss button is clicked", async () => {
+    const user = userEvent.setup();
 
-    expect(action).not.toHaveBeenCalled();
-    primaryActionBtn.simulate("click");
-    expect(action).toHaveBeenCalled();
-  });
-
-  it("calls dismissToast when the dismiss button is clicked", () => {
-    const dismissToastSpy = jest.spyOn(Toaster.prototype, "dismissToast");
-    const component = mount(
-      <Toaster>
-        <Toast title="I Am Toast" key={0} id={0} />
-      </Toaster>
+    const dismissToastSpy = jest.fn();
+    render(
+      <Toast dismissToast={dismissToastSpy} title="I Am Toast" key={0} id={0} />
     );
-    const dismissBtn = component.find('span[role="button"]');
     expect(dismissToastSpy).not.toHaveBeenCalled();
-    dismissBtn.simulate("click");
+
+    const dismissBtn = screen.getByRole("button");
+    await user.click(dismissBtn);
     expect(dismissToastSpy).toHaveBeenCalled();
-  });
-
-  it("should remove the Toast from the Toaster `toasts` state when the dismiss button is clicked", () => {
-    const component = mount(
-      <Toaster>
-        <Toast title="I Am Toast" key={0} id={0} />
-      </Toaster>
-    );
-    const instance = component.find(Toaster).instance() as Toaster;
-    const dismissBtn = component.find('span[role="button"]');
-    let toastsState = instance.state.toasts || [];
-
-    expect(toastsState.length).toBe(1);
-
-    dismissBtn.simulate("click");
-    toastsState = instance.state.toasts || [];
-
-    expect(toastsState.length).toBe(0);
   });
 });

--- a/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
+++ b/packages/toaster/tests/__snapshots__/Toast.test.tsx.snap
@@ -1,205 +1,364 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Toast renders default 1`] = `
-.emotion-0 {
-  max-width: 100%;
-  margin: 16px;
-}
-
-@media (min-width: 900px) {
+<DocumentFragment>
   .emotion-0 {
-    max-width: 20em;
-  }
-}
-
-@media (min-width: 900px) {
-  .emotion-0 {
-    margin: 24px;
-  }
+  background-color: var(--themeBgPrimaryInverted, #1B2029);
+  box-sizing: border-box;
+  border-radius: 6px;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: "title dismiss" "desc  desc" "btn   btn";
+  width: 100%;
+  margin-bottom: 4px;
+  padding-top: 8px;
+  padding-right: 8px;
+  padding-left: 8px;
+  display: grid;
 }
 
 .emotion-1 {
-  list-style: none;
-  margin-left: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 0;
+  grid-area: title;
+  text-transform: capitalize;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-bottom: 8px;
+}
+
+.emotion-1>div {
+  width: auto;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+}
+
+.emotion-3 {
+  grid-area: dismiss;
+  cursor: pointer;
+}
+
+.emotion-4 {
+  vertical-align: middle;
+  fill: inherit;
+}
+
+.emotion-4 use {
+  pointer-events: none;
 }
 
 <div
-  className="emotion-0"
-  data-cy="toaster"
->
-  <ol
-    aria-live="assertive"
-    className="emotion-1"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    aria-atomic="true"
+    aria-relevant="all"
+    class="inverseColorMode emotion-0"
+    data-cy="toast toast.default"
+    role="log"
   >
-    <TransitionGroup
-      childFactory={[Function]}
-      component="div"
+    <div
+      class="emotion-1"
     >
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="toastWrapper-0"
-        mountOnEnter={false}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={
-          {
-            "enter": 0,
-            "exit": 300,
-          }
-        }
-        unmountOnExit={false}
+      <div
+        class="emotion-2"
       >
-        <Component />
-      </Transition>
-    </TransitionGroup>
-  </ol>
-</div>
+        I Am Toast
+      </div>
+    </div>
+    <span
+      class="emotion-3"
+      role="button"
+      tabindex="0"
+    >
+      <svg
+        aria-label="system-close icon"
+        class="emotion-4"
+        data-cy="icon"
+        height="16"
+        preserveAspectRatio="xMinYMin meet"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <use
+          xlink:href="#system-close"
+        />
+      </svg>
+    </span>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Toast renders with actions 1`] = `
-.emotion-0 {
-  max-width: 100%;
-  margin: 16px;
-}
-
-@media (min-width: 900px) {
+<DocumentFragment>
   .emotion-0 {
-    max-width: 20em;
-  }
-}
-
-@media (min-width: 900px) {
-  .emotion-0 {
-    margin: 24px;
-  }
+  background-color: var(--themeBgPrimaryInverted, #1B2029);
+  box-sizing: border-box;
+  border-radius: 6px;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: "title dismiss" "desc  desc" "btn   btn";
+  width: 100%;
+  margin-bottom: 4px;
+  padding-top: 8px;
+  padding-right: 8px;
+  padding-left: 8px;
+  display: grid;
 }
 
 .emotion-1 {
-  list-style: none;
-  margin-left: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 0;
+  grid-area: title;
+  text-transform: capitalize;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-bottom: 8px;
+}
+
+.emotion-1>div {
+  width: auto;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+}
+
+.emotion-3 {
+  grid-area: btn;
+  height: auto;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-bottom: 8px;
+}
+
+.emotion-3>div {
+  width: auto;
+}
+
+.emotion-4 {
+  padding-left: 16px;
+}
+
+.emotion-5 {
+  grid-area: dismiss;
+  cursor: pointer;
+}
+
+.emotion-6 {
+  vertical-align: middle;
+  fill: inherit;
+}
+
+.emotion-6 use {
+  pointer-events: none;
 }
 
 <div
-  className="emotion-0"
-  data-cy="toaster"
->
-  <ol
-    aria-live="assertive"
-    className="emotion-1"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    aria-atomic="true"
+    aria-relevant="all"
+    class="inverseColorMode emotion-0"
+    data-cy="toast toast.default"
+    role="log"
   >
-    <TransitionGroup
-      childFactory={[Function]}
-      component="div"
+    <div
+      class="emotion-1"
     >
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="toastWrapper-0"
-        mountOnEnter={false}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={
-          {
-            "enter": 0,
-            "exit": 300,
-          }
-        }
-        unmountOnExit={false}
+      <div
+        class="emotion-2"
       >
-        <Component />
-      </Transition>
-    </TransitionGroup>
-  </ol>
-</div>
+        I Am Toast
+      </div>
+    </div>
+    <div
+      class="emotion-3"
+      data-cy="toast-actions"
+    >
+      <span
+        class="emotion-4"
+      >
+        <button>
+          primaryAction
+        </button>
+      </span>
+      <span>
+        <button>
+          secondaryAction
+        </button>
+      </span>
+    </div>
+    <span
+      class="emotion-5"
+      role="button"
+      tabindex="0"
+    >
+      <svg
+        aria-label="system-close icon"
+        class="emotion-6"
+        data-cy="icon"
+        height="16"
+        preserveAspectRatio="xMinYMin meet"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <use
+          xlink:href="#system-close"
+        />
+      </svg>
+    </span>
+  </div>
+</DocumentFragment>
 `;
 
 exports[`Toast renders with description 1`] = `
-.emotion-0 {
-  max-width: 100%;
-  margin: 16px;
-}
-
-@media (min-width: 900px) {
+<DocumentFragment>
   .emotion-0 {
-    max-width: 20em;
-  }
-}
-
-@media (min-width: 900px) {
-  .emotion-0 {
-    margin: 24px;
-  }
+  background-color: var(--themeBgPrimaryInverted, #1B2029);
+  box-sizing: border-box;
+  border-radius: 6px;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: "title dismiss" "desc  desc" "btn   btn";
+  width: 100%;
+  margin-bottom: 4px;
+  padding-top: 8px;
+  padding-right: 8px;
+  padding-left: 8px;
+  display: grid;
 }
 
 .emotion-1 {
-  list-style: none;
-  margin-left: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-  padding-left: 0;
+  grid-area: title;
+  text-transform: capitalize;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  height: auto;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 0;
+  padding-bottom: 8px;
+}
+
+.emotion-1>div {
+  width: auto;
+}
+
+.emotion-2 {
+  box-sizing: border-box;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  min-width: 0;
+  width: auto;
+}
+
+.emotion-3 {
+  grid-area: desc;
+  padding-bottom: 8px;
+}
+
+.emotion-4 {
+  grid-area: dismiss;
+  cursor: pointer;
+}
+
+.emotion-5 {
+  vertical-align: middle;
+  fill: inherit;
+}
+
+.emotion-5 use {
+  pointer-events: none;
 }
 
 <div
-  className="emotion-0"
-  data-cy="toaster"
->
-  <ol
-    aria-live="assertive"
-    className="emotion-1"
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
+    aria-atomic="true"
+    aria-relevant="all"
+    class="inverseColorMode emotion-0"
+    data-cy="toast toast.default"
+    role="log"
   >
-    <TransitionGroup
-      childFactory={[Function]}
-      component="div"
+    <div
+      class="emotion-1"
     >
-      <Transition
-        appear={false}
-        enter={true}
-        exit={true}
-        in={false}
-        key="toastWrapper-0"
-        mountOnEnter={false}
-        onEnter={[Function]}
-        onEntered={[Function]}
-        onEntering={[Function]}
-        onExit={[Function]}
-        onExited={[Function]}
-        onExiting={[Function]}
-        timeout={
-          {
-            "enter": 0,
-            "exit": 300,
-          }
-        }
-        unmountOnExit={false}
+      <div
+        class="emotion-2"
       >
-        <Component />
-      </Transition>
-    </TransitionGroup>
-  </ol>
-</div>
+        I Am Toast
+      </div>
+    </div>
+    <div
+      class="emotion-3"
+      data-cy="toast-description"
+    >
+      Description
+    </div>
+    <span
+      class="emotion-4"
+      role="button"
+      tabindex="0"
+    >
+      <svg
+        aria-label="system-close icon"
+        class="emotion-5"
+        data-cy="icon"
+        height="16"
+        preserveAspectRatio="xMinYMin meet"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <use
+          xlink:href="#system-close"
+        />
+      </svg>
+    </span>
+  </div>
+</DocumentFragment>
 `;


### PR DESCRIPTION
The toast test suite was tightly coupled with Toaster. This may have been a copy paste issue or something, but the snapshots didn't even reflect the markup of the Toast component. I have removed the wrapping of each of these in Toaster, and a couple of tests that were targeting behavior of Toaster rather than Toast. I have refactored to use RTL instead of enzyme in other cases.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs



## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
