### PR TITLE
Fix Tab Component again

### DIFF
--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Tabs as ReactTabs, TabList, TabPanel } from "react-tabs";
 import { injectGlobal, cx } from "@emotion/css";
-import nextId from "react-id-generator";
+import uuid from "uuid";
 import { TabItemProps } from "./TabItem";
 import { TabTitle } from "..";
 import {
@@ -95,7 +95,7 @@ const Tabs = ({
           const childrenWithKeys = React.Children.toArray(children).map(
             child => {
               return React.isValidElement<typeof TabTitle>(child)
-                ? React.cloneElement(child, { key: nextId("tab") })
+                ? React.cloneElement(child, { key: `${key}-${uuid()}` })
                 : child;
             }
           );

--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -101,10 +101,11 @@ const Tabs = ({
         const { tabs = [], tabsContent = [] } = acc;
         const { children } = item.props;
         const key = item.key ? item.key : undefined;
-        const childrenWithKeys = React.Children.toArray(children).map(child =>
-          React.isValidElement<typeof TabTitle>(child)
-            ? React.cloneElement(child, { key })
-            : child
+        const childrenWithKeys = React.Children.toArray(children).map(
+          (child, index) =>
+            React.isValidElement<typeof TabTitle>(child)
+              ? React.cloneElement(child, { key: `${key}-${index}` })
+              : child
         );
 
         const title = childrenWithKeys.find(

--- a/packages/tabs/components/Tabs.tsx
+++ b/packages/tabs/components/Tabs.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Tabs as ReactTabs, TabList, TabPanel } from "react-tabs";
 import { injectGlobal, cx } from "@emotion/css";
-import uuid from "uuid";
+
 import { TabItemProps } from "./TabItem";
 import { TabTitle } from "..";
 import {
@@ -13,7 +13,9 @@ import {
 import { listReset } from "../../shared/styles/styleUtils";
 import { BreakpointConfig } from "../../shared/styles/breakpoints";
 import { fullHeightTabs, getTabLayout } from "../style";
+
 export const defaultTabDirection = "horiz";
+
 // Copy & paste from node_modules/react-tabs/style/react-tabs.css
 // Also changed to better fit the ui kit styles.
 // This is needed to give the tabs a style
@@ -22,14 +24,17 @@ injectGlobal`
 .react-tabs {
   -webkit-tap-highlight-color: transparent;
 }
+
 .react-tabs__tab-list {
   ${listReset};
 }
+
 .react-tabs__tab {
   position: relative;
   cursor: pointer;
   font-weight: ${fontWeightMedium};
   color: ${themeTextColorPrimary};
+
   &:after{
     content: "";
     position: absolute;
@@ -37,29 +42,35 @@ injectGlobal`
     display: none;
   }
 }
+
 .react-tabs__tab:focus {
   outline: none;
   background: ${themeBgHover}
 }
+
 .react-tabs__tab--selected {
   &:after{
     display: block;
   }
   color: ${themeBrandPrimary};
 }
+
 .react-tabs__tab--disabled {
   color: GrayText;
   cursor: default;
 }
+
 .react-tabs__tab-panel {
   display: none;
   flex-grow: 1;
 }
+
 .react-tabs__tab-panel--selected {
   display: block;
 }
 `;
 /* eslint-enable */
+
 export type TabDirections = "horiz" | "vert";
 export type TabDirection = BreakpointConfig<TabDirections>;
 export type TabSelected = string;
@@ -71,55 +82,52 @@ export interface TabsProps {
   onSelect?: (tabIndex: number) => void;
   direction?: TabDirection;
 }
+
 const Tabs = ({
   children,
   selectedIndex,
   onSelect,
   direction = defaultTabDirection
 }: TabsProps) => {
-  const { tabs, tabsContent } = React.useMemo(() => {
-    return (
-      React.Children.toArray(children) as Array<
-        React.ReactElement<TabItemProps>
-      >
-    )
-      .filter(item => React.isValidElement<TabItemProps>(item))
-      .reduce<{
-        tabs: React.ReactNode[];
-        tabsContent: React.ReactNode[];
-      }>(
-        (acc, item) => {
-          const { tabs = [], tabsContent = [] } = acc;
-          const { children } = item.props;
-          const key = item.key ? item.key : undefined;
-          const childrenWithKeys = React.Children.toArray(children).map(
-            child => {
-              return React.isValidElement<typeof TabTitle>(child)
-                ? React.cloneElement(child, { key: `${key}-${uuid()}` })
-                : child;
-            }
-          );
-          const title = childrenWithKeys.find(
-            child =>
-              React.isValidElement<typeof TabTitle>(child) &&
-              child.type === TabTitle
-          );
-          const tabChildren = childrenWithKeys.filter(
-            child => !(React.isValidElement(child) && child.type === TabTitle)
-          );
-          return {
-            tabs: [...tabs, title],
-            tabsContent: [
-              ...tabsContent,
-              ...(tabChildren.length
-                ? [<TabPanel key={key}>{tabChildren}</TabPanel>]
-                : [])
-            ]
-          };
-        },
-        { tabs: [], tabsContent: [] }
-      );
-  }, [children]);
+  const { tabs, tabsContent } = (
+    React.Children.toArray(children) as Array<React.ReactElement<TabItemProps>>
+  )
+    .filter(item => React.isValidElement<TabItemProps>(item))
+    .reduce<{
+      tabs: React.ReactNode[];
+      tabsContent: React.ReactNode[];
+    }>(
+      (acc, item) => {
+        const { tabs = [], tabsContent = [] } = acc;
+        const { children } = item.props;
+        const key = item.key ? item.key : undefined;
+        const childrenWithKeys = React.Children.toArray(children).map(child =>
+          React.isValidElement<typeof TabTitle>(child)
+            ? React.cloneElement(child, { key })
+            : child
+        );
+
+        const title = childrenWithKeys.find(
+          child =>
+            React.isValidElement<typeof TabTitle>(child) &&
+            child.type === TabTitle
+        );
+        const tabChildren = childrenWithKeys.filter(
+          child => !(React.isValidElement(child) && child.type === TabTitle)
+        );
+        return {
+          tabs: [...tabs, title],
+          tabsContent: [
+            ...tabsContent,
+            ...(tabChildren.length
+              ? [<TabPanel key={key}>{tabChildren}</TabPanel>]
+              : [])
+          ]
+        };
+      },
+      { tabs: [], tabsContent: [] }
+    );
+
   return (
     <ReactTabs
       className={cx("react-tabs", {
@@ -138,4 +146,5 @@ const Tabs = ({
     </ReactTabs>
   );
 };
+
 export default React.memo(Tabs);

--- a/packages/tabs/stories/Tabs.stories.tsx
+++ b/packages/tabs/stories/Tabs.stories.tsx
@@ -38,8 +38,7 @@ const Template: Story<TabsProps> = ({ direction, ...args }: TabsProps) => {
     >
       <TabItem>
         <TabTitle>Tab 1</TabTitle>
-        <div>Tab content - Section 1.</div>
-        <div>Tab content - Section 2.</div>
+        Tab content.
       </TabItem>
       <TabItem>
         <TabTitle>Tab 2</TabTitle>


### PR DESCRIPTION
<!-- PR Checklist -->

# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When we have a form inside a tab component the tab component rerenders because the key change every time the children changes. This leads to input fields losing focus and other issues.
This uses the `index` as a key, which is not necessarily best practice but it removes the previously existing duplicated key error and fixes the rerender issue.

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [ ] I have reviewed the changes and provided detail to the sections above
