### PR TITLE
fix: duplicate key in tabs component

### DIFF
--- a/packages/tabs/stories/Tabs.stories.tsx
+++ b/packages/tabs/stories/Tabs.stories.tsx
@@ -38,7 +38,8 @@ const Template: Story<TabsProps> = ({ direction, ...args }: TabsProps) => {
     >
       <TabItem>
         <TabTitle>Tab 1</TabTitle>
-        Tab content.
+        <div>Tab content - Section 1.</div>
+        <div>Tab content - Section 2.</div>
       </TabItem>
       <TabItem>
         <TabTitle>Tab 2</TabTitle>


### PR DESCRIPTION
# Description

This commit adds a useMemo to the Tabs component so that we can use a UUID for the keys of the Tabs children. The UUID allows us to generate a unique key, while the useMemo prevents the UUID from being recalculated unless the children change.

Closes D2IQ-92719

## Which issue(s) does this PR relate to?

https://d2iq.atlassian.net/browse/D2IQ-92719

## Testing

I've changed the story so that the first Tab has 2 non-TableTitle children. You should be able to view the Tab story in Storybook without seeing any console warnings.

## Trade-offs

The issue here is that the key for the Tab child components was being set by a const outside of the map, which meant that all children were getting set with the same key. We tried to use `object-hash` to turn the child into a hash and use that as the key but there were type issues with turning a ReactElement into a hash. There wasn't anything else besides index which we could use for the key to make it unique, so we decided to go with useMemo and a UUID for reasons explained in the description.

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [x] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
