### PR TITLE
fix: allow valid css height/width types

### DIFF
--- a/packages/dropdownMenu/components/DropdownMenu.tsx
+++ b/packages/dropdownMenu/components/DropdownMenu.tsx
@@ -21,13 +21,13 @@ export interface DropdownMenuProps {
    */
   initialIsOpen?: boolean;
   /**
-   * Maximum height the menu can grow to
+   * Maximum height the menu can grow to. Can accept any number value and it will add `px` or any valid maxHeight value including vh, ems, or rems.
    */
-  menuMaxHeight?: number;
+  menuMaxHeight?: React.CSSProperties["maxHeight"];
   /**
-   * Maximum width the menu can grow to
+   * Maximum width the menu can grow to. Can accept any number value and it will add `px` or any valid maxWidth value including vw, ems, or rems.
    */
-  menuMaxWidth?: number;
+  menuMaxWidth?: React.CSSProperties["maxWidth"];
   /**
    * callback for when a menu item is clicked
    */
@@ -53,6 +53,7 @@ export interface DropdownMenuProps {
    * Whether the dropdown node should be portalled to document.body, or open in it's parent DOM node
    */
   disablePortal?: boolean;
+  className?: string;
 }
 
 const defaultItemToString = (

--- a/packages/popover/components/PopoverBox.tsx
+++ b/packages/popover/components/PopoverBox.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { cx } from "@emotion/css";
-import { menuList, hideHoriztonalScroll, getPopoverBoxArrow } from "../style";
+import { menuList, hideHorizontalScroll, getPopoverBoxArrow } from "../style";
 import { alignContainerWithCaretStyles } from "../../shared/styles/containerWithCaret";
 import { border } from "../../shared/styles/styleUtils";
 import { Direction } from "../../dropdownable/components/Dropdownable";
@@ -8,11 +8,11 @@ import { Direction } from "../../dropdownable/components/Dropdownable";
 export interface PopoverProps extends React.HTMLProps<HTMLDivElement> {
   children: React.ReactNode;
   direction?: Direction;
-  maxHeight?: number;
-  maxWidth?: number;
+  maxHeight?: React.CSSProperties["maxHeight"];
+  maxWidth?: React.CSSProperties["maxWidth"];
   menuRef?: React.RefObject<HTMLDivElement>;
   showPointerCaret?: boolean;
-  width?: number;
+  width?: React.CSSProperties["width"];
 }
 
 const Popover = (props: PopoverProps) => {
@@ -30,7 +30,7 @@ const Popover = (props: PopoverProps) => {
       <div
         className={cx(menuList, border("all"), {
           [alignContainerWithCaretStyles(direction)]: showPointerCaret,
-          [hideHoriztonalScroll]:
+          [hideHorizontalScroll]:
             !width && !maxWidth && !other.style?.maxWidth && !other.style?.width
         })}
         ref={menuRef}

--- a/packages/popover/style.ts
+++ b/packages/popover/style.ts
@@ -17,7 +17,7 @@ export const menuList = css`
 `;
 
 // Hides unnecessary horizontal scrollbars on Linux and Microsoft
-export const hideHoriztonalScroll = css`
+export const hideHorizontalScroll = css`
   overflow-x: hidden;
 `;
 


### PR DESCRIPTION
Allow height and width types to accept any valid
CSS height/width properties such as vw, ems,
and other string values beyond numbers.

<!-- PR Checklist -->

# Description

I encountered this when attempting to use a value with `vh` where I got a type error. These values should accept any valid related CSS height or width property, such as ems, rems, vh, vw, etc.  Followed the trail up to the `PopoverBox` and update those types there too. 

Included a few other tweaks in here too such as a typo fix, and a className prop for the Dropdown. 

Note: The `React.CSSProperties` type will handle strings or numbers so there will not be a breaking change. 
Emotion will append `px` if only a number is passed in. 

<img width="837" alt="Screen Shot 2022-12-01 at 1 07 09 PM" src="https://user-images.githubusercontent.com/34781875/205138781-eaa052d3-a3e4-4dd7-ae1b-42e846ce797b.png">


<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Which issue(s) does this PR relate to?

<!-- Add a link to the JIRA issue(s)-->
<!-- - https://jira.d2iq.com/browse/D2IQ-NUMBER -->

## Testing

You can update one of these values in the Storybook story. 
I also tested this out using `npm link` in the UI. 

<!--
How can the changes be tested (e.g. modifications to a story or testing in an app that uses ui-kit)?
Is anything required to be able to test?
-->

## Trade-offs

<!--
Are you aware of any weak spots? e.g. performance, functionality
Did you decide anything noteworthy? e.g. algorithms, data structures, tools
-->

## Screenshots

<!--
Would a visual be helpful for reviewers? e.g. "Before" and "After", visual changes a designer can check before merge
-->

## Checklist

- [ ] This PR is associated with a JIRA and it is mentioned in the commit message footer ("Closes …")
- [ ] Significant changes have been tested downstream to avoid breaking changes
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")
- [x] I have reviewed the changes and provided detail to the sections above
