### PR TITLE
fix: toaster stories

### DIFF
--- a/packages/toaster/stories/Toaster.stories.tsx
+++ b/packages/toaster/stories/Toaster.stories.tsx
@@ -5,7 +5,7 @@ import { ToastProps } from "../components/Toast";
 import { fontSizes } from "../../shared/styles/typography";
 import { purple } from "../../design-tokens/build/js/designTokens";
 
-let addedToastId = 0;
+let addedToastId = 1;
 const toastTitle = "I have a message for you";
 const fakeButtonStyles = {
   ["-webkit-appearance"]: "none",
@@ -58,38 +58,49 @@ export const Description = () => (
   </Toaster>
 );
 
+export const MultiToast = () => (
+  <Toaster>
+    <Toast title={toastTitle} key={0} id="default" />
+    <Toast
+      title={toastTitle}
+      key={1}
+      autodismiss
+      id="danger"
+      appearance="danger"
+    />
+  </Toaster>
+);
+
 export const AutoDismiss = () => {
-  const [toasts, setToasts] = React.useState<
-    Array<React.ReactElement<ToastProps>>
-  >([]);
+  const [toasts, setToasts] = React.useState<number[]>([]);
 
-  const addToast = (toastNext: Array<React.ReactElement<ToastProps>>) => {
-    setToasts(toasts.concat(toastNext));
-  };
-
-  const removeToast = (id: string) => {
-    setToasts(toasts.filter(t => t.props.id !== id));
+  const removeToast = (id: number) => {
+    setToasts(toasts.filter(toast => toast !== id));
   };
 
   const handleToastAdd = () => {
     const newToastId = addedToastId++;
-    const toastId = `toast-${newToastId + 1}`;
-    const dismissToast = () => removeToast(toastId);
-
-    addToast([
-      <Toast
-        autodismiss={true}
-        id={toastId}
-        key={newToastId + 1}
-        title={`New message ${newToastId + 1}`}
-        onDismiss={dismissToast}
-      />
-    ]);
+    setToasts([...toasts, newToastId]);
   };
 
   return (
     <div>
-      <Toaster>{toasts}</Toaster>
+      <Toaster>
+        {toasts.map(toastId => {
+          const handleDismiss = () => {
+            removeToast(toastId);
+          };
+          return (
+            <Toast
+              autodismiss
+              id={`toast-${toastId}`}
+              key={toastId}
+              title={`New message ${toastId}`}
+              onDismiss={handleDismiss}
+            />
+          );
+        })}
+      </Toaster>
       <button onClick={handleToastAdd}>Make me toast</button>
     </div>
   );


### PR DESCRIPTION
During a separate refactor I found a bug in how I did the stories for Toaster. Autodismiss should dismiss one at a time rather than all at once. I think this is a bit more conventional react anyway. Also added a story for multiple toasts at the same time.

<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

Toaster stories, particularly autodismiss

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots


https://user-images.githubusercontent.com/815936/198899003-c646e9e1-4ce9-4283-b4d3-e85ac9d86c30.mov



## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
