### PR TITLE
fix: sorter chevron alignment in table header

### DIFF
--- a/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
+++ b/packages/tablev2/__snapshots__/tablev2.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Table v2 rendering renders default 1`] = `
         role="columnheader"
       >
         <div
-          class="css-1fz6wig"
+          class="css-130tuzu"
           data-cy="flex"
         >
           <div
@@ -1021,7 +1021,7 @@ exports[`Table v2 rendering renders without a sticky first column 1`] = `
         role="columnheader"
       >
         <div
-          class="css-1fz6wig"
+          class="css-130tuzu"
           data-cy="flex"
         >
           <div

--- a/packages/tablev2/style.ts
+++ b/packages/tablev2/style.ts
@@ -159,7 +159,7 @@ export const rowScrollShadow = css`
 `;
 
 export const cellFlexWrapper = css`
-  display: flex;
+  display: inline-flex;
   flex-direction: row;
   align-items: center;
   max-width: 100%;


### PR DESCRIPTION
The chevron is bumped down below the header title when a header tooltip is present.

Closes D2IQ-94167

<!-- PR Checklist -->

# Description

With the changes to the chevron to allow it to be clickable, a bug was introduced that forced the chevron down below the header title when there is also a header tooltip present on hover. Setting the display from flex to flex-inline will keep things _inline_ and preserves Table component functionality. 

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing
Check the Column Header With Tooltip story under the Table component. 
Use `npm link` to test within the UI. 
<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

Before
<img width="1490" alt="Screen Shot 2022-11-16 at 4 54 25 PM" src="https://user-images.githubusercontent.com/34781875/202313250-d5bdce51-3c8a-4497-b022-dd41aad487a2.png">

After
<img width="1471" alt="Screen Shot 2022-11-16 at 4 54 01 PM" src="https://user-images.githubusercontent.com/34781875/202313254-37622d59-46b6-45c8-aadf-fbcd115095cf.png">


Tested in the UI with `npm link`
<img width="1721" alt="Screen Shot 2022-11-16 at 4 53 00 PM" src="https://user-images.githubusercontent.com/34781875/202313329-9b924301-157d-4e99-9336-b901cb862f50.png">

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
