### PR TITLE
fix: refactor toggleboxgroup to prevent rerenders

### DIFF
--- a/packages/toggleBox/components/ToggleBoxGroup.tsx
+++ b/packages/toggleBox/components/ToggleBoxGroup.tsx
@@ -43,6 +43,17 @@ export interface ToggleBoxGroupProps {
   label?: React.ReactNode;
 }
 
+const ToggleBoxWrapper = ({ label, children }) => {
+  return label ? (
+    <fieldset className={fieldsetReset}>
+      <legend className={cx(legendReset, getLabelStyle())}>{label}</legend>
+      {children}
+    </fieldset>
+  ) : (
+    children
+  );
+};
+
 const ToggleBoxGroup = ({
   children,
   direction = "row",
@@ -60,41 +71,34 @@ const ToggleBoxGroup = ({
     return selectedItems.filter(selectedChoice => selectedChoice !== value);
   };
 
-  const ToggleBoxes = () => (
-    <Flex direction={direction} gutterSize={gutterSize} align="stretch">
-      {React.Children.toArray(children).map(toggleBox => {
-        const { name, value, ...childProps } = toggleBox.props;
-        const handleChange = e => {
-          onChange?.(getSelectedItems(value, e.target.checked));
-        };
+  return (
+    <ToggleBoxWrapper label={label}>
+      <Flex direction={direction} gutterSize={gutterSize} align="stretch">
+        {React.Children.toArray(children).map(toggleBox => {
+          const { name, value, ...childProps } = toggleBox.props;
+          const handleChange = e => {
+            onChange?.(getSelectedItems(value, e.target.checked));
+          };
 
-        return (
-          <FlexItem
-            key={`buttonWrapper-${childProps.id}`}
-            className={toggleBoxGroupItem}
-          >
-            {React.cloneElement(toggleBox, {
-              name: multiSelect ? name : name || id,
-              type: multiSelect ? "checkbox" : "radio",
-              onChange: handleChange,
-              isActive: selectedItems.includes(value),
-              id: childProps.id,
-              value,
-              ...childProps
-            })}
-          </FlexItem>
-        );
-      })}
-    </Flex>
-  );
-
-  return label ? (
-    <fieldset className={fieldsetReset}>
-      <legend className={cx(legendReset, getLabelStyle())}>{label}</legend>
-      <ToggleBoxes />
-    </fieldset>
-  ) : (
-    <ToggleBoxes />
+          return (
+            <FlexItem
+              key={`buttonWrapper-${childProps.id}`}
+              className={toggleBoxGroupItem}
+            >
+              {React.cloneElement(toggleBox, {
+                name: multiSelect ? name : name || id,
+                type: multiSelect ? "checkbox" : "radio",
+                onChange: handleChange,
+                isActive: selectedItems.includes(value),
+                id: childProps.id,
+                value,
+                ...childProps
+              })}
+            </FlexItem>
+          );
+        })}
+      </Flex>
+    </ToggleBoxWrapper>
   );
 };
 


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

We had seen some re-rendering issues with the ToggleBoxGroup throughout DKP UI. This could be seen through element flashes displaying the re-rendering.
Through some testing with UI Kit linked into the UI, we were able to confirm these changes resolve the issues. 
 It seems that the issue was something to do with the inner function to create ToggleBoxes, which is not an ideal pattern. It simplifies this component to have a wrapper element outside of it to pass in the label and children.


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

You could test out npm link with these changes in the UI. 

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] If any new components were added, there are exported from `packages/index.ts`
- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
